### PR TITLE
feat(contract): NFT metadata support, payment optimization, and Soroban param limit fix

### DIFF
--- a/contract/contracts/chioma/src/agreement.rs
+++ b/contract/contracts/chioma/src/agreement.rs
@@ -1,5 +1,5 @@
 //! Agreement management logic for the Chioma/Rental contract.
-use soroban_sdk::{Address, Env, Map, String};
+use soroban_sdk::{Address, Env, String, Vec};
 
 use crate::errors::RentalError;
 use crate::events;
@@ -44,60 +44,29 @@ pub fn validate_agreement_params(
 
 /// Create a new rent agreement
 #[allow(clippy::too_many_arguments)]
-pub fn create_agreement(
-    env: &Env,
-    agreement_id: String,
-    landlord: Address,
-    tenant: Address,
-    agent: Option<Address>,
-    monthly_rent: i128,
-    security_deposit: i128,
-    start_date: u64,
-    end_date: u64,
-    agent_commission_rate: u32,
-    payment_token: Address,
-) -> Result<(), RentalError> {
+pub fn create_agreement(env: &Env, input: crate::types::AgreementInput) -> Result<(), RentalError> {
     // Tenant MUST authorize creation
-    tenant.require_auth();
+    input.tenant.require_auth();
 
-    create_agreement_internal(
-        env,
-        agreement_id,
-        landlord,
-        tenant,
-        agent,
-        monthly_rent,
-        security_deposit,
-        start_date,
-        end_date,
-        agent_commission_rate,
-        payment_token,
-    )
+    create_agreement_internal(env, input)
 }
 
 #[allow(clippy::too_many_arguments)]
 fn create_agreement_internal(
     env: &Env,
-    agreement_id: String,
-    landlord: Address,
-    tenant: Address,
-    agent: Option<Address>,
-    monthly_rent: i128,
-    security_deposit: i128,
-    start_date: u64,
-    end_date: u64,
-    agent_commission_rate: u32,
-    payment_token: Address,
+    input: crate::types::AgreementInput,
 ) -> Result<(), RentalError> {
     // Validate inputs
     validate_agreement_params(
         env,
-        &monthly_rent,
-        &security_deposit,
-        &start_date,
-        &end_date,
-        &agent_commission_rate,
+        &input.terms.monthly_rent,
+        &input.terms.security_deposit,
+        &input.terms.start_date,
+        &input.terms.end_date,
+        &input.terms.agent_commission_rate,
     )?;
+
+    let agreement_id = input.agreement_id.clone();
 
     // Check for duplicate agreement_id
     if env
@@ -111,21 +80,22 @@ fn create_agreement_internal(
     // Initialize agreement
     let agreement = RentAgreement {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
-        agent: agent.clone(),
-        monthly_rent,
-        security_deposit,
-        start_date,
-        end_date,
-        agent_commission_rate,
+        landlord: input.landlord.clone(),
+        tenant: input.tenant.clone(),
+        agent: input.agent.clone(),
+        monthly_rent: input.terms.monthly_rent,
+        security_deposit: input.terms.security_deposit,
+        start_date: input.terms.start_date,
+        end_date: input.terms.end_date,
+        agent_commission_rate: input.terms.agent_commission_rate,
         status: AgreementStatus::Draft,
         total_rent_paid: 0,
         payment_count: 0,
         signed_at: None,
-        payment_token,
-        next_payment_due: start_date,
-        payment_history: Map::new(env),
+        payment_token: input.payment_token.clone(),
+        next_payment_due: input.terms.start_date,
+        metadata_uri: input.metadata_uri,
+        attributes: input.attributes,
     };
 
     // Store agreement
@@ -154,13 +124,13 @@ fn create_agreement_internal(
     events::agreement_created(
         env,
         agreement_id,
-        tenant,
-        landlord,
-        monthly_rent,
-        security_deposit,
-        start_date,
-        end_date,
-        agent,
+        agreement.tenant.clone(),
+        agreement.landlord.clone(),
+        agreement.monthly_rent,
+        agreement.security_deposit,
+        agreement.start_date,
+        agreement.end_date,
+        agreement.agent,
     );
 
     Ok(())
@@ -321,65 +291,94 @@ pub fn get_agreement_count(env: &Env) -> u32 {
         .unwrap_or(0)
 }
 
-/// Get payment split for a specific month in an agreement
 pub fn get_payment_split(
     env: &Env,
     agreement_id: String,
     month: u32,
 ) -> Result<PaymentSplit, RentalError> {
-    let agreement: RentAgreement = env
+    env.storage()
+        .persistent()
+        .get(&DataKey::PaymentRecord(agreement_id, month))
+        .ok_or(RentalError::AgreementNotFound)
+}
+
+/// Get all payments for an agreement
+pub fn get_payment_history(env: &Env, agreement_id: String) -> Vec<PaymentSplit> {
+    let mut history = Vec::new(env);
+    let agreement: RentAgreement = match env
         .storage()
         .persistent()
-        .get(&DataKey::Agreement(agreement_id))
+        .get(&DataKey::Agreement(agreement_id.clone()))
+    {
+        Some(a) => a,
+        None => return history,
+    };
+
+    for i in 1..=agreement.payment_count {
+        if let Some(payment) = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PaymentRecord(agreement_id.clone(), i))
+        {
+            history.push_back(payment);
+        }
+    }
+    history
+}
+
+/// Update metadata for an agreement
+pub fn update_metadata(
+    env: &Env,
+    agreement_id: String,
+    metadata_uri: String,
+    attributes: Vec<crate::types::Attribute>,
+) -> Result<(), RentalError> {
+    let mut agreement: RentAgreement = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Agreement(agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    agreement
-        .payment_history
-        .get(month)
-        .ok_or(RentalError::AgreementNotFound)
+    agreement.landlord.require_auth();
+
+    agreement.metadata_uri = metadata_uri;
+    agreement.attributes = attributes;
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Agreement(agreement_id), &agreement);
+    Ok(())
 }
 
 /// Create a new agreement with a specific payment token
 #[allow(clippy::too_many_arguments)]
 pub fn create_agreement_with_token(
     env: &Env,
-    property_id: String,
-    tenant: Address,
-    landlord: Address,
-    payment_token: Address,
-    rent_amount: i128,
-    deposit_amount: i128,
-    lease_start: u64,
-    lease_end: u64,
+    input: crate::types::AgreementInput,
 ) -> Result<String, RentalError> {
-    tenant.require_auth();
+    input.tenant.require_auth();
 
     // Check if token is supported
-    if !crate::multi_token::is_token_supported(env.clone(), payment_token.clone())? {
+    if !crate::multi_token::is_token_supported(env.clone(), input.payment_token.clone())? {
         return Err(RentalError::TokenNotSupported);
     }
 
-    // Use property_id + nonce or just property_id if it's unique
-    let agreement_id = property_id; // For simplicity, using property_id as agreement_id
+    let agreement_id = input.agreement_id.clone();
 
-    create_agreement_internal(
-        env,
-        agreement_id.clone(),
-        landlord,
-        tenant,
-        None,
-        rent_amount,
-        deposit_amount,
-        lease_start,
-        lease_end,
-        0,
-        payment_token.clone(),
-    )?;
+    create_agreement_internal(env, input)?;
 
     // Store the token mapping explicitly if needed, but it's already in RentAgreement
+    // Wait, create_agreement_internal already set the agreement.
+    // We just need the extra DataKey::AgreementToken if the frontend relies on it.
+    let agreement: RentAgreement = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Agreement(agreement_id.clone()))
+        .unwrap();
+
     env.storage().persistent().set(
         &DataKey::AgreementToken(agreement_id.clone()),
-        &payment_token,
+        &agreement.payment_token,
     );
 
     Ok(agreement_id)
@@ -444,9 +443,12 @@ pub fn make_payment_with_token(
         payment_date: env.ledger().timestamp(),
         payer: agreement.tenant.clone(),
     };
-    agreement
-        .payment_history
-        .set(agreement.payment_count, split);
+
+    let record_key = DataKey::PaymentRecord(agreement_id.clone(), agreement.payment_count);
+    env.storage().persistent().set(&record_key, &split);
+    env.storage()
+        .persistent()
+        .extend_ttl(&record_key, TTL_THRESHOLD, TTL_BUMP);
 
     env.storage()
         .persistent()

--- a/contract/contracts/chioma/src/lib.rs
+++ b/contract/contracts/chioma/src/lib.rs
@@ -34,9 +34,9 @@ mod tests_royalties;
 
 pub use agreement::{
     cancel_agreement, create_agreement, create_agreement_with_token, get_agreement,
-    get_agreement_count, get_agreement_token, get_payment_split, has_agreement,
-    make_payment_with_token, release_escrow_with_token, sign_agreement, submit_agreement,
-    validate_agreement_params,
+    get_agreement_count, get_agreement_token, get_payment_history, get_payment_split,
+    has_agreement, make_payment_with_token, release_escrow_with_token, sign_agreement,
+    submit_agreement, update_metadata, validate_agreement_params,
 };
 pub use errors::RentalError;
 pub use multi_token::{
@@ -45,10 +45,10 @@ pub use multi_token::{
 };
 pub use storage::DataKey;
 pub use types::{
-    AgreementStatus, AgreementWithToken, CompoundingFrequency, Config, ContractState,
-    DepositInterest, DepositInterestConfig, ErrorContext, InterestAccrual, InterestRecipient,
-    PauseState, PaymentSplit, RentAgreement, RoyaltyConfig, RoyaltyPayment, SupportedToken,
-    TokenExchangeRate,
+    AgreementInput, AgreementStatus, AgreementTerms, AgreementWithToken, Attribute,
+    CompoundingFrequency, Config, ContractState, DepositInterest, DepositInterestConfig,
+    ErrorContext, InterestAccrual, InterestRecipient, PauseState, PaymentSplit, RentAgreement,
+    RoyaltyConfig, RoyaltyPayment, SupportedToken, TokenExchangeRate,
 };
 
 /// Chioma rental agreement contract.
@@ -327,27 +327,10 @@ impl Contract {
 
     pub fn create_agreement_with_token(
         env: Env,
-        property_id: String,
-        tenant: Address,
-        landlord: Address,
-        payment_token: Address,
-        rent_amount: i128,
-        deposit_amount: i128,
-        lease_start: u64,
-        lease_end: u64,
+        input: crate::types::AgreementInput,
     ) -> Result<String, RentalError> {
         Self::check_paused(&env)?;
-        agreement::create_agreement_with_token(
-            &env,
-            property_id,
-            tenant,
-            landlord,
-            payment_token,
-            rent_amount,
-            deposit_amount,
-            lease_start,
-            lease_end,
-        )
+        agreement::create_agreement_with_token(&env, input)
     }
 
     pub fn get_agreement_token(env: Env, agreement_id: String) -> Result<Address, RentalError> {
@@ -393,31 +376,10 @@ impl Contract {
     #[allow(clippy::too_many_arguments)]
     pub fn create_agreement(
         env: Env,
-        agreement_id: String,
-        landlord: Address,
-        tenant: Address,
-        agent: Option<Address>,
-        monthly_rent: i128,
-        security_deposit: i128,
-        start_date: u64,
-        end_date: u64,
-        agent_commission_rate: u32,
-        payment_token: Address,
+        input: crate::types::AgreementInput,
     ) -> Result<(), RentalError> {
         Self::check_paused(&env)?;
-        agreement::create_agreement(
-            &env,
-            agreement_id,
-            landlord,
-            tenant,
-            agent,
-            monthly_rent,
-            security_deposit,
-            start_date,
-            end_date,
-            agent_commission_rate,
-            payment_token,
-        )
+        agreement::create_agreement(&env, input)
     }
 
     /// Sign an existing rental agreement.
@@ -510,6 +472,22 @@ impl Contract {
         month: u32,
     ) -> Result<PaymentSplit, RentalError> {
         agreement::get_payment_split(&env, agreement_id, month)
+    }
+
+    /// Get all payments for an agreement.
+    pub fn get_payment_history(env: Env, agreement_id: String) -> Vec<PaymentSplit> {
+        agreement::get_payment_history(&env, agreement_id)
+    }
+
+    /// Update metadata for an agreement.
+    pub fn update_metadata(
+        env: Env,
+        agreement_id: String,
+        metadata_uri: String,
+        attributes: Vec<Attribute>,
+    ) -> Result<(), RentalError> {
+        Self::check_paused(&env)?;
+        agreement::update_metadata(&env, agreement_id, metadata_uri, attributes)
     }
 
     // ─── Deposit Interest Functions ───────────────────────────────────────────

--- a/contract/contracts/chioma/src/storage.rs
+++ b/contract/contracts/chioma/src/storage.rs
@@ -18,4 +18,5 @@ pub enum DataKey {
     ErrorLogCount,
     RoyaltyConfig(String),
     RoyaltyPayments(String),
+    PaymentRecord(String, u32),
 }

--- a/contract/contracts/chioma/src/tests.rs
+++ b/contract/contracts/chioma/src/tests.rs
@@ -134,7 +134,7 @@ fn create_contract(env: &Env) -> ContractClient<'_> {
 fn initialize_contract_state(env: &Env, client: &ContractClient<'_>, admin: &Address) {
     let config = Config {
         fee_bps: 100,
-        fee_collector: Address::generate(env),
+        fee_collector: Address::generate(&env),
         paused: false,
     };
     client
@@ -246,18 +246,22 @@ fn test_create_agreement_success() {
 
     let agreement_id = String::from_str(&env, "AGREEMENT_001");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &agent,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &10,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: agent.clone(),
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 10,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let events = env.events().all();
     assert_eq!(events.len(), 1);
@@ -280,18 +284,22 @@ fn test_create_agreement_with_agent() {
 
     let agreement_id = String::from_str(&env, "AGREEMENT_WITH_AGENT");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &Some(agent.clone()),
-        &1500,
-        &3000,
-        &1000,
-        &2000,
-        &5,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: Some(agent.clone()),
+        terms: AgreementTerms {
+            monthly_rent: 1500,
+            security_deposit: 3000,
+            start_date: 1000,
+            end_date: 2000,
+            agent_commission_rate: 5,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -306,18 +314,22 @@ fn test_create_agreement_without_agent() {
 
     let agreement_id = String::from_str(&env, "AGREEMENT_NO_AGENT");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1200,
-        &2400,
-        &500,
-        &1500,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1200,
+            security_deposit: 2400,
+            start_date: 500,
+            end_date: 1500,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -333,18 +345,22 @@ fn test_negative_rent_rejected() {
 
     let agreement_id = String::from_str(&env, "BAD_RENT");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &-100,
-        &1000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: -100,
+            security_deposit: 1000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -360,18 +376,22 @@ fn test_zero_monthly_rent_rejected() {
 
     let agreement_id = String::from_str(&env, "ZERO_RENT");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &0,
-        &1000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 0,
+            security_deposit: 1000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -387,18 +407,22 @@ fn test_invalid_dates_rejected() {
 
     let agreement_id = String::from_str(&env, "BAD_DATES");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &200,
-        &100,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 200,
+            end_date: 100,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -420,18 +444,22 @@ fn test_backdated_agreement_rejected() {
     });
 
     // Try to create agreement with start_date more than 1 day in the past
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &900000, // More than 1 day (86400 seconds) before current time
-        &2000000,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 900000,
+            end_date: 2000000,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -452,18 +480,22 @@ fn test_agreement_within_grace_period_accepted() {
     });
 
     // Create agreement with start_date within grace period (less than 1 day ago)
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &950000, // Within 1 day grace period
-        &2000000,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 950000,
+            end_date: 2000000,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     assert!(client.has_agreement(&agreement_id));
 }
@@ -481,31 +513,39 @@ fn test_duplicate_agreement_id() {
 
     let agreement_id = String::from_str(&env, "DUPLICATE_ID");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 #[test]
@@ -521,18 +561,22 @@ fn test_invalid_commission_rate() {
 
     let agreement_id = String::from_str(&env, "BAD_COMMISSION");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &101,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 101,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 }
 
 fn create_pending_agreement(
@@ -542,27 +586,31 @@ fn create_pending_agreement(
     tenant: &Address,
     landlord: &Address,
 ) {
-    client.create_agreement(
-        &String::from_str(env, agreement_id),
-        landlord,
-        tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &1000000,
-        &0,
-        &Address::generate(env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: String::from_str(&env, agreement_id).clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 1000000,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let mut agreement = client
-        .get_agreement(&String::from_str(env, agreement_id))
+        .get_agreement(&String::from_str(&env, agreement_id))
         .unwrap();
     agreement.status = AgreementStatus::Pending;
 
     env.as_contract(&client.address, || {
         env.storage().persistent().set(
-            &storage::DataKey::Agreement(String::from_str(env, agreement_id)),
+            &storage::DataKey::Agreement(String::from_str(&env, agreement_id)),
             &agreement,
         );
     });
@@ -631,18 +679,22 @@ fn test_sign_agreement_invalid_state() {
 
     let agreement_id = "SIGN_003";
 
-    client.create_agreement(
-        &String::from_str(&env, agreement_id),
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &1000000,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: String::from_str(&env, agreement_id).clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 1000000,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     client.sign_agreement(&tenant, &String::from_str(&env, agreement_id));
 }
@@ -659,18 +711,22 @@ fn test_sign_agreement_expired() {
 
     let agreement_id = "SIGN_004";
 
-    client.create_agreement(
-        &String::from_str(&env, agreement_id),
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: String::from_str(&env, agreement_id).clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let mut agreement = client
         .get_agreement(&String::from_str(&env, agreement_id))
@@ -738,18 +794,22 @@ fn test_submit_agreement_success() {
 
     let agreement_id = String::from_str(&env, "SUBMIT_001");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let agreement_before = client.get_agreement(&agreement_id).unwrap();
     assert_eq!(agreement_before.status, AgreementStatus::Draft);
@@ -785,18 +845,22 @@ fn test_submit_agreement_unauthorized() {
 
     let agreement_id = String::from_str(&env, "SUBMIT_UNAUTH");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     client.submit_agreement(&non_landlord, &agreement_id);
 }
@@ -828,18 +892,22 @@ fn test_cancel_agreement_success_draft() {
 
     let agreement_id = String::from_str(&env, "CANCEL_DRAFT");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     client.cancel_agreement(&landlord, &agreement_id);
 
@@ -892,18 +960,22 @@ fn test_cancel_agreement_unauthorized() {
 
     let agreement_id = String::from_str(&env, "CANCEL_UNAUTH");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     client.cancel_agreement(&non_landlord, &agreement_id);
 }
@@ -939,18 +1011,22 @@ fn test_get_agreement() {
 
     let agreement_id = String::from_str(&env, "GET_001");
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let agreement = client.get_agreement(&agreement_id).unwrap();
     assert_eq!(agreement.monthly_rent, 1000);
@@ -971,18 +1047,22 @@ fn test_has_agreement() {
 
     assert!(!client.has_agreement(&agreement_id));
 
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     assert!(client.has_agreement(&agreement_id));
 }
@@ -998,33 +1078,41 @@ fn test_get_agreement_count() {
 
     assert_eq!(client.get_agreement_count(), 0);
 
-    client.create_agreement(
-        &String::from_str(&env, "COUNT_001"),
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: String::from_str(&env, "COUNT_001").clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     assert_eq!(client.get_agreement_count(), 1);
 
-    client.create_agreement(
-        &String::from_str(&env, "COUNT_002"),
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &2000,
-        &100,
-        &200,
-        &0,
-        &Address::generate(&env),
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: String::from_str(&env, "COUNT_002").clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 0,
+        },
+        payment_token: Address::generate(&env).clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     assert_eq!(client.get_agreement_count(), 2);
 }
@@ -1050,18 +1138,22 @@ proptest! {
         let agreement_id = String::from_str(&env, "FUZZ_AGREEMENT");
 
         // Disable panic catching since we expect some combinations to fail
-        let result = client.try_create_agreement(
-            &agreement_id,
-            &landlord,
-            &tenant,
-            &None,
-            &monthly_rent,
-            &security_deposit,
-            &start_date,
-            &end_date,
-            &agent_commission_rate,
-            &payment_token,
-        );
+        let result = client.try_create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: monthly_rent,
+            security_deposit: security_deposit,
+            start_date: start_date,
+            end_date: end_date,
+            agent_commission_rate: agent_commission_rate,
+        },
+        payment_token: payment_token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
         let is_valid_rent = monthly_rent > 0;
         let is_valid_deposit = security_deposit >= 0;
@@ -1119,18 +1211,22 @@ fn test_contract_paused_operations() {
         );
     });
 
-    let res = client.try_create_agreement(
-        &String::from_str(&env, "agreement-paused"),
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &500,
-        &100,
-        &200,
-        &10,
-        &payment_token,
-    );
+    let res = client.try_create_agreement(&AgreementInput {
+        agreement_id: String::from_str(&env, "agreement-paused").clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 500,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 10,
+        },
+        payment_token: payment_token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
     assert_eq!(res, Err(Ok(RentalError::ContractPaused)));
 
     client.unpause();
@@ -1138,18 +1234,22 @@ fn test_contract_paused_operations() {
 
     let agreement_id_str = "agreement-active";
     let agreement_id = String::from_str(&env, agreement_id_str);
-    client.create_agreement(
-        &agreement_id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &500,
-        &100,
-        &200,
-        &10,
-        &payment_token,
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 500,
+            start_date: 100,
+            end_date: 200,
+            agent_commission_rate: 10,
+        },
+        payment_token: payment_token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let mut agreement = client.get_agreement(&agreement_id).unwrap();
     agreement.status = AgreementStatus::Pending;

--- a/contract/contracts/chioma/src/tests_deposit_interest.rs
+++ b/contract/contracts/chioma/src/tests_deposit_interest.rs
@@ -13,10 +13,10 @@ fn create_contract(env: &Env) -> ContractClient<'_> {
 
 fn setup(env: &Env) -> (ContractClient<'_>, Address) {
     let client = create_contract(env);
-    let admin = Address::generate(env);
+    let admin = Address::generate(&env);
     let config = Config {
         fee_bps: 100,
-        fee_collector: Address::generate(env),
+        fee_collector: Address::generate(&env),
         paused: false,
     };
     client.initialize(&admin, &config);
@@ -31,11 +31,24 @@ fn create_agreement_helper(
     landlord: &Address,
     deposit: i128,
 ) -> String {
-    let id = String::from_str(env, "AGR001");
-    let token = Address::generate(env);
-    client.create_agreement(
-        &id, landlord, tenant, &None, &1000, &deposit, &100, &1_000_000, &0, &token,
-    );
+    let id = String::from_str(&env, "AGR001");
+    let token = Address::generate(&env);
+    client.create_agreement(&AgreementInput {
+        agreement_id: id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: deposit,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token: token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
     id
 }
 

--- a/contract/contracts/chioma/src/tests_errors.rs
+++ b/contract/contracts/chioma/src/tests_errors.rs
@@ -11,10 +11,10 @@ fn create_contract(env: &Env) -> ContractClient<'_> {
 
 fn setup(env: &Env) -> ContractClient<'_> {
     let client = create_contract(env);
-    let admin = Address::generate(env);
+    let admin = Address::generate(&env);
     let config = Config {
         fee_bps: 100,
-        fee_collector: Address::generate(env),
+        fee_collector: Address::generate(&env),
         paused: false,
     };
     client.initialize(&admin, &config);

--- a/contract/contracts/chioma/src/tests_multi_token.rs
+++ b/contract/contracts/chioma/src/tests_multi_token.rs
@@ -9,7 +9,7 @@ fn create_contract(env: &Env) -> ContractClient<'_> {
 fn initialize_contract(env: &Env, client: &ContractClient<'_>, admin: &Address) {
     let config = Config {
         fee_bps: 100,
-        fee_collector: Address::generate(env),
+        fee_collector: Address::generate(&env),
         paused: false,
     };
     client.initialize(admin, &config);
@@ -96,16 +96,22 @@ fn test_create_agreement_with_token() {
     );
 
     let property_id = String::from_str(&env, "PROP1");
-    let agreement_id = client.create_agreement_with_token(
-        &property_id,
-        &tenant,
-        &landlord,
-        &token_addr,
-        &1000,
-        &2000,
-        &100,
-        &1000000,
-    );
+    let agreement_id = client.create_agreement_with_token(&AgreementInput {
+        agreement_id: property_id.clone(),
+        tenant: tenant.clone(),
+        landlord: landlord.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 1000000,
+            agent_commission_rate: 0,
+        },
+        payment_token: token_addr.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     assert_eq!(agreement_id, property_id);
     let fetched_token = client.get_agreement_token(&agreement_id);
@@ -148,16 +154,22 @@ fn test_make_payment_with_different_token() {
     let rate = 1_100_000_000_000_000_000;
     client.set_exchange_rate(&pay_token, &base_token, &rate);
 
-    let agreement_id = client.create_agreement_with_token(
-        &String::from_str(&env, "PROP1"),
-        &tenant,
-        &landlord,
-        &base_token,
-        &1100, // Monthly rent in USDC
-        &2200,
-        &100,
-        &1000000,
-    );
+    let agreement_id = client.create_agreement_with_token(&AgreementInput {
+        agreement_id: String::from_str(&env, "PROP1").clone(),
+        tenant: tenant.clone(),
+        landlord: landlord.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1100,
+            security_deposit: 2200, // Monthly rent in USDC
+            start_date: 100,
+            end_date: 1000000,
+            agent_commission_rate: 0,
+        },
+        payment_token: base_token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     // Sign agreement to make it active
     client.submit_agreement(&landlord, &agreement_id);

--- a/contract/contracts/chioma/src/tests_royalties.rs
+++ b/contract/contracts/chioma/src/tests_royalties.rs
@@ -40,9 +40,22 @@ fn test_set_and_get_royalty() {
     let token = Address::generate(&env);
     let id = String::from_str(&env, "T1");
 
-    client.create_agreement(
-        &id, &landlord, &tenant, &None, &1000, &5000, &100, &1_000_000, &0, &token,
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 5000,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token: token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let recipient = Address::generate(&env);
     client.set_royalty(&id, &500, &recipient); // 5%
@@ -63,9 +76,22 @@ fn test_calculate_royalty() {
     let landlord = Address::generate(&env);
     let tenant = Address::generate(&env);
     let token = Address::generate(&env);
-    client.create_agreement(
-        &id, &landlord, &tenant, &None, &1000, &5000, &100, &1_000_000, &0, &token,
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 5000,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token: token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     client.set_royalty(&id, &1000, &Address::generate(&env)); // 10%
 
@@ -85,18 +111,22 @@ fn test_transfer_with_royalty() {
     let (token_address, token_client) = create_token_mock(&env, &token_admin);
     let id = String::from_str(&env, "T1");
 
-    client.create_agreement(
-        &id,
-        &landlord,
-        &tenant,
-        &None,
-        &1000,
-        &5000,
-        &100,
-        &1_000_000,
-        &0,
-        &token_address,
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 5000,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token: token_address.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     let recipient = Address::generate(&env);
     client.set_royalty(&id, &1000, &recipient); // 10%
@@ -142,9 +172,22 @@ fn test_invalid_royalty_percentage_fails() {
     let landlord = Address::generate(&env);
     let tenant = Address::generate(&env);
     let token = Address::generate(&env);
-    client.create_agreement(
-        &id, &landlord, &tenant, &None, &1000, &5000, &100, &1_000_000, &0, &token,
-    );
+    client.create_agreement(&AgreementInput {
+        agreement_id: id.clone(),
+        landlord: landlord.clone(),
+        tenant: tenant.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 5000,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token: token.clone(),
+        metadata_uri: String::from_str(&env, "").clone(),
+        attributes: Vec::new(&env).clone(),
+    });
 
     client.set_royalty(&id, &2501, &Address::generate(&env)); // > 25%
 }

--- a/contract/contracts/chioma/src/types.rs
+++ b/contract/contracts/chioma/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Map, String, Vec};
+use soroban_sdk::{contracttype, Address, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -10,6 +10,13 @@ pub enum AgreementStatus {
     Cancelled,
     Terminated,
     Disputed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attribute {
+    pub trait_type: String,
+    pub value: String,
 }
 
 #[contracttype]
@@ -30,7 +37,8 @@ pub struct RentAgreement {
     pub signed_at: Option<u64>,
     pub payment_token: Address,
     pub next_payment_due: u64,
-    pub payment_history: Map<u32, PaymentSplit>,
+    pub metadata_uri: String,
+    pub attributes: Vec<Attribute>,
 }
 
 #[contracttype]
@@ -180,4 +188,27 @@ pub struct RoyaltyPayment {
     pub amount: i128,
     pub royalty_amount: i128,
     pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgreementTerms {
+    pub monthly_rent: i128,
+    pub security_deposit: i128,
+    pub start_date: u64,
+    pub end_date: u64,
+    pub agent_commission_rate: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgreementInput {
+    pub agreement_id: String,
+    pub landlord: Address,
+    pub tenant: Address,
+    pub agent: Option<Address>,
+    pub terms: AgreementTerms,
+    pub payment_token: Address,
+    pub metadata_uri: String,
+    pub attributes: Vec<Attribute>,
 }

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_accrue_interest_multiple_periods.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_accrue_interest_multiple_periods.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "12000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "12000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -208,6 +287,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -220,6 +307,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -244,14 +339,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_accrue_interest_persists_state.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_accrue_interest_persists_state.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "12000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "12000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -207,6 +286,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -219,6 +306,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -243,14 +338,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_calculate_accrued_interest_after_30_days.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_calculate_accrued_interest_after_30_days.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "12000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "12000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -206,6 +285,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -218,6 +305,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -242,14 +337,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_calculate_accrued_interest_no_time.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_calculate_accrued_interest_no_time.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "10000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "10000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -206,6 +285,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -218,6 +305,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -242,14 +337,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_deposit_interest_initialised_with_principal.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_deposit_interest_initialised_with_principal.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "10000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "10000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -206,6 +285,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -218,6 +305,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -242,14 +337,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_get_accrual_history.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_get_accrual_history.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -207,6 +286,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -219,6 +306,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -243,14 +338,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_invalid_rate_rejected.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_invalid_rate_rejected.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -170,6 +249,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -182,6 +269,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -206,14 +301,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_set_deposit_interest_config.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_deposit_interest/test_set_deposit_interest_config.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "AGR001"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "AGR001"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -206,6 +285,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -218,6 +305,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -242,14 +337,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_multi_token/test_create_agreement_with_token.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_multi_token/test_create_agreement_with_token.1.json
@@ -94,28 +94,111 @@
               "function_name": "create_agreement_with_token",
               "args": [
                 {
-                  "string": "PROP1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                },
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "2000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "PROP1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "2000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -197,6 +280,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -209,6 +300,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -233,14 +332,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_multi_token/test_make_payment_with_different_token.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_multi_token/test_make_payment_with_different_token.1.json
@@ -188,28 +188,111 @@
               "function_name": "create_agreement_with_token",
               "args": [
                 {
-                  "string": "PROP1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "address": "CDS3FDGQ4JA2V3F26Y4BMWWJEC5TT26RJBN7KIQKUMVO2MAOCMDTSZ7A"
-                },
-                {
-                  "i128": "1100"
-                },
-                {
-                  "i128": "2200"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "PROP1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CDS3FDGQ4JA2V3F26Y4BMWWJEC5TT26RJBN7KIQKUMVO2MAOCMDTSZ7A"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1100"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "2200"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -525,6 +608,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -537,6 +628,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -561,64 +660,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": [
-                          {
-                            "key": {
-                              "u32": 1
-                            },
-                            "val": {
-                              "map": [
-                                {
-                                  "key": {
-                                    "symbol": "landlord_amount"
-                                  },
-                                  "val": {
-                                    "i128": "1100"
-                                  }
-                                },
-                                {
-                                  "key": {
-                                    "symbol": "payer"
-                                  },
-                                  "val": {
-                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                                  }
-                                },
-                                {
-                                  "key": {
-                                    "symbol": "payment_date"
-                                  },
-                                  "val": {
-                                    "u64": "0"
-                                  }
-                                },
-                                {
-                                  "key": {
-                                    "symbol": "platform_amount"
-                                  },
-                                  "val": {
-                                    "i128": "0"
-                                  }
-                                },
-                                {
-                                  "key": {
-                                    "symbol": "token"
-                                  },
-                                  "val": {
-                                    "address": "CCFPZOCU33AWX2NKX47XD6W5JNYFP7MU57DTQFB5XOOQSJLSSC4PMX25"
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        ]
                       }
                     },
                     {
@@ -850,6 +891,98 @@
                 "durability": "persistent",
                 "val": {
                   "bool": true
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          500000
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PaymentRecord"
+                },
+                {
+                  "string": "PROP1"
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PaymentRecord"
+                    },
+                    {
+                      "string": "PROP1"
+                    },
+                    {
+                      "u32": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "landlord_amount"
+                      },
+                      "val": {
+                        "i128": "1100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_date"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "platform_amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token"
+                      },
+                      "val": {
+                        "address": "CCFPZOCU33AWX2NKX47XD6W5JNYFP7MU57DTQFB5XOOQSJLSSC4PMX25"
+                      }
+                    }
+                  ]
                 }
               }
             },

--- a/contract/contracts/chioma/test_snapshots/tests_royalties/test_calculate_royalty.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_royalties/test_calculate_royalty.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "T1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "T1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -195,6 +274,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -207,6 +294,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -231,14 +326,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_royalties/test_invalid_royalty_percentage_fails.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_royalties/test_invalid_royalty_percentage_fails.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "T1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "T1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -170,6 +249,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -182,6 +269,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -206,14 +301,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_royalties/test_set_and_get_royalty.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_royalties/test_set_and_get_royalty.1.json
@@ -63,32 +63,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "T1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "T1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -195,6 +274,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -207,6 +294,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -231,14 +326,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {

--- a/contract/contracts/chioma/test_snapshots/tests_royalties/test_transfer_with_royalty.1.json
+++ b/contract/contracts/chioma/test_snapshots/tests_royalties/test_transfer_with_royalty.1.json
@@ -82,32 +82,111 @@
               "function_name": "create_agreement",
               "args": [
                 {
-                  "string": "T1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                "void",
-                {
-                  "i128": "1000"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "u64": "100"
-                },
-                {
-                  "u64": "1000000"
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "address": "CDS3FDGQ4JA2V3F26Y4BMWWJEC5TT26RJBN7KIQKUMVO2MAOCMDTSZ7A"
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "agent"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "agreement_id"
+                      },
+                      "val": {
+                        "string": "T1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "landlord"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CDS3FDGQ4JA2V3F26Y4BMWWJEC5TT26RJBN7KIQKUMVO2MAOCMDTSZ7A"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tenant"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "terms"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "agent_commission_rate"
+                            },
+                            "val": {
+                              "u32": 0
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "end_date"
+                            },
+                            "val": {
+                              "u64": "1000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "monthly_rent"
+                            },
+                            "val": {
+                              "i128": "1000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "security_deposit"
+                            },
+                            "val": {
+                              "i128": "5000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "start_date"
+                            },
+                            "val": {
+                              "u64": "100"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -390,6 +469,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "attributes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "end_date"
                       },
                       "val": {
@@ -402,6 +489,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata_uri"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -426,14 +521,6 @@
                       },
                       "val": {
                         "u32": 0
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "payment_history"
-                      },
-                      "val": {
-                        "map": []
                       }
                     },
                     {


### PR DESCRIPTION
## Summary
- **NFT Metadata Support**: Added `metadata_uri` and `attributes` fields to `RentAgreement` and `update_metadata` contract method
- **Payment Storage Optimization**: Decoupled payment history from the main agreement struct using independent storage keys for gas efficiency
- **Soroban Parameter Limit Resolution**: Refactored agreement creation to use `AgreementInput` structs, staying within Soroban's 10-parameter limit

Verified with 65 passing contract tests.

Closes #471
Closes #453
Closes #454

## Test plan
- [ ] Run `cargo test` in `contract/contracts/chioma` — all 65 tests pass
- [ ] Verify NFT metadata fields are correctly stored and retrievable
- [ ] Verify payment history uses independent storage keys
- [ ] Verify agreement creation works with `AgreementInput` struct