### PR TITLE
feat(rent-obligation): implement TokenizedRentObligationContract NFT minting

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -1208,6 +1208,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rent_obligation"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contract/contracts/rent_obligation/Cargo.toml
+++ b/contract/contracts/rent_obligation/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rent_obligation"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/contracts/rent_obligation/Makefile
+++ b/contract/contracts/rent_obligation/Makefile
@@ -1,0 +1,13 @@
+default: build
+
+test:
+	cargo test
+
+build:
+	cargo build --target wasm32-unknown-unknown --release
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contract/contracts/rent_obligation/README.md
+++ b/contract/contracts/rent_obligation/README.md
@@ -1,0 +1,98 @@
+# Tokenized Rent Obligation Contract
+
+A Soroban smart contract for minting and managing transferable NFTs representing rent agreements on the Stellar network.
+
+## Overview
+
+This contract enables landlords to tokenize their rental income streams as NFTs. These tokens represent the right to receive rent payments from active lease agreements and can be transferred to other parties, enabling use cases such as:
+
+- Using future rental income as collateral
+- Selling property with active leases
+- Trading rental income rights
+
+## Features
+
+- **NFT Minting**: Create unique tokens for each rent agreement
+- **Ownership Transfer**: Transfer obligation ownership between addresses
+- **Duplicate Prevention**: Ensures only one token per agreement
+- **Event Emission**: Tracks minting and transfer activities
+- **Owner Queries**: Check current owner of any obligation
+
+## Contract Methods
+
+### `initialize()`
+Initialize the contract. Must be called before any other operations.
+
+### `mint_obligation(agreement_id: String, landlord: Address)`
+Mint a new tokenized rent obligation NFT.
+- **Parameters**:
+  - `agreement_id`: Unique identifier for the rent agreement
+  - `landlord`: Address that will receive the NFT
+- **Authorization**: Requires `landlord` signature
+- **Errors**:
+  - `NotInitialized`: Contract not initialized
+  - `ObligationAlreadyExists`: Token already minted for this agreement
+
+### `transfer_obligation(from: Address, to: Address, agreement_id: String)`
+Transfer ownership of a tokenized rent obligation.
+- **Parameters**:
+  - `from`: Current owner address
+  - `to`: New owner address
+  - `agreement_id`: Agreement identifier
+- **Authorization**: Requires `from` signature
+- **Errors**:
+  - `NotInitialized`: Contract not initialized
+  - `ObligationNotFound`: No token exists for this agreement
+  - `Unauthorized`: Caller is not the current owner
+
+### `get_obligation_owner(agreement_id: String) -> Option<Address>`
+Query the current owner of a tokenized rent obligation.
+- **Returns**: Owner address or None if obligation doesn't exist
+
+### `get_obligation(agreement_id: String) -> Option<RentObligation>`
+Get full obligation data including mint timestamp.
+
+### `has_obligation(agreement_id: String) -> bool`
+Check if an obligation exists for a given agreement.
+
+### `get_obligation_count() -> u32`
+Get total count of minted obligations.
+
+## Events
+
+### ObligationMinted
+Emitted when a new obligation NFT is minted.
+- Topics: `["minted", landlord: Address]`
+- Data: `agreement_id`, `minted_at`
+
+### ObligationTransferred
+Emitted when an obligation is transferred.
+- Topics: `["transferred", from: Address, to: Address]`
+- Data: `agreement_id`
+
+## Integration with Rental System
+
+When integrated with the main rental contract:
+
+1. **On Agreement Signing**: After a rent agreement is signed and activated, call `mint_obligation()` to create an NFT for the landlord
+2. **Rent Payments**: Payment contract should query `get_obligation_owner()` to determine the current recipient of rent payments
+3. **Property Transfer**: When selling property, transfer the obligation NFT to the new owner using `transfer_obligation()`
+
+## Building
+
+```bash
+make build
+```
+
+## Testing
+
+```bash
+make test
+```
+
+## Security Considerations
+
+- Authorization is required for minting and transfers
+- Only the current owner can transfer an obligation
+- Duplicate minting is prevented at the contract level
+- All storage uses persistent storage with TTL extension

--- a/contract/contracts/rent_obligation/src/errors.rs
+++ b/contract/contracts/rent_obligation/src/errors.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ObligationError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    ObligationAlreadyExists = 3,
+    ObligationNotFound = 4,
+    Unauthorized = 5,
+    InvalidOwner = 6,
+}

