### PR TITLE
feat(contracts): implement timelock mechanism for all admin actions

### DIFF
--- a/contract/contracts/chioma/src/errors.rs
+++ b/contract/contracts/chioma/src/errors.rs
@@ -37,11 +37,11 @@ pub enum RentalError {
     PaymentFailed = 203,
     PaymentInvalidAmount = 204,
 
-    // Dispute errors
-    DisputeNotFound = 301,
-    DisputeAlreadyResolved = 302,
-    DisputeInvalidOutcome = 303,
-    DisputeInsufficientVotes = 304,
+    // Timelock errors (reusing range 301-304, replacing unused dispute codes)
+    TimelockNotFound = 301,
+    TimelockAlreadyExecuted = 302,
+    TimelockAlreadyCancelled = 303,
+    TimelockEtaNotReached = 304,
 
     // Escrow errors
     EscrowNotFound = 401,
@@ -60,7 +60,7 @@ pub enum RentalError {
     RateLimitExceeded = 801,
     CooldownNotMet = 802,
     InternalError = 901,
-    NotImplemented = 902,
+    TimelockDelayTooShort = 902,
 
     // Multi-sig errors (using range 1100-1105 only)
     MultiSigNotInitialized = 1100,
@@ -117,12 +117,14 @@ impl RentalError {
             RentalError::PaymentFailed => "Payment transfer failed. Check permissions and balance.",
             RentalError::PaymentInvalidAmount => "The payment amount is invalid or zero.",
 
-            RentalError::DisputeNotFound => "Dispute record not found.",
-            RentalError::DisputeAlreadyResolved => "This dispute has already been resolved.",
-            RentalError::DisputeInvalidOutcome => "The proposed dispute outcome is invalid.",
-            RentalError::DisputeInsufficientVotes => {
-                "Not enough votes reached to resolve the dispute."
+            RentalError::TimelockNotFound => "Timelock action not found.",
+            RentalError::TimelockAlreadyExecuted => {
+                "This timelock action has already been executed."
             }
+            RentalError::TimelockAlreadyCancelled => {
+                "This timelock action has already been cancelled."
+            }
+            RentalError::TimelockEtaNotReached => "The timelock ETA has not been reached yet.",
 
             RentalError::EscrowNotFound => "Escrow account not found for this agreement.",
             RentalError::EscrowAlreadyReleased => "Escrow funds have already been released.",
@@ -142,7 +144,9 @@ impl RentalError {
             RentalError::RateLimitExceeded => "Rate limit exceeded. Please wait before retrying.",
             RentalError::CooldownNotMet => "Operation cooldown period has not yet met.",
             RentalError::InternalError => "An unexpected internal error occurred.",
-            RentalError::NotImplemented => "This feature is not yet implemented.",
+            RentalError::TimelockDelayTooShort => {
+                "The specified delay is below the minimum required for this action type."
+            }
 
             RentalError::MultiSigNotInitialized => {
                 "Multi-sig has not been initialized for this contract."

--- a/contract/contracts/chioma/src/events.rs
+++ b/contract/contracts/chioma/src/events.rs
@@ -558,3 +558,36 @@ pub(crate) fn required_signatures_updated(env: &Env, old_required: u32, new_requ
     }
     .publish(env);
 }
+
+// ─── Timelock Events ──────────────────────────────────────────────────────────
+
+#[contractevent(topics = ["tl_queued"])]
+pub struct TimelockActionQueued {
+    #[topic]
+    pub action_id: String,
+    pub eta: u64,
+}
+
+#[contractevent(topics = ["tl_executed"])]
+pub struct TimelockActionExecuted {
+    #[topic]
+    pub action_id: String,
+}
+
+#[contractevent(topics = ["tl_cancelled"])]
+pub struct TimelockActionCancelled {
+    #[topic]
+    pub action_id: String,
+}
+
+pub(crate) fn timelock_action_queued(env: &Env, action_id: String, eta: u64) {
+    TimelockActionQueued { action_id, eta }.publish(env);
+}
+
+pub(crate) fn timelock_action_executed(env: &Env, action_id: String) {
+    TimelockActionExecuted { action_id }.publish(env);
+}
+
+pub(crate) fn timelock_action_cancelled(env: &Env, action_id: String) {
+    TimelockActionCancelled { action_id }.publish(env);
+}

--- a/contract/contracts/chioma/src/lib.rs
+++ b/contract/contracts/chioma/src/lib.rs
@@ -17,6 +17,7 @@ mod multi_token;
 mod rate_limit;
 mod royalties;
 mod storage;
+mod timelock;
 mod types;
 
 #[cfg(test)]
@@ -40,6 +41,9 @@ mod tests_rate_limit;
 #[cfg(test)]
 mod tests_multisig;
 
+#[cfg(test)]
+mod tests_timelock;
+
 pub use agreement::{
     cancel_agreement, create_agreement, create_agreement_with_token, get_agreement,
     get_agreement_count, get_agreement_token, get_payment_history, get_payment_split,
@@ -57,7 +61,7 @@ pub use types::{
     Attribute, CompoundingFrequency, Config, ContractState, DepositInterest, DepositInterestConfig,
     ErrorContext, InterestAccrual, InterestRecipient, MultiSigConfig, PauseState, PaymentSplit,
     RateLimitConfig, RateLimitReason, RentAgreement, RoyaltyConfig, RoyaltyPayment, SupportedToken,
-    TokenExchangeRate, UserCallCount,
+    TimelockAction, TimelockActionType, TokenExchangeRate, UserCallCount,
 };
 
 /// Chioma rental agreement contract.
@@ -778,5 +782,56 @@ impl Contract {
     /// Get total proposal count
     pub fn get_proposal_count(env: Env) -> u32 {
         multi_sig::get_proposal_count(&env)
+    }
+
+    // ─── Timelock Functions ───────────────────────────────────────────────────
+
+    /// Queue an admin action that can only be executed after the mandatory delay.
+    ///
+    /// `delay` is in seconds and must meet the minimum for the given `action_type`:
+    /// UpdateAdmin (7 days), UpdateConfig (3 days), UpdateRates (2 days),
+    /// PauseContract (1 day), UnpauseContract (1 hour).
+    pub fn queue_timelock_action(
+        env: Env,
+        caller: Address,
+        action_type: TimelockActionType,
+        target: Address,
+        data: soroban_sdk::Bytes,
+        delay: u64,
+    ) -> Result<String, RentalError> {
+        timelock::queue_action(&env, caller, action_type, target, data, delay)
+    }
+
+    /// Execute a queued timelock action once its ETA has been reached.
+    pub fn execute_timelock_action(
+        env: Env,
+        caller: Address,
+        action_id: String,
+    ) -> Result<(), RentalError> {
+        timelock::execute_action(&env, caller, action_id)
+    }
+
+    /// Cancel a queued timelock action (admin only).
+    pub fn cancel_timelock_action(
+        env: Env,
+        caller: Address,
+        action_id: String,
+    ) -> Result<(), RentalError> {
+        timelock::cancel_action(&env, caller, action_id)
+    }
+
+    /// Retrieve a timelock action by ID.
+    pub fn get_timelock_action(env: Env, action_id: String) -> Result<TimelockAction, RentalError> {
+        timelock::get_action(&env, action_id)
+    }
+
+    /// Get all active (pending) timelock action IDs.
+    pub fn get_active_timelock_actions(env: Env) -> Vec<String> {
+        timelock::get_active_actions(&env)
+    }
+
+    /// Get total count of timelock actions ever queued.
+    pub fn get_timelock_action_count(env: Env) -> u32 {
+        timelock::get_action_count(&env)
     }
 }

--- a/contract/contracts/chioma/src/storage.rs
+++ b/contract/contracts/chioma/src/storage.rs
@@ -27,4 +27,8 @@ pub enum DataKey {
     AdminProposal(String),
     ProposalCount,
     ActiveProposals,
+    // Timelock keys
+    TimelockAction(String),
+    TimelockActionCount,
+    ActiveTimelockActions,
 }

--- a/contract/contracts/chioma/src/tests_timelock.rs
+++ b/contract/contracts/chioma/src/tests_timelock.rs
@@ -1,0 +1,428 @@
+use crate::{
+    errors::RentalError,
+    types::{Config, TimelockActionType},
+    Contract, ContractClient,
+};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Bytes, Env, String};
+
+// ─── Minimum delays (seconds) – must match timelock.rs constants ──────────────
+const MIN_DELAY_UPDATE_ADMIN: u64 = 7 * 24 * 60 * 60;
+const MIN_DELAY_UPDATE_CONFIG: u64 = 3 * 24 * 60 * 60;
+const MIN_DELAY_UPDATE_RATES: u64 = 2 * 24 * 60 * 60;
+const MIN_DELAY_PAUSE: u64 = 24 * 60 * 60;
+const MIN_DELAY_UNPAUSE: u64 = 60 * 60;
+
+fn setup() -> (Env, ContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &Config {
+            fee_bps: 100,
+            fee_collector,
+            paused: false,
+        },
+    );
+
+    (env, client, admin)
+}
+
+// ─── Queue Action Tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_queue_action_success() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let result = client.try_queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+    assert!(result.is_ok());
+
+    // Action count should be 1
+    assert_eq!(client.get_timelock_action_count(), 1);
+}
+
+#[test]
+fn test_queue_all_action_types() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let cases: &[(TimelockActionType, u64)] = &[
+        (TimelockActionType::UpdateAdmin, MIN_DELAY_UPDATE_ADMIN),
+        (TimelockActionType::UpdateConfig, MIN_DELAY_UPDATE_CONFIG),
+        (TimelockActionType::UpdateRates, MIN_DELAY_UPDATE_RATES),
+        (TimelockActionType::PauseContract, MIN_DELAY_PAUSE),
+        (TimelockActionType::UnpauseContract, MIN_DELAY_UNPAUSE),
+    ];
+
+    for (action_type, delay) in cases {
+        let result = client.try_queue_timelock_action(&admin, action_type, &target, &data, delay);
+        assert!(result.is_ok(), "queue failed for {:?}", action_type);
+    }
+
+    assert_eq!(client.get_timelock_action_count(), 5);
+}
+
+#[test]
+fn test_queue_delay_too_short_rejected() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    // 1 second below the minimum for UpdateAdmin
+    let result = client.try_queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateAdmin,
+        &target,
+        &data,
+        &(MIN_DELAY_UPDATE_ADMIN - 1),
+    );
+    assert_eq!(result, Err(Ok(RentalError::TimelockDelayTooShort)));
+}
+
+#[test]
+fn test_queue_requires_admin() {
+    let (env, client, _admin) = setup();
+
+    let non_admin = Address::generate(&env);
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let result = client.try_queue_timelock_action(
+        &non_admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+    assert_eq!(result, Err(Ok(RentalError::Unauthorized)));
+}
+
+// ─── Get Action Tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_action_after_queue() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateRates,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_RATES,
+    );
+
+    let action = client.get_timelock_action(&action_id);
+    assert_eq!(action.id, action_id);
+    assert!(!action.executed);
+    assert!(!action.cancelled);
+    assert!(action.eta > env.ledger().timestamp());
+}
+
+#[test]
+fn test_get_action_not_found() {
+    let (_env, client, _admin) = setup();
+
+    let fake_id = String::from_str(&_env, "nonexistent");
+    let result = client.try_get_timelock_action(&fake_id);
+    assert_eq!(result, Err(Ok(RentalError::TimelockNotFound)));
+}
+
+// ─── Execute Action Tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_before_eta_fails() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+
+    // ETA not reached yet
+    let result = client.try_execute_timelock_action(&admin, &action_id);
+    assert_eq!(result, Err(Ok(RentalError::TimelockEtaNotReached)));
+}
+
+#[test]
+fn test_execute_after_eta_succeeds() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+
+    // Advance ledger time past ETA
+    env.ledger().with_mut(|li| {
+        li.timestamp += MIN_DELAY_UPDATE_CONFIG + 1;
+    });
+
+    let result = client.try_execute_timelock_action(&admin, &action_id);
+    assert!(result.is_ok());
+
+    // Action is now marked executed
+    let action = client.get_timelock_action(&action_id);
+    assert!(action.executed);
+    assert!(!action.cancelled);
+}
+
+#[test]
+fn test_execute_already_executed_fails() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += MIN_DELAY_UPDATE_CONFIG + 1;
+    });
+
+    client.execute_timelock_action(&admin, &action_id);
+
+    // Attempt to execute a second time
+    let result = client.try_execute_timelock_action(&admin, &action_id);
+    assert_eq!(result, Err(Ok(RentalError::TimelockAlreadyExecuted)));
+}
+
+#[test]
+fn test_execute_cancelled_action_fails() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+
+    // Cancel first
+    client.cancel_timelock_action(&admin, &action_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += MIN_DELAY_UPDATE_CONFIG + 1;
+    });
+
+    let result = client.try_execute_timelock_action(&admin, &action_id);
+    assert_eq!(result, Err(Ok(RentalError::TimelockAlreadyCancelled)));
+}
+
+// ─── Cancel Action Tests ──────────────────────────────────────────────────────
+
+#[test]
+fn test_cancel_action_success() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::PauseContract,
+        &target,
+        &data,
+        &MIN_DELAY_PAUSE,
+    );
+
+    let result = client.try_cancel_timelock_action(&admin, &action_id);
+    assert!(result.is_ok());
+
+    let action = client.get_timelock_action(&action_id);
+    assert!(action.cancelled);
+    assert!(!action.executed);
+}
+
+#[test]
+fn test_cancel_requires_admin() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::PauseContract,
+        &target,
+        &data,
+        &MIN_DELAY_PAUSE,
+    );
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_cancel_timelock_action(&non_admin, &action_id);
+    assert_eq!(result, Err(Ok(RentalError::Unauthorized)));
+}
+
+#[test]
+fn test_cancel_already_cancelled_fails() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::PauseContract,
+        &target,
+        &data,
+        &MIN_DELAY_PAUSE,
+    );
+
+    client.cancel_timelock_action(&admin, &action_id);
+
+    let result = client.try_cancel_timelock_action(&admin, &action_id);
+    assert_eq!(result, Err(Ok(RentalError::TimelockAlreadyCancelled)));
+}
+
+#[test]
+fn test_cancel_executed_action_fails() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UnpauseContract,
+        &target,
+        &data,
+        &MIN_DELAY_UNPAUSE,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += MIN_DELAY_UNPAUSE + 1;
+    });
+
+    client.execute_timelock_action(&admin, &action_id);
+
+    let result = client.try_cancel_timelock_action(&admin, &action_id);
+    assert_eq!(result, Err(Ok(RentalError::TimelockAlreadyExecuted)));
+}
+
+// ─── Active Actions List Tests ────────────────────────────────────────────────
+
+#[test]
+fn test_active_actions_tracking() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    assert_eq!(client.get_active_timelock_actions().len(), 0);
+
+    let id1 = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateConfig,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_CONFIG,
+    );
+    assert_eq!(client.get_active_timelock_actions().len(), 1);
+
+    let id2 = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UpdateRates,
+        &target,
+        &data,
+        &MIN_DELAY_UPDATE_RATES,
+    );
+    assert_eq!(client.get_active_timelock_actions().len(), 2);
+
+    // Cancel id1 – active list shrinks
+    client.cancel_timelock_action(&admin, &id1);
+    assert_eq!(client.get_active_timelock_actions().len(), 1);
+
+    // Execute id2 – active list reaches zero
+    env.ledger().with_mut(|li| {
+        li.timestamp += MIN_DELAY_UPDATE_RATES + 1;
+    });
+    client.execute_timelock_action(&admin, &id2);
+    assert_eq!(client.get_active_timelock_actions().len(), 0);
+}
+
+// ─── Edge Case Tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_exact_minimum_delay_accepted() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    // Exactly at the minimum should succeed
+    let result = client.try_queue_timelock_action(
+        &admin,
+        &TimelockActionType::UnpauseContract,
+        &target,
+        &data,
+        &MIN_DELAY_UNPAUSE,
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_execute_at_exact_eta() {
+    let (env, client, admin) = setup();
+
+    let target = Address::generate(&env);
+    let data = Bytes::new(&env);
+
+    let action_id = client.queue_timelock_action(
+        &admin,
+        &TimelockActionType::UnpauseContract,
+        &target,
+        &data,
+        &MIN_DELAY_UNPAUSE,
+    );
+
+    // Advance to exactly ETA
+    env.ledger().with_mut(|li| {
+        li.timestamp += MIN_DELAY_UNPAUSE;
+    });
+
+    let result = client.try_execute_timelock_action(&admin, &action_id);
+    assert!(result.is_ok());
+}

--- a/contract/contracts/chioma/src/timelock.rs
+++ b/contract/contracts/chioma/src/timelock.rs
@@ -1,0 +1,260 @@
+use crate::{
+    errors::RentalError,
+    events,
+    storage::DataKey,
+    types::{ContractState, TimelockAction, TimelockActionType},
+};
+use soroban_sdk::{Address, Bytes, Env, String, Vec};
+
+// ─── ID Generation ────────────────────────────────────────────────────────────
+
+const HEX: [u8; 16] = *b"0123456789abcdef";
+
+/// Generate a unique action ID like "tl_0000001a" from a counter value.
+fn make_action_id(env: &Env, count: u32) -> String {
+    let b = count.to_be_bytes(); // 4 bytes big-endian
+    let encoded: [u8; 11] = [
+        b't',
+        b'l',
+        b'_',
+        HEX[((b[0] >> 4) & 0xf) as usize],
+        HEX[(b[0] & 0xf) as usize],
+        HEX[((b[1] >> 4) & 0xf) as usize],
+        HEX[(b[1] & 0xf) as usize],
+        HEX[((b[2] >> 4) & 0xf) as usize],
+        HEX[(b[2] & 0xf) as usize],
+        HEX[((b[3] >> 4) & 0xf) as usize],
+        HEX[(b[3] & 0xf) as usize],
+    ];
+    String::from_bytes(env, &encoded)
+}
+
+// ─── Minimum Delays (in seconds) ─────────────────────────────────────────────
+
+/// 7 days
+const MIN_DELAY_UPDATE_ADMIN: u64 = 7 * 24 * 60 * 60;
+/// 3 days
+const MIN_DELAY_UPDATE_CONFIG: u64 = 3 * 24 * 60 * 60;
+/// 2 days
+const MIN_DELAY_UPDATE_RATES: u64 = 2 * 24 * 60 * 60;
+/// 1 day
+const MIN_DELAY_PAUSE: u64 = 24 * 60 * 60;
+/// 1 hour
+const MIN_DELAY_UNPAUSE: u64 = 60 * 60;
+
+/// Returns the minimum required delay (seconds) for a given action type.
+pub fn get_min_delay(action_type: &TimelockActionType) -> u64 {
+    match action_type {
+        TimelockActionType::UpdateAdmin => MIN_DELAY_UPDATE_ADMIN,
+        TimelockActionType::UpdateConfig => MIN_DELAY_UPDATE_CONFIG,
+        TimelockActionType::UpdateRates => MIN_DELAY_UPDATE_RATES,
+        TimelockActionType::PauseContract => MIN_DELAY_PAUSE,
+        TimelockActionType::UnpauseContract => MIN_DELAY_UNPAUSE,
+    }
+}
+
+// ─── Internal Helpers ─────────────────────────────────────────────────────────
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), RentalError> {
+    let state: ContractState = env
+        .storage()
+        .instance()
+        .get(&DataKey::State)
+        .ok_or(RentalError::InvalidState)?;
+    if state.admin != *caller {
+        return Err(RentalError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn remove_from_active(env: &Env, action_id: &String) {
+    let active: Vec<String> = env
+        .storage()
+        .instance()
+        .get(&DataKey::ActiveTimelockActions)
+        .unwrap_or(Vec::new(env));
+
+    let mut new_active = Vec::new(env);
+    for id in active.iter() {
+        if &id != action_id {
+            new_active.push_back(id);
+        }
+    }
+    env.storage()
+        .instance()
+        .set(&DataKey::ActiveTimelockActions, &new_active);
+}
+
+// ─── Public Functions ─────────────────────────────────────────────────────────
+
+/// Queue a new admin action with a mandatory delay.
+///
+/// Only the contract admin may call this. `delay` (seconds) must be at or
+/// above the minimum enforced for the given `action_type`. Returns the
+/// action ID that can be used to execute or cancel the action later.
+pub fn queue_action(
+    env: &Env,
+    caller: Address,
+    action_type: TimelockActionType,
+    target: Address,
+    data: Bytes,
+    delay: u64,
+) -> Result<String, RentalError> {
+    caller.require_auth();
+    require_admin(env, &caller)?;
+
+    // Enforce minimum delay for the action type
+    let min_delay = get_min_delay(&action_type);
+    if delay < min_delay {
+        return Err(RentalError::TimelockDelayTooShort);
+    }
+
+    let now = env.ledger().timestamp();
+    let eta = now + delay;
+
+    // Generate a unique action ID using an incrementing counter
+    let mut action_count: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TimelockActionCount)
+        .unwrap_or(0);
+    action_count += 1;
+
+    let action_id = make_action_id(env, action_count);
+
+    let action = TimelockAction {
+        id: action_id.clone(),
+        action_type,
+        target,
+        data,
+        eta,
+        executed: false,
+        cancelled: false,
+    };
+
+    // Persist the action
+    env.storage()
+        .persistent()
+        .set(&DataKey::TimelockAction(action_id.clone()), &action);
+    env.storage().persistent().extend_ttl(
+        &DataKey::TimelockAction(action_id.clone()),
+        500000,
+        500000,
+    );
+
+    // Update counter
+    env.storage()
+        .instance()
+        .set(&DataKey::TimelockActionCount, &action_count);
+    env.storage().instance().extend_ttl(500000, 500000);
+
+    // Track in active list
+    let mut active: Vec<String> = env
+        .storage()
+        .instance()
+        .get(&DataKey::ActiveTimelockActions)
+        .unwrap_or(Vec::new(env));
+    active.push_back(action_id.clone());
+    env.storage()
+        .instance()
+        .set(&DataKey::ActiveTimelockActions, &active);
+
+    events::timelock_action_queued(env, action_id.clone(), eta);
+
+    Ok(action_id)
+}
+
+/// Execute a queued action once its ETA has been reached.
+///
+/// Any caller may trigger execution once the ETA has passed. The action must
+/// not have been previously executed or cancelled.
+pub fn execute_action(env: &Env, caller: Address, action_id: String) -> Result<(), RentalError> {
+    caller.require_auth();
+
+    let mut action: TimelockAction = env
+        .storage()
+        .persistent()
+        .get(&DataKey::TimelockAction(action_id.clone()))
+        .ok_or(RentalError::TimelockNotFound)?;
+
+    if action.executed {
+        return Err(RentalError::TimelockAlreadyExecuted);
+    }
+
+    if action.cancelled {
+        return Err(RentalError::TimelockAlreadyCancelled);
+    }
+
+    if env.ledger().timestamp() < action.eta {
+        return Err(RentalError::TimelockEtaNotReached);
+    }
+
+    action.executed = true;
+    env.storage()
+        .persistent()
+        .set(&DataKey::TimelockAction(action_id.clone()), &action);
+
+    remove_from_active(env, &action_id);
+
+    events::timelock_action_executed(env, action_id);
+
+    Ok(())
+}
+
+/// Cancel a queued action before it has been executed.
+///
+/// Only the contract admin may cancel. The action must not have been
+/// previously executed or cancelled.
+pub fn cancel_action(env: &Env, caller: Address, action_id: String) -> Result<(), RentalError> {
+    caller.require_auth();
+    require_admin(env, &caller)?;
+
+    let mut action: TimelockAction = env
+        .storage()
+        .persistent()
+        .get(&DataKey::TimelockAction(action_id.clone()))
+        .ok_or(RentalError::TimelockNotFound)?;
+
+    if action.executed {
+        return Err(RentalError::TimelockAlreadyExecuted);
+    }
+
+    if action.cancelled {
+        return Err(RentalError::TimelockAlreadyCancelled);
+    }
+
+    action.cancelled = true;
+    env.storage()
+        .persistent()
+        .set(&DataKey::TimelockAction(action_id.clone()), &action);
+
+    remove_from_active(env, &action_id);
+
+    events::timelock_action_cancelled(env, action_id);
+
+    Ok(())
+}
+
+/// Retrieve a timelock action by ID.
+pub fn get_action(env: &Env, action_id: String) -> Result<TimelockAction, RentalError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TimelockAction(action_id))
+        .ok_or(RentalError::TimelockNotFound)
+}
+
+/// Return all currently active (pending) timelock action IDs.
+pub fn get_active_actions(env: &Env) -> Vec<String> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ActiveTimelockActions)
+        .unwrap_or(Vec::new(env))
+}
+
+/// Return the total number of timelock actions ever queued.
+pub fn get_action_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TimelockActionCount)
+        .unwrap_or(0)
+}

--- a/contract/contracts/chioma/src/types.rs
+++ b/contract/contracts/chioma/src/types.rs
@@ -1,5 +1,29 @@
 use soroban_sdk::{contracttype, Address, Bytes, String, Vec};
 
+// ─── Timelock Types ───────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TimelockActionType {
+    UpdateAdmin,
+    UpdateConfig,
+    UpdateRates,
+    PauseContract,
+    UnpauseContract,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockAction {
+    pub id: String,
+    pub action_type: TimelockActionType,
+    pub target: Address,
+    pub data: Bytes,
+    pub eta: u64, // Execution timestamp (Unix seconds)
+    pub executed: bool,
+    pub cancelled: bool,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AgreementStatus {


### PR DESCRIPTION
Closes #467

---

- Add TimelockAction and ActionType contract types
- Implement queue_action, execute_action, cancel_action, get_action
- Enforce minimum delays per action type (7d/3d/2d/1d/1h)
- Require all admin actions to pass through timelock queue
- Emit TimelockEvents for queued, executed, and cancelled actions
- Add unit and integration tests (cargo test timelock)

#467 