### PR TITLE
Add personalized property matching & recommendation engine

### DIFF
--- a/backend/migrations/1790000000000-CreateUserAiPreferencesTable.ts
+++ b/backend/migrations/1790000000000-CreateUserAiPreferencesTable.ts
@@ -1,0 +1,105 @@
+import { MigrationInterface, QueryRunner, Table, Index } from 'typeorm';
+
+export class CreateUserAiPreferencesTable1790000000000 implements MigrationInterface {
+  name = 'CreateUserAiPreferencesTable1790000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_ai_preferences',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isUnique: true,
+          },
+          {
+            name: 'preferred_city',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'max_budget',
+            type: 'decimal',
+            precision: 12,
+            scale: 2,
+            isNullable: true,
+          },
+          {
+            name: 'min_budget',
+            type: 'decimal',
+            precision: 12,
+            scale: 2,
+            isNullable: true,
+          },
+          {
+            name: 'bedrooms',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'bathrooms',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'preferred_type',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'pets_required',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'parking_required',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'furnished_required',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'preferred_amenities',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'user_ai_preferences',
+      new Index({
+        name: 'IDX_user_ai_preferences_user_id',
+        columnNames: ['user_id'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user_ai_preferences');
+  }
+}

--- a/backend/src/modules/ai/ai.module.ts
+++ b/backend/src/modules/ai/ai.module.ts
@@ -1,15 +1,25 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AiController } from './ai.controller';
 import { MlModelManagerService } from './ml-model-manager.service';
 import { FraudDetectionService } from './fraud-detection.service';
 import { RecommendationEngineService } from './recommendation-engine.service';
+import { MatchingAiService } from './matching-ai.service';
+import { MatchingAiController } from './controllers/matching-ai.controller';
+import { UserPreferences } from './entities/user-preferences.entity';
+import { Property } from '../properties/entities/property.entity';
+import { CacheService } from '../../common/cache/cache.service';
 
 @Module({
-  controllers: [AiController],
+  imports: [TypeOrmModule.forFeature([UserPreferences, Property])],
+  controllers: [AiController, MatchingAiController],
   providers: [
     MlModelManagerService,
     FraudDetectionService,
     RecommendationEngineService,
+    MatchingAiService,
+    CacheService,
   ],
+  exports: [MatchingAiService, RecommendationEngineService],
 })
 export class AiModule {}

--- a/backend/src/modules/ai/controllers/matching-ai.controller.ts
+++ b/backend/src/modules/ai/controllers/matching-ai.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { User } from '../../users/entities/user.entity';
+import { MatchingAiService } from '../matching-ai.service';
+import { UpdatePreferencesDto } from '../dto/update-preferences.dto';
+
+@ApiTags('AI Matching')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('api/ai/matching')
+export class MatchingAiController {
+  constructor(private readonly matchingAiService: MatchingAiService) {}
+
+  @Get('recommendations')
+  @ApiOperation({ summary: 'Get personalized property recommendations' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiResponse({ status: 200, description: 'Ranked property recommendations' })
+  getRecommendations(
+    @CurrentUser() user: User,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    return this.matchingAiService.getRecommendations(user.id, limit);
+  }
+
+  @Get('match-score/:propertyId')
+  @ApiOperation({ summary: 'Get match score for a specific property' })
+  @ApiResponse({ status: 200, description: 'Match score and reasons' })
+  getMatchScore(
+    @CurrentUser() user: User,
+    @Param('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.matchingAiService.getMatchScore(user.id, propertyId);
+  }
+
+  @Get('similar/:propertyId')
+  @ApiOperation({ summary: 'Get similar properties' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 5 })
+  @ApiResponse({ status: 200, description: 'Similar properties list' })
+  getSimilarProperties(
+    @Param('propertyId', ParseUUIDPipe) propertyId: string,
+    @Query('limit', new DefaultValuePipe(5), ParseIntPipe) limit: number,
+  ) {
+    return this.matchingAiService.getSimilarProperties(propertyId, limit);
+  }
+
+  @Post('preferences')
+  @ApiOperation({ summary: 'Update user matching preferences' })
+  @ApiResponse({ status: 201, description: 'Preferences saved' })
+  updatePreferences(
+    @CurrentUser() user: User,
+    @Body() dto: UpdatePreferencesDto,
+  ) {
+    return this.matchingAiService.updatePreferences(user.id, dto);
+  }
+
+  @Get('preferences')
+  @ApiOperation({ summary: 'Get current user preferences' })
+  @ApiResponse({ status: 200, description: 'User preferences' })
+  getPreferences(@CurrentUser() user: User) {
+    return this.matchingAiService.getPreferences(user.id);
+  }
+}

--- a/backend/src/modules/ai/dto/update-preferences.dto.ts
+++ b/backend/src/modules/ai/dto/update-preferences.dto.ts
@@ -1,0 +1,66 @@
+import {
+  IsOptional,
+  IsString,
+  IsNumber,
+  IsBoolean,
+  IsArray,
+  Min,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdatePreferencesDto {
+  @ApiPropertyOptional({ example: 'Lagos' })
+  @IsOptional()
+  @IsString()
+  preferredCity?: string;
+
+  @ApiPropertyOptional({ example: 500000 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  maxBudget?: number;
+
+  @ApiPropertyOptional({ example: 50000 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  minBudget?: number;
+
+  @ApiPropertyOptional({ example: 2 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  bedrooms?: number;
+
+  @ApiPropertyOptional({ example: 1 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  bathrooms?: number;
+
+  @ApiPropertyOptional({ example: 'apartment' })
+  @IsOptional()
+  @IsString()
+  preferredType?: string;
+
+  @ApiPropertyOptional({ example: false })
+  @IsOptional()
+  @IsBoolean()
+  petsRequired?: boolean;
+
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
+  @IsBoolean()
+  parkingRequired?: boolean;
+
+  @ApiPropertyOptional({ example: false })
+  @IsOptional()
+  @IsBoolean()
+  furnishedRequired?: boolean;
+
+  @ApiPropertyOptional({ example: ['WiFi', 'Pool'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  preferredAmenities?: string[];
+}

--- a/backend/src/modules/ai/entities/user-preferences.entity.ts
+++ b/backend/src/modules/ai/entities/user-preferences.entity.ts
@@ -1,0 +1,70 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('user_ai_preferences')
+export class UserPreferences {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true })
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'preferred_city', type: 'varchar', nullable: true })
+  preferredCity: string | null;
+
+  @Column({
+    name: 'max_budget',
+    type: 'decimal',
+    precision: 12,
+    scale: 2,
+    nullable: true,
+  })
+  maxBudget: number | null;
+
+  @Column({
+    name: 'min_budget',
+    type: 'decimal',
+    precision: 12,
+    scale: 2,
+    nullable: true,
+  })
+  minBudget: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  bedrooms: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  bathrooms: number | null;
+
+  @Column({ name: 'preferred_type', type: 'varchar', nullable: true })
+  preferredType: string | null;
+
+  @Column({ name: 'pets_required', type: 'boolean', default: false })
+  petsRequired: boolean;
+
+  @Column({ name: 'parking_required', type: 'boolean', default: false })
+  parkingRequired: boolean;
+
+  @Column({ name: 'furnished_required', type: 'boolean', default: false })
+  furnishedRequired: boolean;
+
+  @Column({
+    name: 'preferred_amenities',
+    type: 'simple-array',
+    nullable: true,
+  })
+  preferredAmenities: string[] | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/ai/matching-ai.service.ts
+++ b/backend/src/modules/ai/matching-ai.service.ts
@@ -1,0 +1,292 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  Property,
+  ListingStatus,
+} from '../properties/entities/property.entity';
+import { PropertyAmenity } from '../properties/entities/property-amenity.entity';
+import { UserPreferences } from './entities/user-preferences.entity';
+import { UpdatePreferencesDto } from './dto/update-preferences.dto';
+import { CacheService } from '../../common/cache/cache.service';
+
+const CACHE_TTL_RECOMMENDATIONS = 5 * 60 * 1000; // 5 min
+const CACHE_TTL_SIMILAR = 10 * 60 * 1000; // 10 min
+
+@Injectable()
+export class MatchingAiService {
+  private readonly logger = new Logger(MatchingAiService.name);
+
+  constructor(
+    @InjectRepository(Property)
+    private readonly propertyRepo: Repository<Property>,
+    @InjectRepository(UserPreferences)
+    private readonly preferencesRepo: Repository<UserPreferences>,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  // ─── Scoring ────────────────────────────────────────────────────────────────
+
+  private scoreProperty(
+    property: Property,
+    amenityNames: string[],
+    prefs: UserPreferences,
+  ): { score: number; reasons: string[] } {
+    let score = 0;
+    const reasons: string[] = [];
+
+    if (
+      prefs.preferredCity &&
+      property.city?.toLowerCase() === prefs.preferredCity.toLowerCase()
+    ) {
+      score += 30;
+      reasons.push('city_match');
+    }
+
+    if (prefs.maxBudget && Number(property.price) <= Number(prefs.maxBudget)) {
+      score += 25;
+      reasons.push('within_budget');
+    }
+
+    if (prefs.minBudget && Number(property.price) >= Number(prefs.minBudget)) {
+      score += 5;
+      reasons.push('above_min_budget');
+    }
+
+    if (prefs.bedrooms && property.bedrooms >= prefs.bedrooms) {
+      score += 15;
+      reasons.push('bedroom_match');
+    }
+
+    if (prefs.bathrooms && property.bathrooms >= prefs.bathrooms) {
+      score += 10;
+      reasons.push('bathroom_match');
+    }
+
+    if (prefs.preferredType && property.type === prefs.preferredType) {
+      score += 10;
+      reasons.push('type_match');
+    }
+
+    if (prefs.petsRequired && property.petsAllowed) {
+      score += 8;
+      reasons.push('pets_allowed');
+    } else if (prefs.petsRequired && !property.petsAllowed) {
+      score -= 20; // hard penalty
+    }
+
+    if (prefs.parkingRequired && property.hasParking) {
+      score += 8;
+      reasons.push('parking_available');
+    } else if (prefs.parkingRequired && !property.hasParking) {
+      score -= 15;
+    }
+
+    if (prefs.furnishedRequired && property.isFurnished) {
+      score += 5;
+      reasons.push('furnished');
+    }
+
+    if (prefs.preferredAmenities?.length) {
+      const matched = prefs.preferredAmenities.filter((a) =>
+        amenityNames.some((n) => n.toLowerCase().includes(a.toLowerCase())),
+      );
+      const amenityScore = Math.min(15, matched.length * 3);
+      if (amenityScore > 0) {
+        score += amenityScore;
+        reasons.push('amenity_match');
+      }
+    }
+
+    return { score: Math.max(0, score), reasons };
+  }
+
+  // ─── Public API ─────────────────────────────────────────────────────────────
+
+  async getRecommendations(userId: string, limit = 10) {
+    const cacheKey = `ai:recommendations:${userId}:${limit}`;
+
+    return this.cacheService.getOrSet(
+      cacheKey,
+      async () => {
+        const prefs = await this.preferencesRepo.findOne({ where: { userId } });
+
+        const properties = await this.propertyRepo.find({
+          where: { status: ListingStatus.PUBLISHED },
+          relations: ['amenities'],
+          take: 500, // cap for scoring pass
+        });
+
+        if (!prefs) {
+          // Cold-start: return latest published properties
+          return properties.slice(0, limit).map((p) => ({
+            propertyId: p.id,
+            title: p.title,
+            city: p.city,
+            price: p.price,
+            bedrooms: p.bedrooms,
+            score: 0,
+            matchPercentage: 0,
+            reasons: ['no_preferences_set'],
+          }));
+        }
+
+        const scored = properties.map((p) => {
+          const amenityNames = (p.amenities ?? []).map(
+            (a: PropertyAmenity) => a.name,
+          );
+          const { score, reasons } = this.scoreProperty(p, amenityNames, prefs);
+          return {
+            propertyId: p.id,
+            title: p.title,
+            city: p.city,
+            price: p.price,
+            bedrooms: p.bedrooms,
+            type: p.type,
+            score,
+            matchPercentage: Math.min(100, score),
+            reasons,
+          };
+        });
+
+        return scored.sort((a, b) => b.score - a.score).slice(0, limit);
+      },
+      CACHE_TTL_RECOMMENDATIONS,
+    );
+  }
+
+  async getMatchScore(userId: string, propertyId: string) {
+    const [prefs, property] = await Promise.all([
+      this.preferencesRepo.findOne({ where: { userId } }),
+      this.propertyRepo.findOne({
+        where: { id: propertyId },
+        relations: ['amenities'],
+      }),
+    ]);
+
+    if (!property) {
+      return {
+        propertyId,
+        score: 0,
+        matchPercentage: 0,
+        reasons: ['property_not_found'],
+      };
+    }
+
+    if (!prefs) {
+      return {
+        propertyId,
+        score: 0,
+        matchPercentage: 0,
+        reasons: ['no_preferences_set'],
+      };
+    }
+
+    const amenityNames = (property.amenities ?? []).map(
+      (a: PropertyAmenity) => a.name,
+    );
+    const { score, reasons } = this.scoreProperty(
+      property,
+      amenityNames,
+      prefs,
+    );
+
+    return {
+      propertyId,
+      score,
+      matchPercentage: Math.min(100, score),
+      reasons,
+    };
+  }
+
+  async getSimilarProperties(propertyId: string, limit = 5) {
+    const cacheKey = `ai:similar:${propertyId}:${limit}`;
+
+    return this.cacheService.getOrSet(
+      cacheKey,
+      async () => {
+        const source = await this.propertyRepo.findOne({
+          where: { id: propertyId },
+          relations: ['amenities'],
+        });
+
+        if (!source) return [];
+
+        const candidates = await this.propertyRepo.find({
+          where: { status: ListingStatus.PUBLISHED, city: source.city },
+          relations: ['amenities'],
+          take: 200,
+        });
+
+        const sourceAmenities = (source.amenities ?? []).map(
+          (a: PropertyAmenity) => a.name,
+        );
+
+        const scored = candidates
+          .filter((p) => p.id !== propertyId)
+          .map((p) => {
+            let score = 0;
+
+            if (p.type === source.type) score += 30;
+            if (p.bedrooms === source.bedrooms) score += 20;
+            if (p.bathrooms === source.bathrooms) score += 10;
+            if (p.isFurnished === source.isFurnished) score += 5;
+            if (p.petsAllowed === source.petsAllowed) score += 5;
+            if (p.hasParking === source.hasParking) score += 5;
+
+            // Price proximity: within 20% range
+            const priceDiff =
+              Math.abs(Number(p.price) - Number(source.price)) /
+              Number(source.price);
+            if (priceDiff <= 0.1) score += 20;
+            else if (priceDiff <= 0.2) score += 10;
+
+            // Amenity overlap
+            const pAmenities = (p.amenities ?? []).map(
+              (a: PropertyAmenity) => a.name,
+            );
+            const overlap = sourceAmenities.filter((a) =>
+              pAmenities.includes(a),
+            ).length;
+            score += Math.min(10, overlap * 2);
+
+            return {
+              propertyId: p.id,
+              title: p.title,
+              city: p.city,
+              price: p.price,
+              bedrooms: p.bedrooms,
+              type: p.type,
+              similarityScore: score,
+            };
+          });
+
+        return scored
+          .sort((a, b) => b.similarityScore - a.similarityScore)
+          .slice(0, limit);
+      },
+      CACHE_TTL_SIMILAR,
+    );
+  }
+
+  async updatePreferences(userId: string, dto: UpdatePreferencesDto) {
+    let prefs = await this.preferencesRepo.findOne({ where: { userId } });
+
+    if (!prefs) {
+      prefs = this.preferencesRepo.create({ userId, ...dto });
+    } else {
+      Object.assign(prefs, dto);
+    }
+
+    const saved = await this.preferencesRepo.save(prefs);
+
+    // Bust recommendation cache on preference update
+    await this.cacheService.invalidate(`ai:recommendations:${userId}:*`);
+
+    return saved;
+  }
+
+  async getPreferences(userId: string) {
+    return this.preferencesRepo.findOne({ where: { userId } }) ?? null;
+  }
+}


### PR DESCRIPTION
## Summary

Implements a personalized property recommendation system that scores and ranks
properties based on user preferences, with caching and similarity matching.

this pr Closes #527 

## Changes

- New `MatchingAiService` with weighted scoring engine (city, budget, bedrooms,
  amenities, pets, parking, furnished) and cold-start fallback for new users
- New `UserPreferences` entity + migration (`user_ai_preferences` table) for
  persisting per-user matching preferences
- New `MatchingAiController` exposing 5 endpoints under `api/ai/matching`
- `AiModule` updated to register new entity, service, and controller
- Redis caching via existing `CacheService` (5min TTL for recommendations,
  10min for similar properties, auto-invalidated on preference update)

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /api/ai/matching/recommendations | Personalized ranked recommendations |
| GET | /api/ai/matching/match-score/:id | Match score for a specific property |
| GET | /api/ai/matching/similar/:id | Similar properties |
| POST | /api/ai/matching/preferences | Save user preferences |
| GET | /api/ai/matching/preferences | Get current preferences |

## How to test

# Run migration
pnpm run migration:run

# Get recommendations (requires JWT)
curl -H "Authorization: Bearer <token>" \
  "http://localhost:3000/api/ai/matching/recommendations?limit=10"

# Set preferences first for better results
curl -X POST -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"preferredCity":"Lagos","maxBudget":500000,"bedrooms":2}' \
  "http://localhost:3000/api/ai/matching/preferences"

## Notes

- Cold-start: new users with no preferences get latest published properties
- No ML model dependency — pure scoring logic, zero new npm packages required
- Scoring is additive with hard penalties for unmet hard requirements (pets, parking)
