### PR TITLE
docs: improve AuthService swagger documentation

### DIFF
--- a/backend/src/common/dto/error-response.dto.ts
+++ b/backend/src/common/dto/error-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ErrorResponseDto {
+  @ApiProperty({
+    example: 400,
+    description: 'The HTTP status code',
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    example: 'Bad Request',
+    description: 'The error message summary',
+  })
+  message: string | string[];
+
+  @ApiProperty({
+    example: 'Bad Request',
+    description: 'The error type',
+    required: false,
+  })
+  error?: string;
+}

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -27,6 +27,7 @@ import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { VerifyEmailDto } from './dto/verify-email.dto';
 import { AuthResponseDto, MessageResponseDto } from './dto/auth-response.dto';
+import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { User, AuthMethod } from '../users/entities/user.entity';
@@ -50,7 +51,7 @@ export class AuthController {
     private readonly mfaService: MfaService,
     private readonly configService: ConfigService,
     private readonly jwtService: JwtService,
-  ) {}
+  ) { }
 
   @Post('register')
   @Throttle({ default: { limit: 3, ttl: 60000 } })
@@ -67,10 +68,12 @@ export class AuthController {
   @ApiResponse({
     status: 400,
     description: 'Invalid input or password does not meet requirements',
+    type: ErrorResponseDto,
   })
   @ApiResponse({
     status: 409,
     description: 'Email already registered',
+    type: ErrorResponseDto,
   })
   async register(
     @Body() registerDto: RegisterDto,
@@ -135,6 +138,7 @@ export class AuthController {
   @ApiResponse({
     status: 401,
     description: 'Invalid credentials or account locked',
+    type: ErrorResponseDto,
   })
   async login(
     @Body() loginDto: LoginDto,
@@ -219,6 +223,7 @@ export class AuthController {
   @ApiResponse({
     status: 401,
     description: 'Invalid MFA code or token',
+    type: ErrorResponseDto,
   })
   async completeMfaLogin(
     @Body() completeMfaLoginDto: CompleteMfaLoginDto,
@@ -296,6 +301,7 @@ export class AuthController {
   @ApiResponse({
     status: 401,
     description: 'Invalid or expired refresh token',
+    type: ErrorResponseDto,
   })
   async refreshTokens(
     @Body() refreshTokenDto: RefreshTokenDto,
@@ -341,6 +347,7 @@ export class AuthController {
   @ApiResponse({
     status: 401,
     description: 'Unauthorized',
+    type: ErrorResponseDto,
   })
   async logout(
     @CurrentUser() user: User,
@@ -415,6 +422,7 @@ export class AuthController {
   @ApiResponse({
     status: 400,
     description: 'Invalid or expired reset token',
+    type: ErrorResponseDto,
   })
   async resetPassword(
     @Body() resetPasswordDto: ResetPasswordDto,
@@ -436,6 +444,7 @@ export class AuthController {
   @ApiResponse({
     status: 400,
     description: 'Invalid or expired verification token',
+    type: ErrorResponseDto,
   })
   async verifyEmail(
     @Query() verifyEmailDto: VerifyEmailDto,
@@ -459,6 +468,7 @@ export class AuthController {
   @ApiResponse({
     status: 400,
     description: 'MFA already enabled',
+    type: ErrorResponseDto,
   })
   async enableMfa(
     @CurrentUser() user: User,
@@ -483,6 +493,7 @@ export class AuthController {
   @ApiResponse({
     status: 401,
     description: 'Invalid MFA token',
+    type: ErrorResponseDto,
   })
   async verifyMfa(
     @CurrentUser() user: User,
@@ -541,6 +552,11 @@ export class AuthController {
   @ApiResponse({
     status: 200,
     description: 'Backup codes regenerated successfully',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ErrorResponseDto,
   })
   async regenerateBackupCodes(@CurrentUser() user: User) {
     const codes = await this.mfaService.regenerateBackupCodes(user.id);

--- a/backend/src/modules/auth/dto/auth-response.dto.ts
+++ b/backend/src/modules/auth/dto/auth-response.dto.ts
@@ -1,17 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class UserProfileDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id: string;
+
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'John', nullable: true })
+  firstName: string | null;
+
+  @ApiProperty({ example: 'Doe', nullable: true })
+  lastName: string | null;
+
+  @ApiProperty({ example: 'tenant', description: 'User role' })
+  role: string;
+}
+
 export class AuthResponseDto {
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
   accessToken: string | null;
+
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', required: false })
   refreshToken: string | null;
-  user: {
-    id: string;
-    email: string;
-    firstName: string | null;
-    lastName: string | null;
-    role: string;
-  };
+
+  @ApiProperty({ type: UserProfileDto })
+  user: UserProfileDto;
+
+  @ApiProperty({ example: false, required: false })
   mfaRequired?: boolean;
+
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', required: false })
   mfaToken?: string;
 }
 
 export class MessageResponseDto {
+  @ApiProperty({ example: 'Operation successful' })
   message: string;
 }
+


### PR DESCRIPTION
docs: improve AuthService swagger documentation

I've updated the Swagger documentation for the authentication service to make it clearer for developers.

Changes:
- Added a standard ErrorResponseDto for consistent 400/401 reporting.
- Added @ApiProperty decorators to AuthResponseDto and MessageResponseDto.
- Updated AuthController to include specific error response types and examples.

Closes #108
