### PR TITLE
feat(contracts): validate positive amounts for monthly_rent (i128) (#118)

### DIFF
--- a/contract/contracts/chioma/src/agreement.rs
+++ b/contract/contracts/chioma/src/agreement.rs
@@ -7,6 +7,9 @@ use crate::storage::DataKey;
 use crate::types::{AgreementStatus, PaymentSplit, RentAgreement};
 
 /// Validate agreement parameters
+///
+/// Ensures monthly_rent is strictly positive (i128 > 0) to prevent logical errors
+/// in payment calculations and splits.
 pub fn validate_agreement_params(
     monthly_rent: &i128,
     security_deposit: &i128,

--- a/contract/contracts/chioma/src/tests.rs
+++ b/contract/contracts/chioma/src/tests.rs
@@ -363,6 +363,33 @@ fn test_negative_rent_rejected() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_zero_monthly_rent_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    let agreement_id = String::from_str(&env, "ZERO_RENT");
+
+    client.create_agreement(
+        &agreement_id,
+        &landlord,
+        &tenant,
+        &None,
+        &0,
+        &1000,
+        &100,
+        &200,
+        &0,
+        &Address::generate(&env),
+    );
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #6)")]
 fn test_invalid_dates_rejected() {
     let env = Env::default();

--- a/contract/contracts/chioma/test_snapshots/tests/test_zero_monthly_rent_rejected.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests/test_zero_monthly_rent_rejected.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/contracts/payment/src/lib.rs
+++ b/contract/contracts/payment/src/lib.rs
@@ -127,6 +127,10 @@ impl PaymentContract {
             return Err(Error::NotTenant);
         }
 
+        if payment_amount <= 0 {
+            return Err(Error::InvalidPaymentAmount);
+        }
+
         if payment_amount != agreement.monthly_rent {
             return Err(Error::InvalidPaymentAmount);
         }

--- a/contract/contracts/payment/src/payment_impl.rs
+++ b/contract/contracts/payment/src/payment_impl.rs
@@ -59,6 +59,11 @@ pub fn pay_rent_with_agent(
         return Err(PaymentError::AgreementNotActive);
     }
 
+    // Validate amount is strictly positive to prevent logical errors
+    if amount <= 0 {
+        return Err(PaymentError::InvalidAmount);
+    }
+
     // Validate amount matches monthly rent exactly
     if amount != agreement.monthly_rent {
         return Err(PaymentError::InvalidAmount);


### PR DESCRIPTION
## Summary
Add validation so `monthly_rent` and related payment amounts are strictly positive (`> 0`), avoiding logic errors with zero or negative `i128` values.

## Changes

### Chioma Contract
- Documented agreement validation: `monthly_rent` must be strictly positive
- Added `test_zero_monthly_rent_rejected` to assert zero `monthly_rent` is rejected

### Payment Contract
- Reject `payment_amount <= 0` in `pay_rent` before processing
- Reject `amount <= 0` in `pay_rent_with_agent` before processing

## Testing
- Chioma: all 27 tests pass
- Payment: all 7 tests pass

Closes #118