### PR TITLE
fix: remove spacing between logo and Chioma text

### DIFF
--- a/frontend/components/Logo.tsx
+++ b/frontend/components/Logo.tsx
@@ -27,7 +27,7 @@ export default function Logo({
 
   if (!href) {
     return (
-      <div className={`flex items-center gap-2 ${className}`}>
+      <div className={`flex items-center ${className}`}>
         <Image
           src="/logo_256.png"
           alt="Chioma logo"
@@ -43,7 +43,7 @@ export default function Logo({
   }
 
   return (
-    <Link href={href} className={`flex items-center gap-2 ${className}`}>
+    <Link href={href} className={`flex items-center ${className}`}>
       <Image
         src="/logo_256.png"
         alt="Chioma logo"


### PR DESCRIPTION
# Fix: Remove Spacing Between Logo and Chioma Text

Closes #345

## Description
Removes the gap between the logo image and the "Chioma" text in the Logo component for a more compact and polished appearance.

## Changes
- **File**: `components/Logo.tsx`
- **Change**: Removed `gap-2` Tailwind class from both the Link and div wrapper variants
- **Impact**: Logo and text now display directly adjacent without spacing

## Visual Impact
- Logo and text are now tightly aligned
- Applies to all Logo component instances across the application (navbar, footer, sidebars, auth pages)
- Maintains vertical alignment with `items-center` class

## Testing
✅ All pipeline checks passed:
- ESLint validation
- Prettier formatting check
- Production build successful
- No breaking changes to component API

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Code follows project style guidelines
- [x] All checks pass locally (`make check`)
- [x] No new warnings introduced
- [x] Component functionality unchanged
