### PR TITLE
Implement Weighted Voting for Disputes

### DIFF
--- a/contract/contracts/dispute_resolution/src/dispute.rs
+++ b/contract/contracts/dispute_resolution/src/dispute.rs
@@ -4,8 +4,8 @@ use crate::errors::DisputeError;
 use crate::events;
 use crate::storage::DataKey;
 use crate::types::{
-    AppealStatus, AppealVote, Arbiter, ContractState, Dispute, DisputeAppeal, DisputeOutcome,
-    TimeoutConfig, Vote,
+    AppealStatus, AppealVote, Arbiter, ArbiterStats, ContractState, Dispute, DisputeAppeal,
+    DisputeOutcome, TimeoutConfig, Vote, VotingWeight, WeightedDisputeVotes, WeightedVote,
 };
 
 const APPEAL_WINDOW_SECONDS: u64 = 7 * 24 * 60 * 60;
@@ -691,4 +691,312 @@ pub fn cancel_appeal(env: &Env, appellant: Address, appeal_id: String) -> Result
 
 pub fn get_appeal(env: &Env, appeal_id: String) -> Option<DisputeAppeal> {
     env.storage().persistent().get(&DataKey::Appeal(appeal_id))
+}
+
+// ── Weighted Voting ────────────────────────────────────────────────────────
+
+/// Set rating and disputes-resolved count for an arbiter (admin only).
+/// Rating must be 0-100.
+pub fn set_arbiter_stats(
+    env: &Env,
+    admin: Address,
+    arbiter: Address,
+    rating: u32,
+    disputes_resolved: u32,
+) -> Result<(), DisputeError> {
+    let state: ContractState = env
+        .storage()
+        .instance()
+        .get(&DataKey::State)
+        .ok_or(DisputeError::NotInitialized)?;
+
+    admin.require_auth();
+    if admin != state.admin {
+        return Err(DisputeError::Unauthorized);
+    }
+
+    if !env
+        .storage()
+        .persistent()
+        .has(&DataKey::Arbiter(arbiter.clone()))
+    {
+        return Err(DisputeError::ArbiterNotFound);
+    }
+
+    if rating > 100 {
+        return Err(DisputeError::InvalidRating);
+    }
+
+    let stats = ArbiterStats {
+        rating,
+        disputes_resolved,
+    };
+    let key = DataKey::ArbiterStats(arbiter.clone());
+    env.storage().persistent().set(&key, &stats);
+    env.storage().persistent().extend_ttl(&key, 500000, 500000);
+
+    Ok(())
+}
+
+/// Compute the voting weight for an arbiter.
+///
+/// Formula (integer arithmetic, scale ×100):
+///   base_weight          = 100
+///   rating_multiplier    = rating × 2              (0–200 representing 0.0×–2.0×)
+///   experience_multiplier = min(disputes_resolved × 2, 200)
+///   total_weight         = base × rating_mult/100 × exp_mult/100
+///                        = rating_mult × exp_mult / 100 (minimum 1)
+pub fn calculate_voting_weight(env: &Env, arbiter: Address) -> Result<u32, DisputeError> {
+    let arbiter_info: Arbiter = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Arbiter(arbiter.clone()))
+        .ok_or(DisputeError::ArbiterNotFound)?;
+
+    if !arbiter_info.active {
+        return Err(DisputeError::ArbiterNotFound);
+    }
+
+    let stats: ArbiterStats = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ArbiterStats(arbiter))
+        .unwrap_or(ArbiterStats {
+            rating: 50,
+            disputes_resolved: 0,
+        });
+
+    let rating_mult = stats.rating * 2; // 0–200
+    let exp_mult = if stats.disputes_resolved * 2 < 200 {
+        stats.disputes_resolved * 2
+    } else {
+        200u32
+    };
+
+    // base(100) × rating_mult/100 × exp_mult/100 = rating_mult × exp_mult / 100
+    let computed = rating_mult * exp_mult / 100;
+    let total_weight = if computed == 0 { 1 } else { computed };
+
+    Ok(total_weight)
+}
+
+/// Return the full VotingWeight breakdown for an arbiter.
+pub fn get_voting_weight(env: &Env, arbiter: Address) -> Result<VotingWeight, DisputeError> {
+    let arbiter_info: Arbiter = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Arbiter(arbiter.clone()))
+        .ok_or(DisputeError::ArbiterNotFound)?;
+
+    if !arbiter_info.active {
+        return Err(DisputeError::ArbiterNotFound);
+    }
+
+    let stats: ArbiterStats = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ArbiterStats(arbiter.clone()))
+        .unwrap_or(ArbiterStats {
+            rating: 50,
+            disputes_resolved: 0,
+        });
+
+    let rating_mult = stats.rating * 2;
+    let exp_mult = if stats.disputes_resolved * 2 < 200 {
+        stats.disputes_resolved * 2
+    } else {
+        200u32
+    };
+
+    let computed = rating_mult * exp_mult / 100;
+    let total_weight = if computed == 0 { 1 } else { computed };
+
+    Ok(VotingWeight {
+        arbiter,
+        base_weight: 100,
+        rating_multiplier: rating_mult,
+        experience_multiplier: exp_mult,
+        total_weight,
+    })
+}
+
+/// Cast a weighted vote on an open dispute.
+pub fn vote_on_dispute_weighted(
+    env: &Env,
+    arbiter: Address,
+    dispute_id: String,
+    vote: DisputeOutcome,
+) -> Result<(), DisputeError> {
+    if !env.storage().persistent().has(&DataKey::Initialized) {
+        return Err(DisputeError::NotInitialized);
+    }
+
+    arbiter.require_auth();
+
+    let arbiter_info: Arbiter = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Arbiter(arbiter.clone()))
+        .ok_or(DisputeError::ArbiterNotFound)?;
+
+    if !arbiter_info.active {
+        return Err(DisputeError::ArbiterNotFound);
+    }
+
+    let dispute_key = DataKey::Dispute(dispute_id.clone());
+    let dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&dispute_key)
+        .ok_or(DisputeError::DisputeNotFound)?;
+
+    if dispute.resolved {
+        return Err(DisputeError::DisputeAlreadyResolved);
+    }
+
+    let wvote_key = DataKey::WeightedVote(dispute_id.clone(), arbiter.clone());
+    if env.storage().persistent().has(&wvote_key) {
+        return Err(DisputeError::AlreadyVoted);
+    }
+
+    let weight = calculate_voting_weight(env, arbiter.clone())?;
+
+    let weighted_vote = WeightedVote {
+        arbiter: arbiter.clone(),
+        vote: vote.clone(),
+        weight,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.storage().persistent().set(&wvote_key, &weighted_vote);
+    env.storage()
+        .persistent()
+        .extend_ttl(&wvote_key, 500000, 500000);
+
+    let wdisp_key = DataKey::WeightedDisputeVotes(dispute_id.clone());
+    let mut wdisp: WeightedDisputeVotes =
+        env.storage()
+            .persistent()
+            .get(&wdisp_key)
+            .unwrap_or(WeightedDisputeVotes {
+                weighted_votes_favor_landlord: 0,
+                weighted_votes_favor_tenant: 0,
+                voters: soroban_sdk::Vec::new(env),
+            });
+
+    match vote.clone() {
+        DisputeOutcome::FavorLandlord => wdisp.weighted_votes_favor_landlord += weight,
+        DisputeOutcome::FavorTenant => wdisp.weighted_votes_favor_tenant += weight,
+    }
+
+    wdisp.voters.push_back(arbiter.clone());
+
+    env.storage().persistent().set(&wdisp_key, &wdisp);
+    env.storage()
+        .persistent()
+        .extend_ttl(&wdisp_key, 500000, 500000);
+
+    events::weighted_vote_cast(env, dispute_id, arbiter, weight);
+
+    Ok(())
+}
+
+/// Resolve a dispute using weighted vote totals.
+///
+/// Resolution rules:
+/// - Requires `min_votes_required` weighted voters.
+/// - Outcome with the highest total weight wins.
+/// - Tie broken by the outcome of the first vote cast (first vote wins).
+pub fn resolve_dispute_weighted(
+    env: &Env,
+    dispute_id: String,
+) -> Result<DisputeOutcome, DisputeError> {
+    let state: ContractState = env
+        .storage()
+        .instance()
+        .get(&DataKey::State)
+        .ok_or(DisputeError::NotInitialized)?;
+
+    let dispute_key = DataKey::Dispute(dispute_id.clone());
+    let mut dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&dispute_key)
+        .ok_or(DisputeError::DisputeNotFound)?;
+
+    if dispute.resolved {
+        return Err(DisputeError::DisputeAlreadyResolved);
+    }
+
+    let wdisp_key = DataKey::WeightedDisputeVotes(dispute_id.clone());
+    let wdisp: WeightedDisputeVotes =
+        env.storage()
+            .persistent()
+            .get(&wdisp_key)
+            .unwrap_or(WeightedDisputeVotes {
+                weighted_votes_favor_landlord: 0,
+                weighted_votes_favor_tenant: 0,
+                voters: soroban_sdk::Vec::new(env),
+            });
+
+    if wdisp.voters.len() < state.min_votes_required {
+        return Err(DisputeError::InsufficientVotes);
+    }
+
+    let total_weight = wdisp.weighted_votes_favor_landlord + wdisp.weighted_votes_favor_tenant;
+
+    let outcome = if wdisp.weighted_votes_favor_landlord > wdisp.weighted_votes_favor_tenant {
+        DisputeOutcome::FavorLandlord
+    } else if wdisp.weighted_votes_favor_tenant > wdisp.weighted_votes_favor_landlord {
+        DisputeOutcome::FavorTenant
+    } else {
+        // Tie: first vote wins — look up voters[0]'s WeightedVote
+        let first_voter = wdisp.voters.get(0).unwrap();
+        let first_wvote: WeightedVote = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WeightedVote(dispute_id.clone(), first_voter))
+            .unwrap();
+        first_wvote.vote
+    };
+
+    dispute.resolved = true;
+    dispute.resolved_at = Some(env.ledger().timestamp());
+    env.storage().persistent().set(&dispute_key, &dispute);
+    env.storage()
+        .persistent()
+        .extend_ttl(&dispute_key, 500000, 500000);
+
+    events::dispute_resolved_by_weight(env, dispute_id, outcome.clone(), total_weight);
+
+    Ok(outcome)
+}
+
+/// Return all weighted votes cast for a dispute.
+pub fn get_dispute_votes_weighted(
+    env: &Env,
+    dispute_id: String,
+) -> Result<soroban_sdk::Vec<WeightedVote>, DisputeError> {
+    let wdisp_key = DataKey::WeightedDisputeVotes(dispute_id.clone());
+    let wdisp: WeightedDisputeVotes =
+        env.storage()
+            .persistent()
+            .get(&wdisp_key)
+            .unwrap_or(WeightedDisputeVotes {
+                weighted_votes_favor_landlord: 0,
+                weighted_votes_favor_tenant: 0,
+                voters: soroban_sdk::Vec::new(env),
+            });
+
+    let mut votes = soroban_sdk::Vec::new(env);
+    for voter in wdisp.voters.iter() {
+        let wvote_key = DataKey::WeightedVote(dispute_id.clone(), voter.clone());
+        if let Some(wv) = env
+            .storage()
+            .persistent()
+            .get::<_, WeightedVote>(&wvote_key)
+        {
+            votes.push_back(wv);
+        }
+    }
+    Ok(votes)
 }

