### PR TITLE
fix(init): guard initialize against re-initialization using permanent…

### DIFF
--- a/contract/contracts/chioma/src/lib.rs
+++ b/contract/contracts/chioma/src/lib.rs
@@ -37,7 +37,7 @@ impl Contract {
     /// * `AlreadyInitialized` - If the contract has already been initialized
     /// * `InvalidConfig` - If the configuration parameters are invalid
     pub fn initialize(env: Env, admin: Address, config: Config) -> Result<(), RentalError> {
-        if env.storage().instance().has(&DataKey::State) {
+        if env.storage().persistent().has(&DataKey::Initialized) {
             return Err(RentalError::AlreadyInitialized);
         }
 
@@ -46,6 +46,11 @@ impl Contract {
         if config.fee_bps > 10_000 {
             return Err(RentalError::InvalidConfig);
         }
+
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Initialized, 500000, 500000);
 
         let state = ContractState {
             admin: admin.clone(),

--- a/contract/contracts/chioma/src/storage.rs
+++ b/contract/contracts/chioma/src/storage.rs
@@ -6,4 +6,5 @@ pub enum DataKey {
     Agreement(String),
     AgreementCount,
     State,
+    Initialized,
 }


### PR DESCRIPTION
… storage key

- Add re-initialization check in `initialize` using a dedicated storage key
- Store init flag under `StorageKey::Initialized` as a persistent/immutable entry
- Return `Error::AlreadyInitialized` if contract has already been initialized
- Ensure init key is never deleted or overwritten after first successful call
- Verify existing functionality is unaffected by the guard addition

[Logic] `initialize` function allows re-initialization check based on storage key; ensure key is permanent/immutable. Fixes #113