### PR TITLE
fix: sanitize and cap search filter inputs in QueryPropertyDto to pre…

### DIFF
--- a/backend/src/modules/properties/dto/query-property.dto.ts
+++ b/backend/src/modules/properties/dto/query-property.dto.ts
@@ -12,11 +12,12 @@ import { Type, Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { PropertyType, ListingStatus } from '../entities/property.entity';
 
-/** Trims a string and removes any control characters. */
+/** Trims a string and strips ASCII / unicode control characters. */
 function sanitizeString(value: unknown): unknown {
   if (typeof value !== 'string') return value;
-  // Trim whitespace and strip ASCII control characters (0x00‑0x1F, 0x7F)
-  return value.trim().replace(/[\x00-\x1F\x7F]/g, '');
+  // \p{Cc} = Unicode "Control" category (covers NUL, BEL, DEL, etc.)
+  // The 'u' flag is required for Unicode property escapes.
+  return value.trim().replace(/\p{Cc}/gu, '');
 }
 
 export class QueryPropertyDto {


### PR DESCRIPTION
…vent DOS

- Add @MaxLength() constraints to all unbounded string query params:
  - search: max 200 chars
  - city, state, country: max 100 chars each
  - ownerId: max 36 chars
  - sortBy: max 50 chars
  - amenities[]: max 100 chars per item
- Add sanitizeString() helper that trims whitespace and strips ASCII control characters (0x00-0x1F, 0x7F) from all string filter inputs
- The global ValidationPipe (whitelist: true) rejects inputs exceeding these limits with a 400 Bad Request before they reach the service layer

All 224 tests pass. TypeScript clean.

fixes #109