--- a/contract/contracts/dispute_resolution/src/errors.rs
+++ b/contract/contracts/dispute_resolution/src/errors.rs
@@ -29,4 +29,5 @@ pub enum DisputeError {
     AppealNotCancelable = 23,
     TimeoutNotReached = 24,
     InvalidTimeoutConfig = 25,
+    InvalidRating = 26,
 }

--- a/contract/contracts/dispute_resolution/src/events.rs
+++ b/contract/contracts/dispute_resolution/src/events.rs
@@ -145,3 +145,45 @@ pub(crate) fn appeal_cancelled(env: &Env, appeal_id: String) {
 pub(crate) fn dispute_timeout(env: &Env, agreement_id: String) {
     DisputeTimeout { agreement_id }.publish(env);
 }
+
+// ── Weighted Voting Events ─────────────────────────────────────────────────
+
+#[contractevent(topics = ["weighted_vote_cast"])]
+pub struct WeightedVoteCast {
+    #[topic]
+    pub dispute_id: String,
+    #[topic]
+    pub arbiter: Address,
+    pub weight: u32,
+}
+
+#[contractevent(topics = ["dispute_resolved_by_weight"])]
+pub struct DisputeResolvedByWeight {
+    #[topic]
+    pub dispute_id: String,
+    pub outcome: DisputeOutcome,
+    pub total_weight: u32,
+}
+
+pub(crate) fn weighted_vote_cast(env: &Env, dispute_id: String, arbiter: Address, weight: u32) {
+    WeightedVoteCast {
+        dispute_id,
+        arbiter,
+        weight,
+    }
+    .publish(env);
+}
+
+pub(crate) fn dispute_resolved_by_weight(
+    env: &Env,
+    dispute_id: String,
+    outcome: DisputeOutcome,
+    total_weight: u32,
+) {
+    DisputeResolvedByWeight {
+        dispute_id,
+        outcome,
+        total_weight,
+    }
+    .publish(env);
+}

--- a/contract/contracts/dispute_resolution/src/lib.rs
+++ b/contract/contracts/dispute_resolution/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 mod dispute;
 mod errors;
@@ -12,15 +12,17 @@ mod types;
 mod tests;
 
 pub use dispute::{
-    add_arbiter, cancel_appeal, create_appeal, get_appeal, get_arbiter, get_arbiter_count,
-    get_dispute, get_timeout_config, get_vote, raise_dispute, resolve_appeal, resolve_dispute,
-    resolve_dispute_on_timeout, set_timeout_config, vote_on_appeal, vote_on_dispute,
+    add_arbiter, calculate_voting_weight, cancel_appeal, create_appeal, get_appeal, get_arbiter,
+    get_arbiter_count, get_dispute, get_dispute_votes_weighted, get_timeout_config, get_vote,
+    get_voting_weight, raise_dispute, resolve_appeal, resolve_dispute, resolve_dispute_on_timeout,
+    resolve_dispute_weighted, set_arbiter_stats, set_timeout_config, vote_on_appeal,
+    vote_on_dispute, vote_on_dispute_weighted,
 };
 pub use errors::DisputeError;
 pub use storage::DataKey;
 pub use types::{
-    AppealStatus, AppealVote, Arbiter, ContractState, Dispute, DisputeAppeal, DisputeOutcome,
-    TimeoutConfig, Vote,
+    AppealStatus, AppealVote, Arbiter, ArbiterStats, ContractState, Dispute, DisputeAppeal,
+    DisputeOutcome, TimeoutConfig, Vote, VotingWeight, WeightedDisputeVotes, WeightedVote,
 };
 
 #[contract]
@@ -244,5 +246,49 @@ impl DisputeResolutionContract {
 
     pub fn get_appeal(env: Env, appeal_id: String) -> Option<DisputeAppeal> {
         dispute::get_appeal(&env, appeal_id)
+    }
+
+    // ── Weighted Voting ────────────────────────────────────────────────────
+
+    /// Set rating (0-100) and disputes-resolved count for an arbiter (admin only).
+    pub fn set_arbiter_stats(
+        env: Env,
+        admin: Address,
+        arbiter: Address,
+        rating: u32,
+        disputes_resolved: u32,
+    ) -> Result<(), DisputeError> {
+        dispute::set_arbiter_stats(&env, admin, arbiter, rating, disputes_resolved)
+    }
+
+    /// Return the computed voting weight for an arbiter.
+    pub fn get_voting_weight(env: Env, arbiter: Address) -> Result<VotingWeight, DisputeError> {
+        dispute::get_voting_weight(&env, arbiter)
+    }
+
+    /// Cast a weighted vote on an open dispute.
+    pub fn vote_on_dispute_weighted(
+        env: Env,
+        arbiter: Address,
+        dispute_id: String,
+        vote: DisputeOutcome,
+    ) -> Result<(), DisputeError> {
+        dispute::vote_on_dispute_weighted(&env, arbiter, dispute_id, vote)
+    }
+
+    /// Resolve a dispute by weighted vote totals (ties broken by first vote).
+    pub fn resolve_dispute_weighted(
+        env: Env,
+        dispute_id: String,
+    ) -> Result<DisputeOutcome, DisputeError> {
+        dispute::resolve_dispute_weighted(&env, dispute_id)
+    }
+
+    /// Return all weighted votes for a dispute.
+    pub fn get_dispute_votes_weighted(
+        env: Env,
+        dispute_id: String,
+    ) -> Result<Vec<WeightedVote>, DisputeError> {
+        dispute::get_dispute_votes_weighted(&env, dispute_id)
     }
 }

--- a/contract/contracts/dispute_resolution/src/storage.rs
+++ b/contract/contracts/dispute_resolution/src/storage.rs
@@ -16,4 +16,8 @@ pub enum DataKey {
     AppealFeePaid(String),
     AppealFeeRefunded(String),
     TimeoutConfig,
+    // Weighted voting
+    ArbiterStats(Address),
+    WeightedVote(String, Address),
+    WeightedDisputeVotes(String),
 }

--- a/contract/contracts/dispute_resolution/src/tests.rs
+++ b/contract/contracts/dispute_resolution/src/tests.rs
@@ -6,6 +6,29 @@ use soroban_sdk::{
     Address, Env, String,
 };
 
+// ── Weighted Voting Helpers ────────────────────────────────────────────────
+
+/// Inject a pre-resolved dispute directly into storage so weighted-voting tests
+/// can operate without cross-contract calls.
+fn inject_open_dispute(env: &Env, client: &DisputeResolutionContractClient, dispute_id: &String) {
+    env.as_contract(&client.address, || {
+        let dispute = Dispute {
+            agreement_id: dispute_id.clone(),
+            details_hash: String::from_str(env, "QmWeightedTest"),
+            raised_at: env.ledger().timestamp(),
+            resolved: false,
+            resolved_at: None,
+            votes_favor_landlord: 0,
+            votes_favor_tenant: 0,
+            voters: soroban_sdk::Vec::new(env),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(dispute_id.clone()), &dispute);
+        env.storage().persistent().set(&DataKey::Initialized, &true);
+    });
+}
+
 /// Mock chioma contract that returns a valid RentAgreement for testing.
 #[contract]
 pub struct MockChiomaContract;
@@ -812,6 +835,282 @@ fn test_dispute_timeout_auto_resolve_and_config() {
     let stored = client.get_dispute(&agreement_id).unwrap();
     assert!(stored.resolved);
     assert!(stored.resolved_at.is_some());
+}
+
+// ── Weighted Voting Tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_set_arbiter_stats() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+
+    let result = client.try_set_arbiter_stats(&admin, &arbiter, &80, &50);
+    assert!(result.is_ok());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #26)")]
+fn test_set_arbiter_stats_invalid_rating() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+    // rating > 100 should fail with InvalidRating
+    client.set_arbiter_stats(&admin, &arbiter, &101, &0);
+}
+
+#[test]
+fn test_calculate_voting_weight_default_stats() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+
+    // Default stats: rating=50, disputes_resolved=0
+    // rating_mult = 50×2 = 100; exp_mult = 0 → computed=0 → clamped to 1
+    let vw = client.get_voting_weight(&arbiter);
+    assert_eq!(vw.base_weight, 100);
+    assert_eq!(vw.rating_multiplier, 100); // 50×2
+    assert_eq!(vw.experience_multiplier, 0);
+    assert_eq!(vw.total_weight, 1); // minimum
+}
+
+#[test]
+fn test_calculate_voting_weight_with_stats() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+
+    // rating=100, disputes_resolved=100
+    // rating_mult = 100×2 = 200; exp_mult = min(100×2,200) = 200
+    // total = 200×200/100 = 400
+    client.set_arbiter_stats(&admin, &arbiter, &100, &100);
+    let vw = client.get_voting_weight(&arbiter);
+    assert_eq!(vw.rating_multiplier, 200);
+    assert_eq!(vw.experience_multiplier, 200);
+    assert_eq!(vw.total_weight, 400);
+}
+
+#[test]
+fn test_calculate_voting_weight_experience_cap() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+
+    // disputes_resolved=999 should cap exp_mult at 200
+    client.set_arbiter_stats(&admin, &arbiter, &50, &999);
+    let vw = client.get_voting_weight(&arbiter);
+    assert_eq!(vw.experience_multiplier, 200);
+    // total = 100×200/100 = 200
+    assert_eq!(vw.total_weight, 200);
+}
+
+#[test]
+fn test_vote_on_dispute_weighted_records_vote() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let dispute_id = String::from_str(&env, "weighted-dispute-1");
+
+    env.mock_all_auths();
+    client.initialize(&admin, &1, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+    client.set_arbiter_stats(&admin, &arbiter, &100, &100);
+    inject_open_dispute(&env, &client, &dispute_id);
+
+    let result =
+        client.try_vote_on_dispute_weighted(&arbiter, &dispute_id, &DisputeOutcome::FavorLandlord);
+    assert!(result.is_ok());
+
+    let votes = client.get_dispute_votes_weighted(&dispute_id);
+    assert_eq!(votes.len(), 1);
+    assert_eq!(votes.get(0).unwrap().weight, 400);
+    assert_eq!(votes.get(0).unwrap().vote, DisputeOutcome::FavorLandlord);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_vote_on_dispute_weighted_already_voted() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let dispute_id = String::from_str(&env, "weighted-dispute-dupe");
+
+    env.mock_all_auths();
+    client.initialize(&admin, &1, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+    inject_open_dispute(&env, &client, &dispute_id);
+
+    client.vote_on_dispute_weighted(&arbiter, &dispute_id, &DisputeOutcome::FavorLandlord);
+    // second vote should fail
+    client.vote_on_dispute_weighted(&arbiter, &dispute_id, &DisputeOutcome::FavorTenant);
+}
+
+#[test]
+fn test_resolve_dispute_weighted_favor_landlord() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter1 = Address::generate(&env);
+    let arbiter2 = Address::generate(&env);
+    let arbiter3 = Address::generate(&env);
+    let dispute_id = String::from_str(&env, "weighted-resolve-1");
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter1);
+    client.add_arbiter(&admin, &arbiter2);
+    client.add_arbiter(&admin, &arbiter3);
+
+    // arbiter1: rating=100, disputes=100 → weight=400
+    // arbiter2: rating=100, disputes=100 → weight=400
+    // arbiter3: rating=50, disputes=50   → weight=100
+    client.set_arbiter_stats(&admin, &arbiter1, &100, &100);
+    client.set_arbiter_stats(&admin, &arbiter2, &100, &100);
+    client.set_arbiter_stats(&admin, &arbiter3, &50, &50);
+
+    inject_open_dispute(&env, &client, &dispute_id);
+
+    client.vote_on_dispute_weighted(&arbiter1, &dispute_id, &DisputeOutcome::FavorLandlord);
+    client.vote_on_dispute_weighted(&arbiter2, &dispute_id, &DisputeOutcome::FavorLandlord);
+    client.vote_on_dispute_weighted(&arbiter3, &dispute_id, &DisputeOutcome::FavorTenant);
+
+    // FavorLandlord: 800  vs  FavorTenant: 100
+    let outcome = client.resolve_dispute_weighted(&dispute_id);
+    assert_eq!(outcome, DisputeOutcome::FavorLandlord);
+
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert!(dispute.resolved);
+}
+
+#[test]
+fn test_resolve_dispute_weighted_favor_tenant() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter1 = Address::generate(&env);
+    let arbiter2 = Address::generate(&env);
+    let arbiter3 = Address::generate(&env);
+    let dispute_id = String::from_str(&env, "weighted-resolve-2");
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter1);
+    client.add_arbiter(&admin, &arbiter2);
+    client.add_arbiter(&admin, &arbiter3);
+
+    client.set_arbiter_stats(&admin, &arbiter1, &100, &100); // weight=400
+    client.set_arbiter_stats(&admin, &arbiter2, &100, &100); // weight=400
+    client.set_arbiter_stats(&admin, &arbiter3, &50, &50); // weight=100
+
+    inject_open_dispute(&env, &client, &dispute_id);
+
+    // high-weight arbiters vote for tenant
+    client.vote_on_dispute_weighted(&arbiter1, &dispute_id, &DisputeOutcome::FavorTenant);
+    client.vote_on_dispute_weighted(&arbiter2, &dispute_id, &DisputeOutcome::FavorTenant);
+    client.vote_on_dispute_weighted(&arbiter3, &dispute_id, &DisputeOutcome::FavorLandlord);
+
+    let outcome = client.resolve_dispute_weighted(&dispute_id);
+    assert_eq!(outcome, DisputeOutcome::FavorTenant);
+}
+
+#[test]
+fn test_resolve_dispute_weighted_tie_breaking() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter1 = Address::generate(&env);
+    let arbiter2 = Address::generate(&env);
+    let dispute_id = String::from_str(&env, "weighted-tie-1");
+
+    env.mock_all_auths();
+    client.initialize(&admin, &2, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter1);
+    client.add_arbiter(&admin, &arbiter2);
+
+    // equal weights so both sides tie
+    client.set_arbiter_stats(&admin, &arbiter1, &100, &100); // weight=400
+    client.set_arbiter_stats(&admin, &arbiter2, &100, &100); // weight=400
+
+    inject_open_dispute(&env, &client, &dispute_id);
+
+    // first vote → FavorLandlord (should win on tie)
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    client.vote_on_dispute_weighted(&arbiter1, &dispute_id, &DisputeOutcome::FavorLandlord);
+
+    env.ledger().with_mut(|l| l.timestamp = 2000);
+    client.vote_on_dispute_weighted(&arbiter2, &dispute_id, &DisputeOutcome::FavorTenant);
+
+    // 400 vs 400 → tie broken by first vote → FavorLandlord
+    let outcome = client.resolve_dispute_weighted(&dispute_id);
+    assert_eq!(outcome, DisputeOutcome::FavorLandlord);
+}
+
+#[test]
+fn test_resolve_dispute_weighted_insufficient_votes() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter1 = Address::generate(&env);
+    let dispute_id = String::from_str(&env, "weighted-insuf-1");
+
+    env.mock_all_auths();
+    client.initialize(&admin, &3, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter1);
+    inject_open_dispute(&env, &client, &dispute_id);
+
+    client.vote_on_dispute_weighted(&arbiter1, &dispute_id, &DisputeOutcome::FavorLandlord);
+
+    // only 1 voter, need 3
+    let result = client.try_resolve_dispute_weighted(&dispute_id);
+    assert_eq!(result, Err(Ok(DisputeError::InsufficientVotes)));
+}
+
+#[test]
+fn test_weight_update_reflected_in_new_votes() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &1, &Address::generate(&env));
+    client.add_arbiter(&admin, &arbiter);
+
+    // First check: default stats
+    let vw1 = client.get_voting_weight(&arbiter);
+    assert_eq!(vw1.total_weight, 1);
+
+    // Admin updates the arbiter's stats
+    client.set_arbiter_stats(&admin, &arbiter, &100, &100);
+    let vw2 = client.get_voting_weight(&arbiter);
+    assert_eq!(vw2.total_weight, 400);
 }
 
 #[test]