--- a/contract/contracts/rent_obligation/src/events.rs
+++ b/contract/contracts/rent_obligation/src/events.rs
@@ -1,0 +1,47 @@
+use soroban_sdk::{contractevent, Address, Env, String};
+
+/// Event emitted when a rent obligation NFT is minted
+/// Topics: ["minted", landlord: Address]
+#[contractevent(topics = ["minted"])]
+pub struct ObligationMinted {
+    #[topic]
+    pub landlord: Address,
+    pub agreement_id: String,
+    pub minted_at: u64,
+}
+
+/// Event emitted when a rent obligation NFT is transferred
+/// Topics: ["transferred", from: Address, to: Address]
+#[contractevent(topics = ["transferred"])]
+pub struct ObligationTransferred {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub to: Address,
+    pub agreement_id: String,
+}
+
+/// Helper function to emit obligation minted event
+pub(crate) fn obligation_minted(
+    env: &Env,
+    agreement_id: String,
+    landlord: Address,
+    minted_at: u64,
+) {
+    ObligationMinted {
+        landlord,
+        agreement_id,
+        minted_at,
+    }
+    .publish(env);
+}
+
+/// Helper function to emit obligation transferred event
+pub(crate) fn obligation_transferred(env: &Env, agreement_id: String, from: Address, to: Address) {
+    ObligationTransferred {
+        from,
+        to,
+        agreement_id,
+    }
+    .publish(env);
+}

--- a/contract/contracts/rent_obligation/src/lib.rs
+++ b/contract/contracts/rent_obligation/src/lib.rs
@@ -1,0 +1,206 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use errors::ObligationError;
+pub use storage::DataKey;
+pub use types::RentObligation;
+
+#[contract]
+pub struct TokenizedRentObligationContract;
+
+#[contractimpl]
+impl TokenizedRentObligationContract {
+    /// Initialize the contract.
+    ///
+    /// # Errors
+    /// * `AlreadyInitialized` - If the contract has already been initialized
+    pub fn initialize(env: Env) -> Result<(), ObligationError> {
+        if env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(ObligationError::AlreadyInitialized);
+        }
+
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Initialized, 500000, 500000);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ObligationCount, &0u32);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::ObligationCount, 500000, 500000);
+
+        Ok(())
+    }
+
+    /// Mint a new tokenized rent obligation NFT for a rent agreement.
+    ///
+    /// # Arguments
+    /// * `agreement_id` - Unique identifier for the rent agreement
+    /// * `landlord` - Address of the landlord who will receive the NFT
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract hasn't been initialized
+    /// * `ObligationAlreadyExists` - If an obligation for this agreement already exists
+    pub fn mint_obligation(
+        env: Env,
+        agreement_id: String,
+        landlord: Address,
+    ) -> Result<(), ObligationError> {
+        if !env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(ObligationError::NotInitialized);
+        }
+
+        landlord.require_auth();
+
+        let obligation_key = DataKey::Obligation(agreement_id.clone());
+        let owner_key = DataKey::Owner(agreement_id.clone());
+
+        if env.storage().persistent().has(&obligation_key) {
+            return Err(ObligationError::ObligationAlreadyExists);
+        }
+
+        let obligation = RentObligation {
+            agreement_id: agreement_id.clone(),
+            owner: landlord.clone(),
+            minted_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(&obligation_key, &obligation);
+        env.storage()
+            .persistent()
+            .extend_ttl(&obligation_key, 500000, 500000);
+
+        env.storage().persistent().set(&owner_key, &landlord);
+        env.storage()
+            .persistent()
+            .extend_ttl(&owner_key, 500000, 500000);
+
+        let mut count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ObligationCount)
+            .unwrap_or(0);
+        count += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::ObligationCount, &count);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::ObligationCount, 500000, 500000);
+
+        events::obligation_minted(&env, agreement_id, landlord, obligation.minted_at);
+
+        Ok(())
+    }
+
+    /// Transfer ownership of a tokenized rent obligation to another address.
+    ///
+    /// # Arguments
+    /// * `from` - Current owner of the obligation
+    /// * `to` - New owner to transfer to
+    /// * `agreement_id` - Agreement identifier for the obligation
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If contract hasn't been initialized
+    /// * `ObligationNotFound` - If the obligation doesn't exist
+    /// * `Unauthorized` - If the caller is not the current owner
+    pub fn transfer_obligation(
+        env: Env,
+        from: Address,
+        to: Address,
+        agreement_id: String,
+    ) -> Result<(), ObligationError> {
+        if !env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(ObligationError::NotInitialized);
+        }
+
+        from.require_auth();
+
+        let obligation_key = DataKey::Obligation(agreement_id.clone());
+        let owner_key = DataKey::Owner(agreement_id.clone());
+
+        let mut obligation: RentObligation = env
+            .storage()
+            .persistent()
+            .get(&obligation_key)
+            .ok_or(ObligationError::ObligationNotFound)?;
+
+        if obligation.owner != from {
+            return Err(ObligationError::Unauthorized);
+        }
+
+        obligation.owner = to.clone();
+
+        env.storage().persistent().set(&obligation_key, &obligation);
+        env.storage()
+            .persistent()
+            .extend_ttl(&obligation_key, 500000, 500000);
+
+        env.storage().persistent().set(&owner_key, &to);
+        env.storage()
+            .persistent()
+            .extend_ttl(&owner_key, 500000, 500000);
+
+        events::obligation_transferred(&env, agreement_id, from, to);
+
+        Ok(())
+    }
+
+    /// Get the current owner of a tokenized rent obligation.
+    ///
+    /// # Arguments
+    /// * `agreement_id` - Agreement identifier for the obligation
+    ///
+    /// # Returns
+    /// The address of the current owner, or None if the obligation doesn't exist
+    pub fn get_obligation_owner(env: Env, agreement_id: String) -> Option<Address> {
+        let owner_key = DataKey::Owner(agreement_id);
+        env.storage().persistent().get(&owner_key)
+    }
+
+    /// Get the full obligation data for an agreement.
+    ///
+    /// # Arguments
+    /// * `agreement_id` - Agreement identifier for the obligation
+    ///
+    /// # Returns
+    /// The RentObligation data, or None if the obligation doesn't exist
+    pub fn get_obligation(env: Env, agreement_id: String) -> Option<RentObligation> {
+        let obligation_key = DataKey::Obligation(agreement_id);
+        env.storage().persistent().get(&obligation_key)
+    }
+
+    /// Check if an obligation exists for a given agreement.
+    ///
+    /// # Arguments
+    /// * `agreement_id` - Agreement identifier to check
+    ///
+    /// # Returns
+    /// True if the obligation exists, false otherwise
+    pub fn has_obligation(env: Env, agreement_id: String) -> bool {
+        let obligation_key = DataKey::Obligation(agreement_id);
+        env.storage().persistent().has(&obligation_key)
+    }
+
+    /// Get the total count of minted obligations.
+    ///
+    /// # Returns
+    /// The total number of obligations that have been minted
+    pub fn get_obligation_count(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ObligationCount)
+            .unwrap_or(0)
+    }
+}

