### PR TITLE
removed hello example

### DIFF
--- a/contract/contracts/chioma/src/lib.rs
+++ b/contract/contracts/chioma/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
 mod agreement;
 mod errors;

--- a/contract/contracts/chioma/src/tests.rs
+++ b/contract/contracts/chioma/src/tests.rs
@@ -1,25 +1,8 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger, MockAuth, MockAuthInvoke},
-    vec, Address, Env, IntoVal, String,
+    Address, Env, IntoVal, String,
 };
-
-#[test]
-fn test_hello() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let words = client.hello(&String::from_str(&env, "Dev"));
-    assert_eq!(
-        words,
-        vec![
-            &env,
-            String::from_str(&env, "Hello"),
-            String::from_str(&env, "Dev"),
-        ]
-    );
-}
 
 #[test]
 fn test_successful_initialization() {


### PR DESCRIPTION
##  Remove `hello` Example Function from `lib.rs`

Closes #112 


### Overview

This PR removes the unused `hello` example function from:

- Removed the `hello` example function from the `Contract` implementation.
- Removed the unused `Vec` import from `soroban_sdk`.
- No changes were made to business logic or contract behavior.

### 🛠 Type of Change

- [x] Code cleanup / refactor