--- a/contract/contracts/dispute_resolution/src/types.rs
+++ b/contract/contracts/dispute_resolution/src/types.rs
@@ -1,5 +1,54 @@
 use soroban_sdk::{contracttype, Address, String, Vec};
 
+// ── Weighted Voting Types ──────────────────────────────────────────────────
+
+/// Admin-set stats used to compute an arbiter's voting weight.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArbiterStats {
+    /// 0-100; drives rating_multiplier (rating/50 → 0.0x-2.0x)
+    pub rating: u32,
+    /// Total disputes the arbiter has resolved; drives experience_multiplier
+    pub disputes_resolved: u32,
+}
+
+/// Computed voting weight for an arbiter.
+/// Multipliers are stored scaled ×100 (e.g. 50 = 0.50×, 200 = 2.00×).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VotingWeight {
+    pub arbiter: Address,
+    /// Always 100
+    pub base_weight: u32,
+    /// rating × 2  (range 0–200, representing 0.0×–2.0×)
+    pub rating_multiplier: u32,
+    /// min(disputes_resolved × 2, 200)  (range 0–200)
+    pub experience_multiplier: u32,
+    /// base × rating_mult/100 × exp_mult/100, minimum 1
+    pub total_weight: u32,
+}
+
+/// A single weighted vote cast by an arbiter.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WeightedVote {
+    pub arbiter: Address,
+    pub vote: DisputeOutcome,
+    pub weight: u32,
+    pub timestamp: u64,
+}
+
+/// Accumulated weighted-voting state for a dispute.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WeightedDisputeVotes {
+    pub weighted_votes_favor_landlord: u32,
+    pub weighted_votes_favor_tenant: u32,
+    /// Ordered list of arbiters who have cast a weighted vote.
+    /// voters[0] is used for tie-breaking (first vote wins).
+    pub voters: Vec<Address>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DisputeOutcome {


### PR DESCRIPTION
##Description 

This PR introduces a weighted voting mechanism for dispute resolution, allowing arbiter votes to carry different weights based on predefined criteria such as experience, reputation, or rating.

Previously, all arbiters had equal voting power, which could lead to suboptimal dispute outcomes and reduced trust in the system. This update improves fairness, incentivizes high-quality arbiters, and strengthens the integrity of dispute resolution.

closes #470