--- a/contract/contracts/rent_obligation/src/storage.rs
+++ b/contract/contracts/rent_obligation/src/storage.rs
@@ -1,0 +1,10 @@
+use soroban_sdk::{contracttype, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Initialized,
+    Obligation(String),
+    Owner(String),
+    ObligationCount,
+}

--- a/contract/contracts/rent_obligation/src/tests.rs
+++ b/contract/contracts/rent_obligation/src/tests.rs
@@ -1,0 +1,300 @@
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, String,
+};
+
+fn create_contract(env: &Env) -> TokenizedRentObligationContractClient<'_> {
+    let contract_id = env.register(TokenizedRentObligationContract, ());
+    TokenizedRentObligationContractClient::new(env, &contract_id)
+}
+
+#[test]
+fn test_successful_initialization() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let result = client.try_initialize();
+    assert!(result.is_ok());
+
+    let count = client.get_obligation_count();
+    assert_eq!(count, 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_double_initialization_fails() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    client.initialize();
+    client.initialize();
+}
+
+#[test]
+fn test_mint_obligation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    let result = client.try_mint_obligation(&agreement_id, &landlord);
+    assert!(result.is_ok());
+
+    let owner = client.get_obligation_owner(&agreement_id);
+    assert_eq!(owner, Some(landlord.clone()));
+
+    let has_obligation = client.has_obligation(&agreement_id);
+    assert!(has_obligation);
+
+    let count = client.get_obligation_count();
+    assert_eq!(count, 1);
+
+    let obligation = client.get_obligation(&agreement_id);
+    assert!(obligation.is_some());
+    let obligation = obligation.unwrap();
+    assert_eq!(obligation.agreement_id, agreement_id);
+    assert_eq!(obligation.owner, landlord);
+    assert_eq!(obligation.minted_at, env.ledger().timestamp());
+}
+
+#[test]
+#[should_panic]
+fn test_mint_obligation_requires_auth() {
+    let env = Env::default();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_mint_duplicate_obligation_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+    client.mint_obligation(&agreement_id, &landlord);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_mint_without_initialization_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+
+    let landlord = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+}
+
+#[test]
+fn test_transfer_obligation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+
+    let result = client.try_transfer_obligation(&landlord, &new_owner, &agreement_id);
+    assert!(result.is_ok());
+
+    let owner = client.get_obligation_owner(&agreement_id);
+    assert_eq!(owner, Some(new_owner.clone()));
+
+    let obligation = client.get_obligation(&agreement_id);
+    assert!(obligation.is_some());
+    let obligation = obligation.unwrap();
+    assert_eq!(obligation.owner, new_owner);
+}
+
+#[test]
+#[should_panic]
+fn test_transfer_obligation_requires_auth() {
+    let env = Env::default();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &landlord,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "mint_obligation",
+                args: (&agreement_id, &landlord).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .mint_obligation(&agreement_id, &landlord);
+
+    client.transfer_obligation(&landlord, &new_owner, &agreement_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_transfer_nonexistent_obligation_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "nonexistent");
+
+    client.transfer_obligation(&landlord, &new_owner, &agreement_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_transfer_from_non_owner_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let fake_owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+
+    client.transfer_obligation(&fake_owner, &new_owner, &agreement_id);
+}
+
+#[test]
+fn test_multiple_obligations() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord1 = Address::generate(&env);
+    let landlord2 = Address::generate(&env);
+    let landlord3 = Address::generate(&env);
+
+    let agreement_id1 = String::from_str(&env, "agreement_001");
+    let agreement_id2 = String::from_str(&env, "agreement_002");
+    let agreement_id3 = String::from_str(&env, "agreement_003");
+
+    client.mint_obligation(&agreement_id1, &landlord1);
+    client.mint_obligation(&agreement_id2, &landlord2);
+    client.mint_obligation(&agreement_id3, &landlord3);
+
+    assert_eq!(client.get_obligation_count(), 3);
+
+    assert_eq!(client.get_obligation_owner(&agreement_id1), Some(landlord1));
+    assert_eq!(client.get_obligation_owner(&agreement_id2), Some(landlord2));
+    assert_eq!(client.get_obligation_owner(&agreement_id3), Some(landlord3));
+}
+
+#[test]
+fn test_get_nonexistent_obligation() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    client.initialize();
+
+    let agreement_id = String::from_str(&env, "nonexistent");
+
+    let owner = client.get_obligation_owner(&agreement_id);
+    assert_eq!(owner, None);
+
+    let obligation = client.get_obligation(&agreement_id);
+    assert_eq!(obligation, None);
+
+    let has_obligation = client.has_obligation(&agreement_id);
+    assert!(!has_obligation);
+}
+
+#[test]
+fn test_transfer_chain() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let buyer1 = Address::generate(&env);
+    let buyer2 = Address::generate(&env);
+    let buyer3 = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+    assert_eq!(
+        client.get_obligation_owner(&agreement_id),
+        Some(landlord.clone())
+    );
+
+    client.transfer_obligation(&landlord, &buyer1, &agreement_id);
+    assert_eq!(
+        client.get_obligation_owner(&agreement_id),
+        Some(buyer1.clone())
+    );
+
+    client.transfer_obligation(&buyer1, &buyer2, &agreement_id);
+    assert_eq!(
+        client.get_obligation_owner(&agreement_id),
+        Some(buyer2.clone())
+    );
+
+    client.transfer_obligation(&buyer2, &buyer3, &agreement_id);
+    assert_eq!(
+        client.get_obligation_owner(&agreement_id),
+        Some(buyer3.clone())
+    );
+
+    assert_eq!(client.get_obligation_count(), 1);
+}
+
+#[test]
+fn test_events_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    client.initialize();
+
+    let landlord = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let agreement_id = String::from_str(&env, "agreement_001");
+
+    client.mint_obligation(&agreement_id, &landlord);
+    client.transfer_obligation(&landlord, &new_owner, &agreement_id);
+
+    let all_events = env.events().all();
+    assert!(!all_events.is_empty());
+}

--- a/contract/contracts/rent_obligation/src/types.rs
+++ b/contract/contracts/rent_obligation/src/types.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RentObligation {
+    pub agreement_id: String,
+    pub owner: Address,
+    pub minted_at: u64,
+}


### PR DESCRIPTION


- Create new Soroban contract at `contract/contracts/rent_obligation`
- Implement `mint_obligation` with landlord auth and duplicate mint guard
- Implement `transfer_obligation` with current owner auth enforcement
- Implement `get_obligation_owner` as public read returning current owner
- Store obligation token map keyed by agreement_id with owner and metadata
- Emit mint and transfer events compatible with SEP-0041 indexing standards
- Add unit tests: mint, duplicate mint guard, transfer, ownership, unauthorized
- Add inline documentation for all public contract methods

Create Tokenized Rent Obligation Contract
Fixes #193