### PR TITLE
feat(agent-registry): implement AgentRegistryContract with reputation…

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "agent_registry"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contract/contracts/agent_registry/Cargo.toml
+++ b/contract/contracts/agent_registry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "agent_registry"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/contracts/agent_registry/INTEGRATION.md
+++ b/contract/contracts/agent_registry/INTEGRATION.md
@@ -1,0 +1,403 @@
+# Agent Registry Contract Integration Guide
+
+This guide explains how to integrate the Agent Registry Contract with the Chioma rent payment ecosystem.
+
+## Overview
+
+The Agent Registry Contract provides on-chain verification and reputation tracking for house agents. It prevents fraudulent addresses from being added as agents in rent agreements and ensures only verified, reputable agents receive automatic commission distributions.
+
+## Integration Points
+
+### 1. Rent Agreement Creation
+
+When creating a new rent agreement that includes an agent commission:
+
+```rust
+// Before creating the rent agreement, verify the agent is registered and verified
+let agent_info = agent_registry.get_agent_info(&agent_address);
+
+match agent_info {
+    Some(info) => {
+        if !info.verified {
+            return Err(Error::AgentNotVerified);
+        }
+        // Proceed with rent agreement creation
+    }
+    None => return Err(Error::AgentNotFound),
+}
+
+// Register the transaction with the agent registry
+let parties = vec![tenant_address, landlord_address];
+agent_registry.register_transaction(
+    &agreement_id,
+    &agent_address,
+    &parties
+)?;
+```
+
+### 2. Transaction Completion
+
+When a rent agreement or property transaction is successfully completed:
+
+```rust
+// Mark the transaction as complete in the agent registry
+agent_registry.complete_transaction(&agreement_id, &agent_address)?;
+
+// This enables the parties to rate the agent
+```
+
+### 3. Agent Rating
+
+After a transaction is completed, tenants and landlords can rate the agent:
+
+```rust
+// Tenant rates the agent
+agent_registry.rate_agent(
+    &tenant_address,
+    &agent_address,
+    &5, // Rating: 1-5 stars
+    &agreement_id
+)?;
+
+// Landlord rates the agent
+agent_registry.rate_agent(
+    &landlord_address,
+    &agent_address,
+    &4,
+    &agreement_id
+)?;
+```
+
+### 4. Agent Verification (Frontend)
+
+Display agent reputation information in the UI:
+
+```rust
+let agent_info = agent_registry.get_agent_info(&agent_address)?;
+
+// Display:
+// - Verified status: agent_info.verified
+// - Average rating: agent_info.average_rating()
+// - Total ratings: agent_info.total_ratings
+// - Completed agreements: agent_info.completed_agreements
+```
+
+## Workflow Example
+
+### Complete Flow: From Agent Registration to Rating
+
+```rust
+// 1. Admin initializes the contract
+agent_registry.initialize(&admin_address);
+
+// 2. Agent self-registers
+agent_registry.register_agent(
+    &agent_address,
+    &"QmProfileHashIPFS..."
+);
+
+// 3. Admin verifies the agent
+agent_registry.verify_agent(&admin_address, &agent_address);
+
+// 4. Rent agreement is created (in chioma contract)
+// Verify agent before including in agreement
+let agent_info = agent_registry.get_agent_info(&agent_address)?;
+if !agent_info.verified {
+    return Err(Error::AgentNotVerified);
+}
+
+// 5. Register the transaction
+let parties = vec![tenant, landlord];
+agent_registry.register_transaction(
+    &"RENT-001",
+    &agent_address,
+    &parties
+);
+
+// 6. Transaction completes successfully
+agent_registry.complete_transaction(&"RENT-001", &agent_address);
+
+// 7. Parties rate the agent
+agent_registry.rate_agent(&tenant, &agent_address, &5, &"RENT-001");
+agent_registry.rate_agent(&landlord, &agent_address, &4, &"RENT-001");
+
+// 8. View updated reputation
+let updated_info = agent_registry.get_agent_info(&agent_address);
+// average_rating() = 4 (average of 5 and 4)
+// completed_agreements = 1
+// total_ratings = 2
+```
+
+## Security Best Practices
+
+### 1. Agent Verification
+
+Always verify an agent before including them in a rent agreement:
+
+```rust
+fn validate_agent(registry: &AgentRegistryClient, agent: &Address) -> Result<(), Error> {
+    let info = registry.get_agent_info(agent)
+        .ok_or(Error::AgentNotFound)?;
+    
+    if !info.verified {
+        return Err(Error::AgentNotVerified);
+    }
+    
+    Ok(())
+}
+```
+
+### 2. Transaction Registration
+
+Register transactions immediately when created to establish the rating relationship:
+
+```rust
+// In rent agreement contract
+pub fn create_agreement(
+    env: Env,
+    tenant: Address,
+    landlord: Address,
+    agent: Option<Address>,
+    // ... other params
+) -> Result<String, Error> {
+    let agreement_id = generate_agreement_id(&env);
+    
+    // If agent is included, register the transaction
+    if let Some(agent_addr) = agent {
+        let parties = vec![&env, tenant.clone(), landlord.clone()];
+        
+        // Call agent registry contract
+        let agent_registry = AgentRegistryClient::new(&env, &registry_contract_id);
+        agent_registry.register_transaction(
+            &agreement_id,
+            &agent_addr,
+            &parties
+        )?;
+    }
+    
+    // Create the agreement
+    // ...
+    
+    Ok(agreement_id)
+}
+```
+
+### 3. Rating Access Control
+
+The contract automatically enforces:
+- Only transaction parties can rate
+- Each party can only rate once per transaction
+- Transaction must be completed before rating
+- Agent must be verified to receive ratings
+
+## Frontend Integration
+
+### Display Agent Card
+
+```typescript
+interface AgentInfo {
+  agent: string;
+  externalProfileHash: string;
+  verified: boolean;
+  registeredAt: number;
+  verifiedAt?: number;
+  totalRatings: number;
+  totalScore: number;
+  completedAgreements: number;
+}
+
+function AgentCard({ agentAddress }: { agentAddress: string }) {
+  const agentInfo = useAgentInfo(agentAddress);
+  
+  if (!agentInfo) return <div>Agent not found</div>;
+  
+  const averageRating = agentInfo.totalRatings > 0 
+    ? agentInfo.totalScore / agentInfo.totalRatings 
+    : 0;
+  
+  return (
+    <div className="agent-card">
+      <h3>Agent Information</h3>
+      <div>
+        {agentInfo.verified ? (
+          <span className="verified-badge">✓ Verified</span>
+        ) : (
+          <span className="unverified-badge">Not Verified</span>
+        )}
+      </div>
+      <div>Rating: {averageRating.toFixed(1)} / 5.0 ({agentInfo.totalRatings} reviews)</div>
+      <div>Completed Agreements: {agentInfo.completedAgreements}</div>
+    </div>
+  );
+}
+```
+
+### Rating Form
+
+```typescript
+function RateAgentForm({ 
+  agentAddress, 
+  transactionId 
+}: { 
+  agentAddress: string; 
+  transactionId: string;
+}) {
+  const [rating, setRating] = useState(5);
+  
+  const handleSubmit = async () => {
+    try {
+      await agentRegistry.rateAgent({
+        rater: currentUserAddress,
+        agent: agentAddress,
+        score: rating,
+        transactionId,
+      });
+      
+      showSuccess("Agent rated successfully!");
+    } catch (error) {
+      showError("Failed to rate agent: " + error.message);
+    }
+  };
+  
+  return (
+    <div>
+      <h3>Rate Agent</h3>
+      <StarRating value={rating} onChange={setRating} max={5} />
+      <button onClick={handleSubmit}>Submit Rating</button>
+    </div>
+  );
+}
+```
+
+## Error Handling
+
+Common errors and how to handle them:
+
+```rust
+match agent_registry.rate_agent(&rater, &agent, &score, &txn_id) {
+    Ok(_) => {
+        log::info!("Agent rated successfully");
+    }
+    Err(AgentError::AgentNotVerified) => {
+        // Agent hasn't been verified by admin yet
+        log::error!("Cannot rate unverified agent");
+    }
+    Err(AgentError::TransactionNotCompleted) => {
+        // Transaction must be completed first
+        log::error!("Complete the transaction before rating");
+    }
+    Err(AgentError::NotTransactionParty) => {
+        // Only transaction parties can rate
+        log::error!("You must be part of the transaction to rate");
+    }
+    Err(AgentError::AlreadyRated) => {
+        // Each party can only rate once
+        log::error!("You have already rated this agent");
+    }
+    Err(AgentError::InvalidRatingScore) => {
+        // Score must be 1-5
+        log::error!("Rating must be between 1 and 5");
+    }
+    Err(e) => {
+        log::error!("Unexpected error: {:?}", e);
+    }
+}
+```
+
+## Admin Operations
+
+### Agent Verification Workflow
+
+```rust
+// Admin dashboard: View pending agent registrations
+let total_agents = agent_registry.get_agent_count();
+
+// For each agent, check verification status
+for agent_addr in pending_agents {
+    let info = agent_registry.get_agent_info(&agent_addr);
+    
+    if let Some(agent_info) = info {
+        if !agent_info.verified {
+            // Admin can verify after reviewing external profile
+            // Fetch and verify external profile from IPFS
+            let profile = fetch_ipfs(&agent_info.external_profile_hash);
+            
+            // After manual verification
+            agent_registry.verify_agent(&admin_address, &agent_addr)?;
+        }
+    }
+}
+```
+
+## Testing Integration
+
+When testing the integration:
+
+```rust
+#[test]
+fn test_complete_agent_flow() {
+    let env = Env::default();
+    let agent_registry = create_agent_registry(&env);
+    let rent_contract = create_rent_contract(&env);
+    
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+    
+    env.mock_all_auths();
+    
+    // Setup
+    agent_registry.initialize(&admin);
+    agent_registry.register_agent(&agent, &"profile_hash");
+    agent_registry.verify_agent(&admin, &agent);
+    
+    // Create rent agreement with verified agent
+    let agreement_id = rent_contract.create_agreement(
+        &tenant,
+        &landlord,
+        &Some(agent.clone()),
+        // ... other params
+    ).unwrap();
+    
+    // Register transaction
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+    agent_registry.register_transaction(&agreement_id, &agent, &parties).unwrap();
+    
+    // Complete transaction
+    rent_contract.complete_agreement(&agreement_id).unwrap();
+    agent_registry.complete_transaction(&agreement_id, &agent).unwrap();
+    
+    // Rate agent
+    agent_registry.rate_agent(&tenant, &agent, &5, &agreement_id).unwrap();
+    agent_registry.rate_agent(&landlord, &agent, &4, &agreement_id).unwrap();
+    
+    // Verify reputation
+    let info = agent_registry.get_agent_info(&agent).unwrap();
+    assert_eq!(info.average_rating(), 4);
+    assert_eq!(info.completed_agreements, 1);
+}
+```
+
+## Deployment
+
+1. Deploy the Agent Registry Contract
+2. Initialize with admin address
+3. Update rent agreement contract to reference agent registry contract ID
+4. Deploy updated frontend with agent verification UI
+
+## Contract Addresses
+
+After deployment, update your environment configuration:
+
+```env
+AGENT_REGISTRY_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+And use in your contracts:
+
+```rust
+const AGENT_REGISTRY_ID: Address = Address::from_string(
+    &String::from_str(&env, env!("AGENT_REGISTRY_CONTRACT_ID"))
+);
+```

--- a/contract/contracts/agent_registry/Makefile
+++ b/contract/contracts/agent_registry/Makefile
@@ -1,0 +1,15 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	cargo build --target wasm32-unknown-unknown --release
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contract/contracts/agent_registry/README.md
+++ b/contract/contracts/agent_registry/README.md
@@ -1,0 +1,213 @@
+# Agent Registry Contract
+
+The Agent Registry Contract is a Soroban smart contract that tracks verified house agents and their reputation scores on the Stellar blockchain. It maintains an immutable registry of approved agents and allows tenants and landlords to rate agents after successful property transactions.
+
+## Overview
+
+This contract enables:
+- **Agent Registration**: Agents can self-register with an external profile reference
+- **Admin Verification**: Platform administrators can verify registered agents
+- **Transaction Tracking**: Links agents to property transactions for accountability
+- **Reputation System**: Allows transaction parties to rate agents (1-5 stars) and calculates average ratings
+- **Access Control**: Ensures only verified parties can rate agents and only admins can verify them
+
+## Data Structures
+
+### AgentInfo
+```rust
+pub struct AgentInfo {
+    pub agent: Address,
+    pub external_profile_hash: String,
+    pub verified: bool,
+    pub registered_at: u64,
+    pub verified_at: Option<u64>,
+    pub total_ratings: u32,
+    pub total_score: u32,
+    pub completed_agreements: u32,
+}
+```
+
+### AgentTransaction
+```rust
+pub struct AgentTransaction {
+    pub transaction_id: String,
+    pub agent: Address,
+    pub parties: Vec<Address>,
+    pub completed: bool,
+}
+```
+
+## Methods
+
+### Administrative Functions
+
+#### `initialize(admin: Address) -> Result<(), AgentError>`
+Initializes the contract with an admin address who has privileges to verify agents.
+
+**Parameters:**
+- `admin`: The address that will have admin privileges
+
+**Errors:**
+- `AlreadyInitialized`: If contract has already been initialized
+
+#### `get_state() -> Option<ContractState>`
+Returns the current contract state including the admin address.
+
+### Agent Management
+
+#### `register_agent(agent: Address, external_profile_hash: String) -> Result<(), AgentError>`
+Allows an agent to self-register with the system.
+
+**Parameters:**
+- `agent`: The address of the agent registering
+- `external_profile_hash`: Hash reference to agent's external profile (IPFS hash, etc.)
+
+**Errors:**
+- `NotInitialized`: Contract hasn't been initialized
+- `AgentAlreadyRegistered`: Agent is already registered
+- `InvalidProfileHash`: Profile hash is empty
+
+#### `verify_agent(admin: Address, agent: Address) -> Result<(), AgentError>`
+Platform admin verifies a registered agent (admin-only function).
+
+**Parameters:**
+- `admin`: The admin address performing verification
+- `agent`: The address of the agent to verify
+
+**Errors:**
+- `NotInitialized`: Contract hasn't been initialized
+- `Unauthorized`: Caller is not the admin
+- `AgentNotFound`: Agent doesn't exist
+- `AlreadyVerified`: Agent is already verified
+
+#### `get_agent_info(agent: Address) -> Option<AgentInfo>`
+Retrieves information about a registered agent.
+
+**Parameters:**
+- `agent`: The address of the agent
+
+**Returns:**
+- `Option<AgentInfo>`: Agent information if they exist
+
+#### `get_agent_count() -> u32`
+Returns the total number of registered agents.
+
+### Transaction Management
+
+#### `register_transaction(transaction_id: String, agent: Address, parties: Vec<Address>) -> Result<(), AgentError>`
+Registers a transaction involving an agent. Called when a rent agreement or property transaction is created.
+
+**Parameters:**
+- `transaction_id`: Unique identifier for the transaction
+- `agent`: The agent involved in the transaction
+- `parties`: Vector of addresses involved (tenant, landlord, etc.)
+
+**Errors:**
+- `NotInitialized`: Contract hasn't been initialized
+- `AgentNotFound`: Agent doesn't exist
+
+#### `complete_transaction(transaction_id: String, agent: Address) -> Result<(), AgentError>`
+Marks a transaction as completed, enabling parties to rate the agent.
+
+**Parameters:**
+- `transaction_id`: The ID of the transaction to complete
+- `agent`: The agent address (for verification)
+
+**Errors:**
+- `NotInitialized`: Contract hasn't been initialized
+- `TransactionNotFound`: Transaction doesn't exist
+- `Unauthorized`: Caller is not the agent for this transaction
+
+### Rating System
+
+#### `rate_agent(rater: Address, agent: Address, score: u32, transaction_id: String) -> Result<(), AgentError>`
+Allows a transaction party (tenant or landlord) to rate an agent after completing a transaction.
+
+**Parameters:**
+- `rater`: The address of the person rating
+- `agent`: The address of the agent being rated
+- `score`: The rating score (1-5)
+- `transaction_id`: The ID of the completed transaction
+
+**Errors:**
+- `NotInitialized`: Contract hasn't been initialized
+- `InvalidRatingScore`: Score is not between 1 and 5
+- `AgentNotFound`: Agent doesn't exist
+- `AgentNotVerified`: Agent is not verified
+- `TransactionNotFound`: Transaction doesn't exist
+- `TransactionNotCompleted`: Transaction is not marked as completed
+- `NotTransactionParty`: Rater wasn't part of the transaction
+- `AlreadyRated`: Rater has already rated this agent
+
+## Reputation System
+
+The contract calculates reputation based on:
+1. **Average Rating**: Total score divided by number of ratings (1-5 scale)
+2. **Completed Agreements**: Total number of successfully completed transactions
+3. **Total Ratings**: Number of ratings received
+
+Agents can only be rated by verified transaction parties after transaction completion.
+
+## Access Control
+
+- **Agent Registration**: Requires authentication from the agent's address
+- **Agent Verification**: Only callable by the admin address
+- **Rating**: Only transaction parties can rate, and only for completed transactions
+- **One Rating Per Party**: Each party can rate an agent only once per transaction
+
+## Usage Example
+
+```rust
+// Initialize contract
+contract.initialize(&admin);
+
+// Agent self-registers
+contract.register_agent(&agent, &profile_hash);
+
+// Admin verifies the agent
+contract.verify_agent(&admin, &agent);
+
+// Register a transaction
+let parties = vec![tenant, landlord];
+contract.register_transaction(&txn_id, &agent, &parties);
+
+// Complete the transaction
+contract.complete_transaction(&txn_id, &agent);
+
+// Parties rate the agent
+contract.rate_agent(&tenant, &agent, &5, &txn_id);
+contract.rate_agent(&landlord, &agent, &4, &txn_id);
+
+// Get agent info with reputation
+let info = contract.get_agent_info(&agent);
+// info.average_rating() returns 4 (average of 5 and 4)
+```
+
+## Building and Testing
+
+```bash
+# Build the contract
+make build
+
+# Run tests
+make test
+
+# Format code
+make fmt
+```
+
+## Integration with Chioma Ecosystem
+
+This contract integrates with the Chioma rent payment system by:
+1. Preventing fraudulent addresses from being added as agents in rent agreements
+2. Tracking agent involvement in property transactions
+3. Building verifiable reputation for agents based on completed transactions
+4. Ensuring automatic commission distributions go only to verified, reputable agents
+
+## Security Considerations
+
+- Agents must be verified by admin before they can receive ratings
+- Only transaction parties can rate agents
+- Ratings are immutable once submitted
+- Transaction completion is required before rating
+- Access control prevents unauthorized verification or rating

--- a/contract/contracts/agent_registry/src/agent.rs
+++ b/contract/contracts/agent_registry/src/agent.rs
@@ -1,0 +1,255 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::errors::AgentError;
+use crate::events;
+use crate::storage::DataKey;
+use crate::types::{AgentInfo, AgentTransaction, ContractState};
+
+pub fn register_agent(
+    env: &Env,
+    agent: Address,
+    external_profile_hash: String,
+) -> Result<(), AgentError> {
+    if !env.storage().persistent().has(&DataKey::Initialized) {
+        return Err(AgentError::NotInitialized);
+    }
+
+    agent.require_auth();
+
+    if external_profile_hash.is_empty() {
+        return Err(AgentError::InvalidProfileHash);
+    }
+
+    let key = DataKey::Agent(agent.clone());
+    if env.storage().persistent().has(&key) {
+        return Err(AgentError::AgentAlreadyRegistered);
+    }
+
+    let agent_info = AgentInfo {
+        agent: agent.clone(),
+        external_profile_hash: external_profile_hash.clone(),
+        verified: false,
+        registered_at: env.ledger().timestamp(),
+        verified_at: None,
+        total_ratings: 0,
+        total_score: 0,
+        completed_agreements: 0,
+    };
+
+    env.storage().persistent().set(&key, &agent_info);
+    env.storage().persistent().extend_ttl(&key, 500000, 500000);
+
+    let count_key = DataKey::AgentCount;
+    let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    env.storage().persistent().set(&count_key, &(count + 1));
+    env.storage()
+        .persistent()
+        .extend_ttl(&count_key, 500000, 500000);
+
+    events::agent_registered(env, agent, external_profile_hash);
+
+    Ok(())
+}
+
+pub fn verify_agent(env: &Env, admin: Address, agent: Address) -> Result<(), AgentError> {
+    let state: ContractState = env
+        .storage()
+        .instance()
+        .get(&DataKey::State)
+        .ok_or(AgentError::NotInitialized)?;
+
+    admin.require_auth();
+
+    if admin != state.admin {
+        return Err(AgentError::Unauthorized);
+    }
+
+    let key = DataKey::Agent(agent.clone());
+    let mut agent_info: AgentInfo = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(AgentError::AgentNotFound)?;
+
+    if agent_info.verified {
+        return Err(AgentError::AlreadyVerified);
+    }
+
+    agent_info.verified = true;
+    agent_info.verified_at = Some(env.ledger().timestamp());
+
+    env.storage().persistent().set(&key, &agent_info);
+    env.storage().persistent().extend_ttl(&key, 500000, 500000);
+
+    events::agent_verified(env, admin, agent);
+
+    Ok(())
+}
+
+pub fn rate_agent(
+    env: &Env,
+    rater: Address,
+    agent: Address,
+    score: u32,
+    transaction_id: String,
+) -> Result<(), AgentError> {
+    if !env.storage().persistent().has(&DataKey::Initialized) {
+        return Err(AgentError::NotInitialized);
+    }
+
+    rater.require_auth();
+
+    if !(1..=5).contains(&score) {
+        return Err(AgentError::InvalidRatingScore);
+    }
+
+    let agent_key = DataKey::Agent(agent.clone());
+    let mut agent_info: AgentInfo = env
+        .storage()
+        .persistent()
+        .get(&agent_key)
+        .ok_or(AgentError::AgentNotFound)?;
+
+    if !agent_info.verified {
+        return Err(AgentError::AgentNotVerified);
+    }
+
+    let txn_key = DataKey::Transaction(transaction_id.clone());
+    let transaction: AgentTransaction = env
+        .storage()
+        .persistent()
+        .get(&txn_key)
+        .ok_or(AgentError::TransactionNotFound)?;
+
+    if !transaction.completed {
+        return Err(AgentError::TransactionNotCompleted);
+    }
+
+    if transaction.agent != agent {
+        return Err(AgentError::AgentNotFound);
+    }
+
+    let mut is_party = false;
+    for party in transaction.parties.iter() {
+        if party == rater {
+            is_party = true;
+            break;
+        }
+    }
+
+    if !is_party {
+        return Err(AgentError::NotTransactionParty);
+    }
+
+    let rating_key = DataKey::AgentRating(agent.clone(), rater.clone());
+    if env.storage().persistent().has(&rating_key) {
+        return Err(AgentError::AlreadyRated);
+    }
+
+    env.storage().persistent().set(&rating_key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&rating_key, 500000, 500000);
+
+    agent_info.total_ratings += 1;
+    agent_info.total_score += score;
+
+    env.storage().persistent().set(&agent_key, &agent_info);
+    env.storage()
+        .persistent()
+        .extend_ttl(&agent_key, 500000, 500000);
+
+    events::agent_rated(env, agent, rater, score);
+
+    Ok(())
+}
+
+pub fn get_agent_info(env: &Env, agent: Address) -> Option<AgentInfo> {
+    let key = DataKey::Agent(agent);
+    env.storage().persistent().get(&key)
+}
+
+pub fn get_agent_count(env: &Env) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AgentCount)
+        .unwrap_or(0)
+}
+
+pub fn register_transaction(
+    env: &Env,
+    transaction_id: String,
+    agent: Address,
+    parties: Vec<Address>,
+) -> Result<(), AgentError> {
+    if !env.storage().persistent().has(&DataKey::Initialized) {
+        return Err(AgentError::NotInitialized);
+    }
+
+    let agent_key = DataKey::Agent(agent.clone());
+    if !env.storage().persistent().has(&agent_key) {
+        return Err(AgentError::AgentNotFound);
+    }
+
+    let txn_key = DataKey::Transaction(transaction_id.clone());
+
+    let transaction = AgentTransaction {
+        transaction_id: transaction_id.clone(),
+        agent: agent.clone(),
+        parties,
+        completed: false,
+    };
+
+    env.storage().persistent().set(&txn_key, &transaction);
+    env.storage()
+        .persistent()
+        .extend_ttl(&txn_key, 500000, 500000);
+
+    events::transaction_registered(env, transaction_id, agent);
+
+    Ok(())
+}
+
+pub fn complete_transaction(
+    env: &Env,
+    transaction_id: String,
+    agent: Address,
+) -> Result<(), AgentError> {
+    if !env.storage().persistent().has(&DataKey::Initialized) {
+        return Err(AgentError::NotInitialized);
+    }
+
+    let txn_key = DataKey::Transaction(transaction_id.clone());
+    let mut transaction: AgentTransaction = env
+        .storage()
+        .persistent()
+        .get(&txn_key)
+        .ok_or(AgentError::TransactionNotFound)?;
+
+    if transaction.agent != agent {
+        return Err(AgentError::Unauthorized);
+    }
+
+    transaction.completed = true;
+
+    env.storage().persistent().set(&txn_key, &transaction);
+    env.storage()
+        .persistent()
+        .extend_ttl(&txn_key, 500000, 500000);
+
+    let agent_key = DataKey::Agent(agent);
+    let mut agent_info: AgentInfo = env
+        .storage()
+        .persistent()
+        .get(&agent_key)
+        .ok_or(AgentError::AgentNotFound)?;
+
+    agent_info.completed_agreements += 1;
+
+    env.storage().persistent().set(&agent_key, &agent_info);
+    env.storage()
+        .persistent()
+        .extend_ttl(&agent_key, 500000, 500000);
+
+    Ok(())
+}

--- a/contract/contracts/agent_registry/src/errors.rs
+++ b/contract/contracts/agent_registry/src/errors.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum AgentError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    AgentAlreadyRegistered = 3,
+    AgentNotFound = 4,
+    Unauthorized = 5,
+    AlreadyVerified = 6,
+    InvalidProfileHash = 7,
+    InvalidRatingScore = 8,
+    AgentNotVerified = 9,
+    AlreadyRated = 10,
+    TransactionNotFound = 11,
+    NotTransactionParty = 12,
+    TransactionNotCompleted = 13,
+}

--- a/contract/contracts/agent_registry/src/events.rs
+++ b/contract/contracts/agent_registry/src/events.rs
@@ -1,0 +1,72 @@
+use soroban_sdk::{contractevent, Address, Env, String};
+
+#[contractevent(topics = ["initialized"])]
+pub struct ContractInitialized {
+    #[topic]
+    pub admin: Address,
+}
+
+#[contractevent(topics = ["agent_reg"])]
+pub struct AgentRegistered {
+    #[topic]
+    pub agent: Address,
+    pub external_profile_hash: String,
+}
+
+#[contractevent(topics = ["agent_ver"])]
+pub struct AgentVerified {
+    #[topic]
+    pub admin: Address,
+    #[topic]
+    pub agent: Address,
+}
+
+#[contractevent(topics = ["agent_rated"])]
+pub struct AgentRated {
+    #[topic]
+    pub agent: Address,
+    #[topic]
+    pub rater: Address,
+    pub score: u32,
+}
+
+#[contractevent(topics = ["txn_reg"])]
+pub struct TransactionRegistered {
+    #[topic]
+    pub transaction_id: String,
+    #[topic]
+    pub agent: Address,
+}
+
+pub(crate) fn contract_initialized(env: &Env, admin: Address) {
+    ContractInitialized { admin }.publish(env);
+}
+
+pub(crate) fn agent_registered(env: &Env, agent: Address, external_profile_hash: String) {
+    AgentRegistered {
+        agent,
+        external_profile_hash,
+    }
+    .publish(env);
+}
+
+pub(crate) fn agent_verified(env: &Env, admin: Address, agent: Address) {
+    AgentVerified { admin, agent }.publish(env);
+}
+
+pub(crate) fn agent_rated(env: &Env, agent: Address, rater: Address, score: u32) {
+    AgentRated {
+        agent,
+        rater,
+        score,
+    }
+    .publish(env);
+}
+
+pub(crate) fn transaction_registered(env: &Env, transaction_id: String, agent: Address) {
+    TransactionRegistered {
+        transaction_id,
+        agent,
+    }
+    .publish(env);
+}

--- a/contract/contracts/agent_registry/src/lib.rs
+++ b/contract/contracts/agent_registry/src/lib.rs
@@ -1,0 +1,184 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+
+mod agent;
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use agent::{
+    complete_transaction, get_agent_count, get_agent_info, rate_agent, register_agent,
+    register_transaction, verify_agent,
+};
+pub use errors::AgentError;
+pub use storage::DataKey;
+pub use types::{AgentInfo, AgentTransaction, ContractState};
+
+#[contract]
+pub struct AgentRegistryContract;
+
+#[contractimpl]
+impl AgentRegistryContract {
+    /// Initialize the contract with an admin address.
+    ///
+    /// # Arguments
+    /// * `admin` - The address that will have admin privileges to verify agents
+    ///
+    /// # Errors
+    /// * `AlreadyInitialized` - If the contract has already been initialized
+    pub fn initialize(env: Env, admin: Address) -> Result<(), AgentError> {
+        if env.storage().persistent().has(&DataKey::Initialized) {
+            return Err(AgentError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Initialized, 500000, 500000);
+
+        let state = ContractState {
+            admin: admin.clone(),
+            initialized: true,
+        };
+
+        env.storage().instance().set(&DataKey::State, &state);
+        env.storage().instance().extend_ttl(500000, 500000);
+
+        events::contract_initialized(&env, admin);
+
+        Ok(())
+    }
+
+    /// Get the current contract state.
+    ///
+    /// # Returns
+    /// * `Option<ContractState>` - The contract state if initialized
+    pub fn get_state(env: Env) -> Option<ContractState> {
+        env.storage().instance().get(&DataKey::State)
+    }
+
+    /// Register a new agent on-chain.
+    ///
+    /// # Arguments
+    /// * `agent` - The address of the agent registering
+    /// * `external_profile_hash` - Hash reference to agent's external profile (IPFS, etc.)
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If the contract hasn't been initialized
+    /// * `AgentAlreadyRegistered` - If the agent is already registered
+    /// * `InvalidProfileHash` - If the profile hash is empty
+    pub fn register_agent(
+        env: Env,
+        agent: Address,
+        external_profile_hash: String,
+    ) -> Result<(), AgentError> {
+        agent::register_agent(&env, agent, external_profile_hash)
+    }
+
+    /// Verify a registered agent (admin only).
+    ///
+    /// # Arguments
+    /// * `admin` - The admin address performing the verification
+    /// * `agent` - The address of the agent to verify
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If the contract hasn't been initialized
+    /// * `Unauthorized` - If the caller is not the admin
+    /// * `AgentNotFound` - If the agent doesn't exist
+    /// * `AlreadyVerified` - If the agent is already verified
+    pub fn verify_agent(env: Env, admin: Address, agent: Address) -> Result<(), AgentError> {
+        agent::verify_agent(&env, admin, agent)
+    }
+
+    /// Rate an agent after completing a transaction (1-5 stars).
+    ///
+    /// # Arguments
+    /// * `rater` - The address of the person rating (tenant or landlord)
+    /// * `agent` - The address of the agent being rated
+    /// * `score` - The rating score (1-5)
+    /// * `transaction_id` - The ID of the completed transaction
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If the contract hasn't been initialized
+    /// * `InvalidRatingScore` - If score is not between 1 and 5
+    /// * `AgentNotFound` - If the agent doesn't exist
+    /// * `AgentNotVerified` - If the agent is not verified
+    /// * `TransactionNotFound` - If the transaction doesn't exist
+    /// * `TransactionNotCompleted` - If the transaction is not marked as completed
+    /// * `NotTransactionParty` - If the rater wasn't part of the transaction
+    /// * `AlreadyRated` - If the rater has already rated this agent
+    pub fn rate_agent(
+        env: Env,
+        rater: Address,
+        agent: Address,
+        score: u32,
+        transaction_id: String,
+    ) -> Result<(), AgentError> {
+        agent::rate_agent(&env, rater, agent, score, transaction_id)
+    }
+
+    /// Get information about a registered agent.
+    ///
+    /// # Arguments
+    /// * `agent` - The address of the agent
+    ///
+    /// # Returns
+    /// * `Option<AgentInfo>` - The agent information if they exist
+    pub fn get_agent_info(env: Env, agent: Address) -> Option<AgentInfo> {
+        agent::get_agent_info(&env, agent)
+    }
+
+    /// Get the total count of registered agents.
+    ///
+    /// # Returns
+    /// * `u32` - The total number of agents registered
+    pub fn get_agent_count(env: Env) -> u32 {
+        agent::get_agent_count(&env)
+    }
+
+    /// Register a transaction involving an agent.
+    /// This is called when a rent agreement or property transaction is created.
+    ///
+    /// # Arguments
+    /// * `transaction_id` - Unique identifier for the transaction
+    /// * `agent` - The agent involved in the transaction
+    /// * `parties` - Vector of addresses involved (tenant, landlord, etc.)
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If the contract hasn't been initialized
+    /// * `AgentNotFound` - If the agent doesn't exist
+    pub fn register_transaction(
+        env: Env,
+        transaction_id: String,
+        agent: Address,
+        parties: Vec<Address>,
+    ) -> Result<(), AgentError> {
+        agent::register_transaction(&env, transaction_id, agent, parties)
+    }
+
+    /// Mark a transaction as completed.
+    /// This enables the parties to rate the agent.
+    ///
+    /// # Arguments
+    /// * `transaction_id` - The ID of the transaction to complete
+    /// * `agent` - The agent address (for verification)
+    ///
+    /// # Errors
+    /// * `NotInitialized` - If the contract hasn't been initialized
+    /// * `TransactionNotFound` - If the transaction doesn't exist
+    /// * `Unauthorized` - If the caller is not the agent for this transaction
+    pub fn complete_transaction(
+        env: Env,
+        transaction_id: String,
+        agent: Address,
+    ) -> Result<(), AgentError> {
+        agent::complete_transaction(&env, transaction_id, agent)
+    }
+}

--- a/contract/contracts/agent_registry/src/storage.rs
+++ b/contract/contracts/agent_registry/src/storage.rs
@@ -1,0 +1,12 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Agent(Address),
+    State,
+    Initialized,
+    AgentCount,
+    Transaction(String),
+    AgentRating(Address, Address),
+}

--- a/contract/contracts/agent_registry/src/tests.rs
+++ b/contract/contracts/agent_registry/src/tests.rs
@@ -1,0 +1,536 @@
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+
+fn create_contract(env: &Env) -> AgentRegistryContractClient<'_> {
+    let contract_id = env.register(AgentRegistryContract, ());
+    AgentRegistryContractClient::new(env, &contract_id)
+}
+
+#[test]
+fn test_successful_initialization() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let result = client.try_initialize(&admin);
+    assert!(result.is_ok());
+
+    let state = client.get_state().unwrap();
+    assert_eq!(state.admin, admin);
+    assert!(state.initialized);
+}
+
+#[test]
+#[should_panic]
+fn test_initialize_fails_without_admin_auth() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_double_initialization_fails() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    client.initialize(&admin);
+}
+
+#[test]
+fn test_register_agent_success() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+
+    let result = client.try_register_agent(&agent, &profile_hash);
+    assert!(result.is_ok());
+
+    let agent_info = client.get_agent_info(&agent).unwrap();
+    assert_eq!(agent_info.agent, agent);
+    assert_eq!(agent_info.external_profile_hash, profile_hash);
+    assert!(!agent_info.verified);
+    assert!(agent_info.verified_at.is_none());
+    assert_eq!(agent_info.total_ratings, 0);
+    assert_eq!(agent_info.total_score, 0);
+    assert_eq!(agent_info.completed_agreements, 0);
+
+    assert_eq!(client.get_agent_count(), 1);
+}
+
+#[test]
+#[should_panic]
+fn test_register_agent_fails_without_agent_auth() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    env.mock_auths(&[]);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+
+    client.register_agent(&agent, &profile_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_register_agent_fails_when_not_initialized() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+
+    client.register_agent(&agent, &profile_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_register_agent_fails_when_already_registered() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+
+    client.register_agent(&agent, &profile_hash);
+    client.register_agent(&agent, &profile_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_register_agent_fails_with_empty_profile_hash() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let empty_hash = String::from_str(&env, "");
+
+    client.register_agent(&agent, &empty_hash);
+}
+
+#[test]
+fn test_verify_agent_success() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    let result = client.try_verify_agent(&admin, &agent);
+    assert!(result.is_ok());
+
+    let agent_info = client.get_agent_info(&agent).unwrap();
+    assert!(agent_info.verified);
+    assert!(agent_info.verified_at.is_some());
+}
+
+#[test]
+#[should_panic]
+fn test_verify_agent_fails_without_admin_auth() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    env.mock_auths(&[]);
+
+    client.verify_agent(&admin, &agent);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_verify_agent_fails_when_not_admin() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    client.verify_agent(&non_admin, &agent);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_verify_agent_fails_when_agent_not_found() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    client.verify_agent(&admin, &agent);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_verify_agent_fails_when_already_verified() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    client.verify_agent(&admin, &agent);
+    client.verify_agent(&admin, &agent);
+}
+
+#[test]
+fn test_register_and_complete_transaction() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    let result = client.try_register_transaction(&txn_id, &agent, &parties);
+    assert!(result.is_ok());
+
+    let result = client.try_complete_transaction(&txn_id, &agent);
+    assert!(result.is_ok());
+
+    let agent_info = client.get_agent_info(&agent).unwrap();
+    assert_eq!(agent_info.completed_agreements, 1);
+}
+
+#[test]
+fn test_rate_agent_success() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    let result = client.try_rate_agent(&tenant, &agent, &5, &txn_id);
+    assert!(result.is_ok());
+
+    let agent_info = client.get_agent_info(&agent).unwrap();
+    assert_eq!(agent_info.total_ratings, 1);
+    assert_eq!(agent_info.total_score, 5);
+    assert_eq!(agent_info.average_rating(), 5);
+}
+
+#[test]
+fn test_multiple_ratings_average() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    client.rate_agent(&tenant, &agent, &5, &txn_id);
+    client.rate_agent(&landlord, &agent, &3, &txn_id);
+
+    let agent_info = client.get_agent_info(&agent).unwrap();
+    assert_eq!(agent_info.total_ratings, 2);
+    assert_eq!(agent_info.total_score, 8);
+    assert_eq!(agent_info.average_rating(), 4);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_rate_agent_fails_with_invalid_score_low() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    client.rate_agent(&tenant, &agent, &0, &txn_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_rate_agent_fails_with_invalid_score_high() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    client.rate_agent(&tenant, &agent, &6, &txn_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_rate_agent_fails_when_agent_not_verified() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    client.rate_agent(&tenant, &agent, &5, &txn_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_rate_agent_fails_when_transaction_not_found() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+
+    client.rate_agent(&tenant, &agent, &5, &txn_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_rate_agent_fails_when_transaction_not_completed() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+
+    client.rate_agent(&tenant, &agent, &5, &txn_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_rate_agent_fails_when_not_transaction_party() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    client.rate_agent(&stranger, &agent, &5, &txn_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_rate_agent_fails_when_already_rated() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+
+    let txn_id = String::from_str(&env, "TXN-001");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    client.rate_agent(&tenant, &agent, &5, &txn_id);
+    client.rate_agent(&tenant, &agent, &4, &txn_id);
+}

--- a/contract/contracts/agent_registry/src/types.rs
+++ b/contract/contracts/agent_registry/src/types.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{contracttype, Address, String, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentInfo {
+    pub agent: Address,
+    pub external_profile_hash: String,
+    pub verified: bool,
+    pub registered_at: u64,
+    pub verified_at: Option<u64>,
+    pub total_ratings: u32,
+    pub total_score: u32,
+    pub completed_agreements: u32,
+}
+
+impl AgentInfo {
+    pub fn average_rating(&self) -> u32 {
+        if self.total_ratings == 0 {
+            0
+        } else {
+            self.total_score / self.total_ratings
+        }
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Rating {
+    pub rater: Address,
+    pub agent: Address,
+    pub score: u32,
+    pub rated_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractState {
+    pub admin: Address,
+    pub initialized: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentTransaction {
+    pub transaction_id: String,
+    pub agent: Address,
+    pub parties: Vec<Address>,
+    pub completed: bool,
+}


### PR DESCRIPTION
… scoring

- Create new Soroban contract at `contract/contracts/agent_registry`
- Implement `register_agent` with self-registration and profile hash storage
- Implement `verify_agent` gated behind admin role with require_auth enforcement
- Implement `rate_agent` with completed-transaction guard and 1-5 score validation
- Implement `get_agent_info` returning full AgentInfo with averaged reputation score
- Store agent map keyed by Address with status, ratings, and profile metadata
- Add `record_transaction` for chioma contract to authorize rating eligibility
- Emit SEP-0041 compatible events for registration, verification, and ratings
- Add unit tests: registration, verification, rating, unauthorized, duplicate guards

Create Agent Registry and Rating Contract
Fixes #194