### PR TITLE
perf(properties): use ILIKE instead of LOWER() in findAll for index usage

### DIFF
--- a/backend/src/modules/properties/properties.service.ts
+++ b/backend/src/modules/properties/properties.service.ts
@@ -185,19 +185,19 @@ export class PropertiesService {
     }
 
     if (filters.city) {
-      queryBuilder.andWhere('LOWER(property.city) = LOWER(:city)', {
+      queryBuilder.andWhere('property.city ILIKE :city', {
         city: filters.city,
       });
     }
 
     if (filters.state) {
-      queryBuilder.andWhere('LOWER(property.state) = LOWER(:state)', {
+      queryBuilder.andWhere('property.state ILIKE :state', {
         state: filters.state,
       });
     }
 
     if (filters.country) {
-      queryBuilder.andWhere('LOWER(property.country) = LOWER(:country)', {
+      queryBuilder.andWhere('property.country ILIKE :country', {
         country: filters.country,
       });
     }
@@ -210,15 +210,21 @@ export class PropertiesService {
 
     if (filters.search) {
       queryBuilder.andWhere(
-        '(LOWER(property.title) LIKE LOWER(:search) OR LOWER(property.description) LIKE LOWER(:search))',
+        '(property.title ILIKE :search OR property.description ILIKE :search)',
         { search: `%${filters.search}%` },
       );
     }
 
     if (filters.amenities && filters.amenities.length > 0) {
+      const amenityParams = Object.fromEntries(
+        filters.amenities.map((a, i) => [`amenity${i}`, a]),
+      );
+      const amenityConditions = filters.amenities
+        .map((_, i) => `pa.name ILIKE :amenity${i}`)
+        .join(' OR ');
       queryBuilder.andWhere(
-        'EXISTS (SELECT 1 FROM property_amenities pa WHERE pa.property_id = property.id AND LOWER(pa.name) IN (:...amenities))',
-        { amenities: filters.amenities.map((a) => a.toLowerCase()) },
+        `EXISTS (SELECT 1 FROM property_amenities pa WHERE pa.property_id = property.id AND (${amenityConditions}))`,
+        amenityParams,
       );
     }
 


### PR DESCRIPTION

## Performance: Use ILIKE instead of LOWER() in PropertiesService.findAll

### Summary
Updates `findAll` in `PropertiesService` so location, search, and amenity filters no longer wrap columns in `LOWER()`, allowing PostgreSQL to use indexes and avoid full table scans.

### Problem
- `LOWER(property.city)`, `LOWER(property.state)`, `LOWER(property.country)`, `LOWER(property.title)`, `LOWER(property.description)`, and `LOWER(pa.name)` in the query prevent use of indexes on those columns.
- This led to full table scans, slower queries, and worse scalability as the dataset grows.

### Solution
- **City, state, country:** `LOWER(column) = LOWER(:param)` → `column ILIKE :param` (still case-insensitive).
- **Search (title/description):** `LOWER(column) LIKE LOWER(:search)` → `column ILIKE :search` with `%...%` pattern.
- **Amenities:** `LOWER(pa.name) IN (:...amenities)` → `pa.name ILIKE :amenity0 OR pa.name ILIKE :amenity1 ...` so the column is not wrapped in a function.

### Files changed
- `backend/src/modules/properties/properties.service.ts`

### Testing
- Existing filters behave the same from a user perspective (case-insensitive).
- No API or DTO changes.

### Follow-up (later)
- Add indexes (e.g. `pg_trgm` GIN/GiST) on filtered columns to get the full benefit of these changes.

### Closes: #97 