### PR TITLE
Implement WebSocket session management

### DIFF
--- a/backend/src/modules/messaging/messaging.gateway.ts
+++ b/backend/src/modules/messaging/messaging.gateway.ts
@@ -7,10 +7,11 @@ import {
   OnGatewayConnection,
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
+import { Logger, UseGuards } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { MessagingService } from './messaging.service';
-import { UseGuards } from '@nestjs/common';
 import { RoomAccessGuard } from './room-access.guard';
+import { WebSocketSessionService } from './websocket-session.service';
 
 @WebSocketGateway({
   namespace: '/messaging',
@@ -22,34 +23,96 @@ export class MessagingGateway
   @WebSocketServer()
   server: Server;
 
-  constructor(private readonly messagingService: MessagingService) {}
+  private readonly logger = new Logger(MessagingGateway.name);
 
-  async handleConnection(_socket: Socket) {
-    // Authorization logic can be added here
+  constructor(
+    private readonly messagingService: MessagingService,
+    private readonly sessionService: WebSocketSessionService,
+  ) {}
+
+  async handleConnection(socket: Socket) {
+    try {
+      const userId = socket.handshake.query.userId as string;
+      if (!userId) {
+        this.logger.warn(`Connection rejected — no userId: ${socket.id}`);
+        socket.disconnect();
+        return;
+      }
+
+      const session = await this.sessionService.createSession(
+        userId,
+        socket.id,
+      );
+      socket.data.sessionId = session.id;
+      socket.data.userId = userId;
+
+      this.logger.log(
+        `Client connected: ${socket.id} | session: ${session.id}`,
+      );
+    } catch (err) {
+      this.logger.error(`handleConnection error: ${err.message}`);
+      socket.disconnect();
+    }
   }
 
-  async handleDisconnect(_socket: Socket) {
-    // Handle disconnect logic
+  async handleDisconnect(socket: Socket) {
+    if (socket.data.sessionId) {
+      await this.sessionService.deleteSession(socket.data.sessionId);
+    }
+    this.logger.log(`Client disconnected: ${socket.id}`);
   }
 
   @UseGuards(RoomAccessGuard)
   @SubscribeMessage('message:send')
   async handleMessageSend(
     @MessageBody() data: any,
-    @ConnectedSocket() _socket: Socket,
+    @ConnectedSocket() socket: Socket,
   ) {
+    const valid = await this.sessionService.validateSession(
+      socket.data.sessionId,
+    );
+    if (!valid) {
+      socket.emit('error', { message: 'Session expired or invalid' });
+      socket.disconnect();
+      return;
+    }
+
+    await this.sessionService.updateActivity(socket.data.sessionId);
+
     const message = await this.messagingService.saveMessage(data);
     this.server.to(data.chatGroupId).emit('message:receive', message);
     return message;
   }
 
   @SubscribeMessage('typing:start')
-  handleTypingStart(@MessageBody() data: any) {
+  async handleTypingStart(
+    @MessageBody() data: any,
+    @ConnectedSocket() socket: Socket,
+  ) {
+    await this.sessionService.updateActivity(socket.data.sessionId);
     this.server.to(data.chatGroupId).emit('typing:start', data);
   }
 
   @SubscribeMessage('typing:stop')
-  handleTypingStop(@MessageBody() data: any) {
+  async handleTypingStop(
+    @MessageBody() data: any,
+    @ConnectedSocket() socket: Socket,
+  ) {
+    await this.sessionService.updateActivity(socket.data.sessionId);
     this.server.to(data.chatGroupId).emit('typing:stop', data);
+  }
+
+  @SubscribeMessage('session:ping')
+  async handlePing(@ConnectedSocket() socket: Socket) {
+    const valid = await this.sessionService.validateSession(
+      socket.data.sessionId,
+    );
+    if (!valid) {
+      socket.emit('session:expired');
+      socket.disconnect();
+      return;
+    }
+    await this.sessionService.updateActivity(socket.data.sessionId);
+    return { status: 'ok', sessionId: socket.data.sessionId };
   }
 }

--- a/backend/src/modules/messaging/messaging.module.ts
+++ b/backend/src/modules/messaging/messaging.module.ts
@@ -1,14 +1,21 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MessagingGateway } from './messaging.gateway';
 import { MessagingService } from './messaging.service';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { WebSocketSessionService } from './websocket-session.service';
 import { Message } from './entities/message.entity';
 import { ChatRoom } from './entities/chat-room.entity';
 import { Participant } from './entities/participant.entity';
+import { CacheService } from '../../common/cache/cache.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Message, ChatRoom, Participant])],
-  providers: [MessagingGateway, MessagingService],
-  exports: [MessagingService],
+  providers: [
+    MessagingGateway,
+    MessagingService,
+    WebSocketSessionService,
+    CacheService,
+  ],
+  exports: [MessagingService, WebSocketSessionService],
 })
 export class MessagingModule {}

--- a/backend/src/modules/messaging/websocket-session.service.spec.ts
+++ b/backend/src/modules/messaging/websocket-session.service.spec.ts
@@ -1,0 +1,212 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebSocketSessionService } from './websocket-session.service';
+import { CacheService } from '../../common/cache/cache.service';
+
+const mockCacheService = {
+  get: jest.fn(),
+  set: jest.fn(),
+  invalidate: jest.fn(),
+};
+
+describe('WebSocketSessionService', () => {
+  let service: WebSocketSessionService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebSocketSessionService,
+        { provide: CacheService, useValue: mockCacheService },
+      ],
+    }).compile();
+
+    service = module.get<WebSocketSessionService>(WebSocketSessionService);
+  });
+
+  describe('createSession', () => {
+    it('creates and stores a session', async () => {
+      mockCacheService.get.mockResolvedValue(null); // no existing connections
+      mockCacheService.set.mockResolvedValue(undefined);
+
+      const session = await service.createSession('user-1', 'conn-1');
+
+      expect(session.userId).toBe('user-1');
+      expect(session.connectionId).toBe('conn-1');
+      expect(session.id).toBeDefined();
+      expect(mockCacheService.set).toHaveBeenCalledTimes(2); // session + user connections
+    });
+
+    it('evicts oldest session when max connections exceeded', async () => {
+      const existingIds = ['s1', 's2', 's3', 's4', 's5'];
+      const existingSessions = existingIds.map((id) => ({
+        id,
+        userId: 'user-1',
+        connectionId: `conn-${id}`,
+        connectedAt: new Date(Date.now() - 10000).toISOString(),
+        lastActivity: new Date().toISOString(),
+        metadata: {},
+      }));
+
+      mockCacheService.get
+        .mockResolvedValueOnce(existingIds) // getUserConnectionIds for count
+        .mockResolvedValueOnce(existingIds) // getUserConnectionIds for evict
+        .mockResolvedValueOnce(existingSessions[0]) // getSession for oldest
+        .mockResolvedValueOnce(existingSessions[1])
+        .mockResolvedValueOnce(existingSessions[2])
+        .mockResolvedValueOnce(existingSessions[3])
+        .mockResolvedValueOnce(existingSessions[4])
+        .mockResolvedValueOnce(existingSessions[0]) // deleteSession getSession
+        .mockResolvedValue(null);
+
+      mockCacheService.set.mockResolvedValue(undefined);
+      mockCacheService.invalidate.mockResolvedValue(undefined);
+
+      const session = await service.createSession('user-1', 'conn-new');
+      expect(session.userId).toBe('user-1');
+      expect(mockCacheService.invalidate).toHaveBeenCalled();
+    });
+  });
+
+  describe('getSession', () => {
+    it('returns session from cache', async () => {
+      const mockSession = {
+        id: 'sess-1',
+        userId: 'user-1',
+        connectionId: 'conn-1',
+        connectedAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        metadata: {},
+      };
+      mockCacheService.get.mockResolvedValue(mockSession);
+
+      const result = await service.getSession('sess-1');
+      expect(result).toEqual(mockSession);
+    });
+
+    it('returns null when session not found', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      const result = await service.getSession('nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateSession', () => {
+    it('returns true for active session', async () => {
+      const session = {
+        id: 'sess-1',
+        userId: 'user-1',
+        connectionId: 'conn-1',
+        connectedAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        metadata: {},
+      };
+      mockCacheService.get.mockResolvedValue(session);
+
+      const result = await service.validateSession('sess-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns false and deletes session when idle timeout exceeded', async () => {
+      const session = {
+        id: 'sess-1',
+        userId: 'user-1',
+        connectionId: 'conn-1',
+        connectedAt: new Date(Date.now() - 31 * 60 * 1000).toISOString(),
+        lastActivity: new Date(Date.now() - 31 * 60 * 1000).toISOString(), // 31 min ago
+        metadata: {},
+      };
+      mockCacheService.get
+        .mockResolvedValueOnce(session) // validateSession
+        .mockResolvedValueOnce(session) // deleteSession -> getSession
+        .mockResolvedValue([]); // removeUserConnection
+
+      mockCacheService.set.mockResolvedValue(undefined);
+      mockCacheService.invalidate.mockResolvedValue(undefined);
+
+      const result = await service.validateSession('sess-1');
+      expect(result).toBe(false);
+      expect(mockCacheService.invalidate).toHaveBeenCalledWith(
+        'ws-session:sess-1',
+      );
+    });
+
+    it('returns false when session does not exist', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      const result = await service.validateSession('nonexistent');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateActivity', () => {
+    it('updates lastActivity and resets TTL', async () => {
+      const session = {
+        id: 'sess-1',
+        userId: 'user-1',
+        connectionId: 'conn-1',
+        connectedAt: new Date().toISOString(),
+        lastActivity: new Date(Date.now() - 5000).toISOString(),
+        metadata: {},
+      };
+      mockCacheService.get.mockResolvedValue(session);
+      mockCacheService.set.mockResolvedValue(undefined);
+
+      await service.updateActivity('sess-1');
+
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        'ws-session:sess-1',
+        expect.objectContaining({ id: 'sess-1' }),
+        expect.any(Number),
+      );
+    });
+
+    it('does nothing when session not found', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      await service.updateActivity('nonexistent');
+      expect(mockCacheService.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('removes session and user connection tracking', async () => {
+      const session = {
+        id: 'sess-1',
+        userId: 'user-1',
+        connectionId: 'conn-1',
+        connectedAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        metadata: {},
+      };
+      mockCacheService.get
+        .mockResolvedValueOnce(session)
+        .mockResolvedValue(['sess-1']);
+      mockCacheService.set.mockResolvedValue(undefined);
+      mockCacheService.invalidate.mockResolvedValue(undefined);
+
+      await service.deleteSession('sess-1');
+
+      expect(mockCacheService.invalidate).toHaveBeenCalledWith(
+        'ws-session:sess-1',
+      );
+    });
+  });
+
+  describe('getUserSessions', () => {
+    it('returns all active sessions for a user', async () => {
+      const session = {
+        id: 'sess-1',
+        userId: 'user-1',
+        connectionId: 'conn-1',
+        connectedAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        metadata: {},
+      };
+      mockCacheService.get
+        .mockResolvedValueOnce(['sess-1'])
+        .mockResolvedValueOnce(session);
+
+      const result = await service.getUserSessions('user-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('sess-1');
+    });
+  });
+});

--- a/backend/src/modules/messaging/websocket-session.service.ts
+++ b/backend/src/modules/messaging/websocket-session.service.ts
@@ -1,0 +1,187 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { CacheService } from '../../common/cache/cache.service';
+
+export interface WebSocketSession {
+  id: string;
+  userId: string;
+  connectionId: string;
+  connectedAt: string;
+  lastActivity: string;
+  metadata: Record<string, any>;
+}
+
+const SESSION_PREFIX = 'ws-session';
+const USER_CONNECTIONS_PREFIX = 'ws-user-connections';
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours absolute
+const IDLE_TTL_MS = 30 * 60 * 1000; // 30 min idle
+const MAX_CONNECTIONS_PER_USER = 5;
+
+@Injectable()
+export class WebSocketSessionService {
+  private readonly logger = new Logger(WebSocketSessionService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  // ─── Session CRUD ────────────────────────────────────────────────────────────
+
+  async createSession(
+    userId: string,
+    connectionId: string,
+  ): Promise<WebSocketSession> {
+    const connectionCount = await this.getUserConnectionCount(userId);
+    if (connectionCount >= MAX_CONNECTIONS_PER_USER) {
+      this.logger.warn(
+        `User ${userId} exceeded max connections (${MAX_CONNECTIONS_PER_USER})`,
+      );
+      // Evict oldest connection
+      await this.evictOldestConnection(userId);
+    }
+
+    const session: WebSocketSession = {
+      id: randomUUID(),
+      userId,
+      connectionId,
+      connectedAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      metadata: {},
+    };
+
+    await this.cacheService.set(
+      `${SESSION_PREFIX}:${session.id}`,
+      session,
+      SESSION_TTL_MS,
+    );
+
+    await this.trackUserConnection(userId, session.id);
+
+    this.logger.log(`Session created: ${session.id} for user ${userId}`);
+    return session;
+  }
+
+  async getSession(sessionId: string): Promise<WebSocketSession | null> {
+    return this.cacheService.get<WebSocketSession>(
+      `${SESSION_PREFIX}:${sessionId}`,
+    );
+  }
+
+  async getSessionByConnectionId(
+    connectionId: string,
+  ): Promise<WebSocketSession | null> {
+    // Scan user connections to find by connectionId — used on disconnect
+    // In practice the gateway stores sessionId on socket.data so this is a fallback
+    return null;
+  }
+
+  async updateActivity(sessionId: string): Promise<void> {
+    const session = await this.getSession(sessionId);
+    if (!session) return;
+
+    session.lastActivity = new Date().toISOString();
+
+    // Reset idle TTL on activity, but cap at absolute TTL from connectedAt
+    const connectedAt = new Date(session.connectedAt).getTime();
+    const absoluteRemaining = SESSION_TTL_MS - (Date.now() - connectedAt);
+    const ttl = Math.min(IDLE_TTL_MS, absoluteRemaining);
+
+    if (ttl <= 0) {
+      await this.deleteSession(sessionId);
+      return;
+    }
+
+    await this.cacheService.set(`${SESSION_PREFIX}:${sessionId}`, session, ttl);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const session = await this.getSession(sessionId);
+    if (session) {
+      await this.removeUserConnection(session.userId, sessionId);
+    }
+    await this.cacheService.invalidate(`${SESSION_PREFIX}:${sessionId}`);
+    this.logger.log(`Session deleted: ${sessionId}`);
+  }
+
+  async validateSession(sessionId: string): Promise<boolean> {
+    const session = await this.getSession(sessionId);
+    if (!session) return false;
+
+    // Check idle timeout
+    const idleMs = Date.now() - new Date(session.lastActivity).getTime();
+    if (idleMs > IDLE_TTL_MS) {
+      await this.deleteSession(sessionId);
+      return false;
+    }
+
+    return true;
+  }
+
+  // ─── Multi-connection tracking ───────────────────────────────────────────────
+
+  async getUserSessions(userId: string): Promise<WebSocketSession[]> {
+    const sessionIds = await this.getUserConnectionIds(userId);
+    const sessions = await Promise.all(
+      sessionIds.map((id) => this.getSession(id)),
+    );
+    return sessions.filter(Boolean) as WebSocketSession[];
+  }
+
+  async getUserConnectionCount(userId: string): Promise<number> {
+    const ids = await this.getUserConnectionIds(userId);
+    return ids.length;
+  }
+
+  async deleteAllUserSessions(userId: string): Promise<void> {
+    const sessionIds = await this.getUserConnectionIds(userId);
+    await Promise.all(sessionIds.map((id) => this.deleteSession(id)));
+    await this.cacheService.invalidate(`${USER_CONNECTIONS_PREFIX}:${userId}`);
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────────────────
+
+  private async getUserConnectionIds(userId: string): Promise<string[]> {
+    return (
+      (await this.cacheService.get<string[]>(
+        `${USER_CONNECTIONS_PREFIX}:${userId}`,
+      )) ?? []
+    );
+  }
+
+  private async trackUserConnection(
+    userId: string,
+    sessionId: string,
+  ): Promise<void> {
+    const ids = await this.getUserConnectionIds(userId);
+    ids.push(sessionId);
+    await this.cacheService.set(
+      `${USER_CONNECTIONS_PREFIX}:${userId}`,
+      ids,
+      SESSION_TTL_MS,
+    );
+  }
+
+  private async removeUserConnection(
+    userId: string,
+    sessionId: string,
+  ): Promise<void> {
+    const ids = await this.getUserConnectionIds(userId);
+    const updated = ids.filter((id) => id !== sessionId);
+    await this.cacheService.set(
+      `${USER_CONNECTIONS_PREFIX}:${userId}`,
+      updated,
+      SESSION_TTL_MS,
+    );
+  }
+
+  private async evictOldestConnection(userId: string): Promise<void> {
+    const sessions = await this.getUserSessions(userId);
+    if (!sessions.length) return;
+
+    const oldest = sessions.sort(
+      (a, b) =>
+        new Date(a.connectedAt).getTime() - new Date(b.connectedAt).getTime(),
+    )[0];
+
+    this.logger.warn(`Evicting oldest session ${oldest.id} for user ${userId}`);
+    await this.deleteSession(oldest.id);
+  }
+}


### PR DESCRIPTION
## Summary

Implements WebSocket session management for the messaging gateway, replacing
the empty connection/disconnect handlers with a full session lifecycle.

this pr Closes #508 

## Changes

- New `WebSocketSessionService` — creates, validates, updates, and deletes
  sessions backed by Redis via the existing `CacheService`
- Idle timeout: 30 minutes | Absolute timeout: 24 hours
- Multi-connection support per user with a cap of 5 — oldest session auto-evicted
- Updated `MessagingGateway` — session created on connect, validated and
  refreshed on every message, cleaned up on disconnect
- Added `session:ping` event for clients to keep sessions alive
- `MessagingModule` updated to register `WebSocketSessionService` and `CacheService`
- Unit tests covering: create, get, validate, updateActivity, delete, getUserSessions

## Session Keys (Redis)

- ws-session:<sessionId>
- ws-user-connections:<userId>

## Testing

pnpm run test --testPathPattern=websocket-session
