### PR TITLE
fix: debounce navbar scroll event listener

### DIFF
--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -11,11 +11,21 @@ const Navbar = () => {
   const pathname = usePathname();
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
     const handleScroll = () => {
-      setIsScrolled(window.scrollY > 20);
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        setIsScrolled(window.scrollY > 20);
+      }, 100);
     };
+
     window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   const navLinks = [


### PR DESCRIPTION
Closes #123 

---

### Description
This pull request makes a minor improvement to the `Navbar` component by optimizing the scroll event handler to reduce unnecessary updates.

### Changes Made
* UI performance optimization:
  * `frontend/components/Navbar.tsx`: Added a debounce mechanism to the scroll event handler using `setTimeout` and `clearTimeout`, ensuring `setIsScrolled` is only called after scrolling has stopped for 100ms. Also ensures timers are cleared when the component unmounts.

@caxtonacollins 
Please review. If there are changes to be made, tell me. Thanks.