### PR TITLE
fix: move auth rate limit values to environment config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,8 @@ JWT_SECRET=your-super-secret-key-minimum-32-characters-long
 JWT_REFRESH_SECRET=your-super-refresh-secret-key-minimum-32-characters
 JWT_EXPIRATION=15m
 JWT_REFRESH_EXPIRATION=7d
+AUTH_RATE_LIMIT_WINDOW_MS=900000
+AUTH_RATE_LIMIT_MAX_REQUESTS=5
 
 # Database Configuration
 DB_HOST=localhost


### PR DESCRIPTION
Closes #102

---

Moves hardcoded auth rate limiting values (WINDOW_MS and MAX_REQUESTS) to environment variables so limits can be configured per environment without changing code. Falls back to existing defaults if variables are not set.