### PR TITLE
docs: add API documentation standards, backend docs index, and demo c……redentials on signup

### DIFF
--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -1,188 +1,205 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# Chioma Backend Documentation
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Welcome to the Chioma backend documentation hub. This index covers all aspects of the NestJS API service, from local setup to production operations.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+---
 
-## Description
+## Navigation
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+| Category | Description |
+|---|---|
+| [Getting Started](#getting-started) | Prerequisites, local setup, environment config |
+| [API Reference](#api-reference) | Endpoint docs, standards, versioning, changelog |
+| [Architecture](#architecture) | System design, dependency graph, performance |
+| [Database](#database) | Schema, migrations, indexes |
+| [Blockchain](#blockchain) | Stellar integration, anchor, SEP-0010 auth |
+| [Caching](#caching) | Redis/Upstash strategy, invalidation, monitoring |
+| [Queues](#queues) | Bull queue implementation |
+| [Deployment](#deployment) | Production setup, Docker, CI/CD |
+| [Security](#security) | Encryption, threat model, compliance |
+| [Integrations](#integrations) | Third-party services |
+| [Community](#community) | Contributing, code of conduct, team policies |
 
-## Project setup
+---
+
+## Getting Started
+
+| Document | Summary |
+|---|---|
+| [Quick Start](./setup/QUICK_START.md) | Run the backend locally in under 5 minutes |
+| [Demo Credentials](./setup/DEMO_CREDENTIALS.md) | Pre-seeded accounts for local testing |
+| [Demo Login](./setup/DEMO_LOGIN.md) | Step-by-step demo login guide |
+| [Neon DB Credentials](./setup/GET_NEON_CREDENTIALS.md) | Connect to Neon serverless PostgreSQL |
+| [Seeding](./setup/SEEDING_COMPLETE.md) | Seed scripts and initial data |
+
+**Quickest path to running locally:**
 
 ```bash
-$ pnpm install
-```
-
-## Compile and run the project
-
-```bash
-# development
-$ pnpm run start
-
-# watch mode
-$ pnpm run start:dev
-
-# production mode
-$ pnpm run start:prod
-```
-
-```Docker
+# Clone and install
 cd backend
+pnpm install
+
+# Copy env and configure
+cp .env.example .env.development
+
+# Start services
 docker-compose up -d
+
+# Run migrations and seed
 pnpm run migration:run
-```
-
-## Seed initial admin user
-
-```bash
-# Create admin with defaults
 pnpm run seed:admin
-
-# Create admin with custom credentials
-pnpm run seed:admin -- --email admin@example.com --password SecurePass123!
-
-# Force update existing admin (recommended for production automation)
-pnpm run seed:admin:prod
 ```
 
-Admin seed defaults can be configured with environment variables:
+The API will be available at `http://localhost:5000/api` and Swagger UI at `http://localhost:5000/api/docs`.
 
-```dotenv
-ADMIN_DEFAULT_EMAIL=admin@chioma.local
-ADMIN_DEFAULT_FIRST_NAME=System
-ADMIN_DEFAULT_LAST_NAME=Administrator
-ADMIN_AUTO_GENERATE_PASSWORD=true
-```
+---
 
-Docker deployment integration example:
+## API Reference
 
-```dockerfile
-RUN pnpm run seed:admin:prod
-```
+| Document | Summary |
+|---|---|
+| [API Overview](./api/api-documentation.md) | Base URL, auth, all endpoint groups |
+| [API Standards](./api/API-STANDARDS.md) | Annotation conventions, request/response formats |
+| [Authentication Guide](./api/AUTHENTICATION.md) | JWT flow, SEP-0010, refresh tokens |
+| [Error Codes](./api/ERROR-CODES.md) | All error codes, HTTP status mapping, examples |
+| [Rate Limiting](./api/RATE-LIMITING.md) | Limits, quotas, headers, retry guidance |
+| [Pagination](./api/PAGINATION.md) | Cursor and offset pagination standards |
+| [API Versioning](./api/API-VERSIONING.md) | URI versioning strategy and deprecation policy |
+| [API Changelog](./api/API-CHANGELOG.md) | History of breaking and non-breaking changes |
+| [SDK Generation](./api/SDK-GENERATION.md) | Auto-generate client SDKs from OpenAPI spec |
+| [Webhook Verification](./api/WEBHOOK_SIGNATURE_VERIFICATION.md) | Validate incoming webhook payloads |
 
-## Run tests
+**Swagger UI** is served at `/api/docs` and is auto-generated from NestJS `@ApiProperty` / `@ApiOperation` decorators — it always reflects the current codebase.
+
+---
+
+## Architecture
+
+| Document | Summary |
+|---|---|
+| [Dependency Graph](./architecture/DEPENDENCY_GRAPH.md) | Module dependency overview |
+| [Scalability & Performance](./architecture/scalability-and-performance.md) | Horizontal scaling, caching layers, DB tuning |
+
+**Key design decisions:**
+- NestJS modular monolith with domain-scoped modules (`auth`, `agreements`, `payments`, …)
+- URI-based API versioning (`/api/v1/...`); `defaultVersion: '1'`
+- JWT + Stellar SEP-0010 dual auth
+- TypeORM + PostgreSQL (Neon serverless in production)
+- Bull queues via Redis for async jobs
+
+---
+
+## Database
+
+| Document | Summary |
+|---|---|
+| [Performance Indexes](./database/PERFORMANCE_INDEXES.md) | Index strategy for high-traffic queries |
+
+Migrations live in `backend/migrations/`. Run with:
 
 ```bash
-# unit tests
-$ pnpm run test
-
-# e2e tests
-$ pnpm run test:e2e
-
-# test coverage
-$ pnpm run test:cov
+pnpm run migration:run       # apply pending migrations
+pnpm run migration:revert    # roll back last migration
+pnpm run migration:generate  # generate migration from entity changes
 ```
 
-### Backend Pipeline Checks
+---
 
-The backend also includes a comprehensive Makefile for CI/CD validation.
+## Blockchain
 
-#### Backend Quick Start
+| Document | Summary |
+|---|---|
+| [Stellar Auth (SEP-0010)](./blockchain/stellar-auth.md) | Wallet-based authentication flow |
+| [Anchor Integration Guide](./blockchain/anchor-integration-guide.md) | Fiat on/off-ramp via Stellar anchors |
+| [Anchor Implementation](./blockchain/ANCHOR_IMPLEMENTATION.md) | Internal implementation notes |
+| [Anchor Integration](./blockchain/anchor-integration.md) | Additional anchor setup details |
+| [Payment Gateway](./blockchain/payment-gateway-integration.md) | Stellar payment processing |
 
-```bash
-cd ../backend
+---
 
-# Run full CI pipeline (matches GitHub Actions)
-make ci
+## Caching
 
-# Run all backend workflows (CI + security)
-make all
+| Document | Summary |
+|---|---|
+| [Overview](./caching/README.md) | Cache architecture |
+| [Strategy](./caching/strategy.md) | TTL policies, cache keys |
+| [Invalidation](./caching/invalidation.md) | Cache invalidation patterns |
+| [Monitoring](./caching/monitoring.md) | Cache hit rates and observability |
+| [Examples](./caching/examples.md) | Code examples using `@Cached` decorator |
+| [Troubleshooting](./caching/troubleshooting.md) | Common cache issues |
 
-# Get help with all available commands
-make help
-```
+---
 
-#### Key Backend Commands
+## Queues
 
-```bash
-# Main pipeline commands
-make ci              # Full CI pipeline: install, format-check, lint, typecheck, test-cov, build
-make security-ci     # Security pipeline: install, security-lint, security-test, build
-make all             # Run all CI/CD pipelines
+| Document | Summary |
+|---|---|
+| [Bull Queues](./queues/BULL_QUEUES_IMPLEMENTATION.md) | Queue setup, workers, job types |
+| [Implementation Summary](./queues/IMPLEMENTATION_SUMMARY.md) | Summary of queue usage |
 
-# Individual checks
-make lint            # Run ESLint
-make format-check    # Check Prettier formatting
-make typecheck       # TypeScript type checking
-make test            # Run unit tests
-make test-cov        # Run tests with coverage
-make test-e2e        # Run E2E tests (requires PostgreSQL)
-make build           # Build the application
-
-# Pre-commit workflow
-make pre-commit      # Run format-check, lint, typecheck, test
-```
-
-### Before Creating a PR
-
-Run these commands to ensure your PR will pass all pipeline checks:
-
-```bash
-# Frontend checks
-cd frontend
-make check
-
-# Backend checks (if you changed backend code)
-cd ../backend
-make ci
-```
-
-Makefile is designed to replicate the exact same checks that run in GitHub Actions, giving you confidence that your PR will pass the CI/CD pipeline.
+---
 
 ## Deployment
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+| Document | Summary |
+|---|---|
+| [Deployment Guide](./deployment/DEPLOYMENT.md) | Step-by-step deployment |
+| [Production Setup](./deployment/PRODUCTION_SETUP.md) | Environment config, secrets, health checks |
 
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+Docker Compose files:
+- `docker-compose.yml` — local development
+- `docker-compose.production.yml` — production
+- `docker-compose.monitoring.yml` — Prometheus + Grafana
+- `docker-compose.docs.yml` — serve docs locally
+
+---
+
+## Security
+
+| Document | Summary |
+|---|---|
+| [Encryption](./encryption.md) | Field-level encryption for sensitive data |
+| [Tenant Screening Compliance](./compliance/TENANT_SCREENING_COMPLIANCE.md) | FCRA / compliance notes |
+
+Security features active in every request:
+- Helmet security headers
+- CSRF token validation
+- Request size limits (1 MB JSON / URL-encoded)
+- Rate limiting via NestJS Throttler
+- Threat detection middleware
+- Audit logging for privileged operations
+
+---
+
+## Integrations
+
+| Document | Summary |
+|---|---|
+| [Tenant Screening](./integrations/TENANT_SCREENING_PROVIDER_RESEARCH.md) | Third-party screening providers |
+| [Tenant Screening Integration](./api/TENANT_SCREENING_INTEGRATION.md) | API integration guide |
+
+---
+
+## Community
+
+| Document | Summary |
+|---|---|
+| [Contributing](./community/CONTRIBUTING.md) | How to contribute |
+| [Contribution Guidelines](./community/CONTRIBUTION_GUIDELINES.md) | Detailed guidelines |
+| [Code of Conduct](./community/CODE_OF_CONDUCT.md) | Community standards |
+| [Community Support](./community/COMMUNITY-SUPPORT.md) | Where to get help |
+| [Team Policies](./community/TEAM_POLICIES.md) | Internal team standards |
+
+---
+
+## Makefile Reference
 
 ```bash
-$ pnpm install -g @nestjs/mau
-$ mau deploy
+make ci          # Full CI: install → format-check → lint → typecheck → test-cov → build
+make lint        # ESLint
+make typecheck   # tsc --noEmit
+make test        # Jest unit tests
+make test-e2e    # E2E tests (requires PostgreSQL)
+make build       # Compile TypeScript
+make pre-commit  # format-check + lint + typecheck + test
 ```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).

--- a/backend/docs/api/API-STANDARDS.md
+++ b/backend/docs/api/API-STANDARDS.md
@@ -1,0 +1,241 @@
+# Chioma API Documentation Standards
+
+This document defines the conventions all backend engineers must follow when adding or modifying API endpoints. Following these standards keeps Swagger/OpenAPI output accurate and consistent.
+
+---
+
+## 1. Swagger/OpenAPI Annotations
+
+Every public endpoint **must** carry the following decorators from `@nestjs/swagger`.
+
+### Controller level
+
+```typescript
+@ApiTags('Payments')                       // groups endpoints in Swagger UI
+@ApiBearerAuth('JWT-auth')                 // shows the padlock icon
+@Controller('payments')
+export class PaymentsController {}
+```
+
+### Method level (minimum required set)
+
+```typescript
+@ApiOperation({
+  summary: 'Initiate a rent payment',
+  description:
+    'Creates a pending payment record and returns a Stellar transaction ' +
+    'envelope for the client to sign. Idempotent when an `Idempotency-Key` ' +
+    'header is provided.',
+})
+@ApiResponse({ status: 201, description: 'Payment initiated', type: PaymentResponseDto })
+@ApiResponse({ status: 400, description: 'Validation error', type: ErrorResponseDto })
+@ApiResponse({ status: 401, description: 'Unauthenticated' })
+@ApiResponse({ status: 422, description: 'Business rule violation', type: ErrorResponseDto })
+@Post()
+async initiatePayment(@Body() dto: InitiatePaymentDto): Promise<PaymentResponseDto> {}
+```
+
+### DTO level
+
+Every DTO property must have `@ApiProperty` (or `@ApiPropertyOptional` for optional fields):
+
+```typescript
+export class InitiatePaymentDto {
+  @ApiProperty({
+    description: 'Agreement ID this payment is for',
+    example: 'agr_01HN7K3P2X',
+  })
+  @IsString()
+  agreementId: string;
+
+  @ApiProperty({
+    description: 'Amount in stroops (1 XLM = 10,000,000 stroops)',
+    example: 5000000000,
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  amountStroops: number;
+
+  @ApiPropertyOptional({
+    description: 'Memo to attach to the Stellar transaction',
+    maxLength: 28,
+    example: 'Rent April 2025',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(28)
+  memo?: string;
+}
+```
+
+---
+
+## 2. HTTP Status Codes
+
+| Scenario | Status |
+|---|---|
+| Successful GET / list | 200 |
+| Resource created | 201 |
+| No content (DELETE success) | 204 |
+| Validation / schema error | 400 |
+| Unauthenticated | 401 |
+| Authenticated but not authorised | 403 |
+| Resource not found | 404 |
+| Conflict (duplicate, state clash) | 409 |
+| Business rule violation | 422 |
+| Rate limit exceeded | 429 |
+| Unexpected server error | 500 |
+| Downstream service unavailable | 503 |
+
+---
+
+## 3. Request / Response Format
+
+### Success response (single resource)
+
+```json
+{
+  "id": "pay_01HN7K3P2X",
+  "status": "PENDING",
+  "amountStroops": 5000000000,
+  "currency": "XLM",
+  "createdAt": "2025-04-01T09:30:00Z"
+}
+```
+
+### Success response (paginated list)
+
+```json
+{
+  "data": [ { "id": "pay_01HN7K3P2X", "status": "PENDING" } ],
+  "meta": {
+    "total": 142,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 8
+  }
+}
+```
+
+### Error response
+
+All error responses follow the `ErrorResponseDto` shape:
+
+```json
+{
+  "statusCode": 422,
+  "error": "PAYMENT_AMOUNT_BELOW_MINIMUM",
+  "message": "Payment amount must be at least 1 stroop.",
+  "timestamp": "2025-04-01T09:30:00Z",
+  "path": "/api/payments",
+  "requestId": "req_a1b2c3d4"
+}
+```
+
+The `error` field is a stable machine-readable code. See [ERROR-CODES.md](./ERROR-CODES.md) for the full registry.
+
+---
+
+## 4. Authentication Documentation
+
+Every protected endpoint must include:
+
+1. `@ApiBearerAuth('JWT-auth')` on the controller or individual method.
+2. An `@ApiResponse({ status: 401, description: 'Unauthenticated' })`.
+3. An `@ApiResponse({ status: 403, description: 'Insufficient permissions' })` if role checks apply.
+
+Public endpoints (e.g. health check, Stellar challenge) must be explicitly marked:
+
+```typescript
+@ApiSecurity([])  // overrides controller-level ApiBearerAuth
+@Get('challenge')
+async getChallenge() {}
+```
+
+---
+
+## 5. Pagination
+
+Use `PaginationQueryDto` for all list endpoints:
+
+```typescript
+@ApiQuery({ name: 'page', required: false, example: 1 })
+@ApiQuery({ name: 'limit', required: false, example: 20 })
+@Get()
+async list(@Query() query: PaginationQueryDto) {}
+```
+
+See [PAGINATION.md](./PAGINATION.md) for cursor-based pagination used on high-throughput resources.
+
+---
+
+## 6. Filtering & Sorting
+
+Document every supported query parameter explicitly:
+
+```typescript
+@ApiQuery({ name: 'status', enum: PaymentStatus, required: false })
+@ApiQuery({ name: 'from', description: 'ISO 8601 start date', required: false, example: '2025-01-01' })
+@ApiQuery({ name: 'to',   description: 'ISO 8601 end date',   required: false, example: '2025-03-31' })
+@ApiQuery({ name: 'sort', enum: ['createdAt', '-createdAt', 'amount', '-amount'], required: false })
+```
+
+A `-` prefix on a sort field means descending order.
+
+---
+
+## 7. Idempotency
+
+Endpoints that create or mutate resources should support an `Idempotency-Key` header:
+
+```typescript
+@ApiHeader({
+  name: 'Idempotency-Key',
+  description:
+    'Client-generated unique key (UUID v4). Repeated requests with the same ' +
+    'key within 24 hours return the original response without re-executing.',
+  required: false,
+  example: '550e8400-e29b-41d4-a716-446655440000',
+})
+```
+
+---
+
+## 8. Deprecating an Endpoint
+
+1. Add `deprecated: true` to the `@ApiOperation` decorator.
+2. Add a `@ApiHeader` noting the replacement.
+3. Log a warning in the controller if the deprecated path is hit.
+4. Record the deprecation in [API-CHANGELOG.md](./API-CHANGELOG.md) with a sunset date.
+
+```typescript
+@ApiOperation({
+  summary: '[DEPRECATED] Get payment — use GET /api/payments/:id instead',
+  deprecated: true,
+})
+```
+
+---
+
+## 9. Auto-Generation
+
+The OpenAPI JSON spec is generated at application boot by `SwaggerModule.createDocument`. To export a static copy:
+
+```bash
+pnpm run generate:openapi   # writes openapi.json to project root
+```
+
+Client SDKs can be generated from this spec — see [SDK-GENERATION.md](./SDK-GENERATION.md).
+
+---
+
+## 10. Reviewing API Documentation
+
+PR reviewers must verify:
+
+- [ ] All new endpoints have `@ApiTags`, `@ApiOperation`, and at least one `@ApiResponse`.
+- [ ] All DTO properties have `@ApiProperty` with `description` and `example`.
+- [ ] New error codes are added to [ERROR-CODES.md](./ERROR-CODES.md).
+- [ ] Breaking changes are recorded in [API-CHANGELOG.md](./API-CHANGELOG.md).
+- [ ] Rate-limited endpoints are documented in [RATE-LIMITING.md](./RATE-LIMITING.md).

--- a/backend/docs/api/AUTHENTICATION.md
+++ b/backend/docs/api/AUTHENTICATION.md
@@ -1,0 +1,230 @@
+# Authentication Guide
+
+Chioma supports two authentication methods: **JWT (email/password)** and **Stellar SEP-0010 (wallet-based)**. Both methods issue a JWT access token that is used the same way in subsequent requests.
+
+---
+
+## 1. JWT Authentication (Email / Password)
+
+### Register
+
+```
+POST /api/auth/register
+```
+
+**Request body:**
+
+```json
+{
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "email": "jane@example.com",
+  "password": "SecurePass123!",
+  "role": "TENANT"
+}
+```
+
+**Success — 201:**
+
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "rt_...",
+  "user": {
+    "id": "usr_01HN7K",
+    "email": "jane@example.com",
+    "role": "tenant",
+    "firstName": "Jane",
+    "lastName": "Doe"
+  }
+}
+```
+
+**Error codes:** `USER_ALREADY_EXISTS` (409), `VALIDATION_ERROR` (400).
+
+---
+
+### Login
+
+```
+POST /api/auth/login
+```
+
+**Request body:**
+
+```json
+{
+  "email": "jane@example.com",
+  "password": "SecurePass123!"
+}
+```
+
+**Success — 200:** Same shape as the register response.
+
+**Error codes:** `INVALID_CREDENTIALS` (401), `USER_SOFT_DELETED` (403), `MFA_REQUIRED` (403).
+
+---
+
+### Refresh Access Token
+
+```
+POST /api/auth/refresh
+```
+
+**Request body:**
+
+```json
+{ "refreshToken": "rt_..." }
+```
+
+**Success — 200:**
+
+```json
+{
+  "accessToken": "eyJhbGci...",
+  "refreshToken": "rt_newtoken..."
+}
+```
+
+**Error codes:** `REFRESH_TOKEN_EXPIRED` (401), `TOKEN_INVALID` (401).
+
+---
+
+### Logout
+
+```
+POST /api/auth/logout
+Authorization: Bearer <access_token>
+```
+
+Invalidates the current refresh token server-side. Returns 204 on success.
+
+---
+
+## 2. Stellar SEP-0010 Authentication (Wallet)
+
+This flow implements [SEP-0010](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) for wallet-based authentication without a password.
+
+### Step 1 — Request a challenge
+
+```
+GET /api/auth/stellar/challenge?account=G...
+```
+
+**Response — 200:**
+
+```json
+{
+  "transaction": "AAAAAgAAAAB...",
+  "networkPassphrase": "Test SDF Network ; September 2015"
+}
+```
+
+The `transaction` is a Stellar transaction envelope that must be signed by the wallet's private key.
+
+### Step 2 — Sign and submit
+
+Sign the transaction with the Stellar keypair, then POST the signed envelope:
+
+```
+POST /api/auth/stellar/verify
+```
+
+**Request body:**
+
+```json
+{
+  "transaction": "AAAAAgAAAAB...<signed>",
+  "account": "GABC...XYZ"
+}
+```
+
+**Success — 200:** Same JWT response shape as email login.
+
+**Error codes:** `STELLAR_CHALLENGE_INVALID` (401), `STELLAR_CHALLENGE_EXPIRED` (401).
+
+---
+
+## 3. Using the Access Token
+
+Include the JWT in every protected request:
+
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+Token lifetime: **15 minutes** (configurable via `JWT_EXPIRATION`).
+Refresh token lifetime: **7 days** (configurable via `JWT_REFRESH_EXPIRATION`).
+
+---
+
+## 4. Multi-Factor Authentication (MFA)
+
+When MFA is enabled on an account, login returns a `MFA_REQUIRED` (403) response with a `mfaToken` instead of a full JWT:
+
+```json
+{
+  "statusCode": 403,
+  "error": "MFA_REQUIRED",
+  "mfaToken": "mfa_01HN7K..."
+}
+```
+
+Complete the challenge:
+
+```
+POST /api/auth/mfa/verify
+```
+
+```json
+{
+  "mfaToken": "mfa_01HN7K...",
+  "code": "123456"
+}
+```
+
+On success, returns the standard JWT response.
+
+---
+
+## 5. Password Reset
+
+```
+POST /api/auth/forgot-password
+```
+
+```json
+{ "email": "jane@example.com" }
+```
+
+Returns 200 regardless of whether the email exists (prevents enumeration).
+
+```
+POST /api/auth/reset-password
+```
+
+```json
+{
+  "token": "<reset_token_from_email>",
+  "password": "NewSecurePass123!"
+}
+```
+
+---
+
+## 6. Role-Based Access
+
+| Role | Value | Dashboard |
+|---|---|---|
+| Tenant | `tenant` | `/` |
+| Landlord | `landlord` | `/landlords` |
+| Agent | `agent` | `/agents` |
+| Admin | `admin` | `/landlords` |
+
+The `role` field on the user object uses lowercase. The signup form accepts `TENANT` or `LANDLORD` (uppercase enum).
+
+---
+
+## 7. Demo Accounts
+
+See [DEMO_CREDENTIALS.md](../setup/DEMO_CREDENTIALS.md) for pre-seeded accounts to use during development and testing.

--- a/backend/docs/api/ERROR-CODES.md
+++ b/backend/docs/api/ERROR-CODES.md
@@ -1,0 +1,153 @@
+# Chioma API Error Codes
+
+All error responses use a stable machine-readable `error` code alongside the HTTP status. Clients should branch on `error`, not `message` — messages may be localised or refined over time.
+
+## Error Response Shape
+
+```json
+{
+  "statusCode": 422,
+  "error": "PAYMENT_AMOUNT_BELOW_MINIMUM",
+  "message": "Payment amount must be at least 1 stroop.",
+  "timestamp": "2025-04-01T09:30:00Z",
+  "path": "/api/payments",
+  "requestId": "req_a1b2c3d4"
+}
+```
+
+---
+
+## Registry
+
+### Authentication & Authorisation — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `INVALID_CREDENTIALS` | 401 | Email or password is incorrect. |
+| `TOKEN_EXPIRED` | 401 | JWT access token has expired — refresh via `/auth/refresh`. |
+| `TOKEN_INVALID` | 401 | JWT signature is invalid or the token is malformed. |
+| `TOKEN_MISSING` | 401 | `Authorization: Bearer <token>` header is absent. |
+| `REFRESH_TOKEN_EXPIRED` | 401 | Refresh token has expired — re-authenticate. |
+| `MFA_REQUIRED` | 403 | Multi-factor authentication challenge must be completed. |
+| `MFA_INVALID_CODE` | 403 | TOTP code is incorrect or expired. |
+| `FORBIDDEN` | 403 | Authenticated user does not have the required role or permission. |
+| `STELLAR_CHALLENGE_INVALID` | 401 | SEP-0010 challenge response failed verification. |
+| `STELLAR_CHALLENGE_EXPIRED` | 401 | SEP-0010 challenge has expired (15-minute window). |
+
+### Validation — 400
+
+| Code | HTTP | Description |
+|---|---|---|
+| `VALIDATION_ERROR` | 400 | One or more request fields failed schema validation. `details` array included. |
+| `INVALID_UUID` | 400 | A path or query parameter must be a valid UUID. |
+| `INVALID_DATE_RANGE` | 400 | `from` date is after `to` date. |
+| `INVALID_CURRENCY` | 400 | Currency code is not supported. |
+| `INVALID_JSON` | 400 | Request body could not be parsed as JSON. |
+| `IDEMPOTENCY_KEY_CONFLICT` | 409 | An in-flight request with this idempotency key already exists. |
+
+### User — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `USER_NOT_FOUND` | 404 | No user matches the provided ID. |
+| `USER_ALREADY_EXISTS` | 409 | A user with this email address is already registered. |
+| `USER_SOFT_DELETED` | 403 | This account has been deactivated. |
+| `EMAIL_NOT_VERIFIED` | 403 | Email address must be verified before proceeding. |
+| `KYC_REQUIRED` | 403 | KYC verification must be completed before this action. |
+| `KYC_REJECTED` | 403 | KYC verification was rejected. |
+
+### Rent Agreements — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `AGREEMENT_NOT_FOUND` | 404 | No agreement matches the provided ID. |
+| `AGREEMENT_NOT_ACTIVE` | 422 | Operation requires an active agreement. |
+| `AGREEMENT_ALREADY_EXISTS` | 409 | An active agreement already exists for this property/tenant pair. |
+| `AGREEMENT_EXPIRED` | 422 | Agreement end date has passed. |
+| `INVALID_RENT_AMOUNT` | 422 | Rent amount must be greater than zero. |
+| `AGREEMENT_NOT_AUTHORIZED` | 403 | Caller is not a party to this agreement. |
+
+### Payments — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `PAYMENT_NOT_FOUND` | 404 | No payment matches the provided ID. |
+| `PAYMENT_AMOUNT_BELOW_MINIMUM` | 422 | Payment amount must be at least 1 stroop. |
+| `PAYMENT_ALREADY_PROCESSED` | 409 | Payment has already been completed or cancelled. |
+| `INSUFFICIENT_BALANCE` | 422 | Stellar account does not have sufficient balance. |
+| `PAYMENT_METHOD_NOT_FOUND` | 404 | No payment method matches the provided ID. |
+
+### Escrow & Disputes — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `ESCROW_NOT_FOUND` | 404 | No escrow record matches the provided ID. |
+| `ESCROW_ALREADY_ACTIVE` | 409 | An escrow is already active for this agreement. |
+| `DISPUTE_NOT_FOUND` | 404 | No dispute matches the provided ID. |
+| `DISPUTE_ALREADY_RESOLVED` | 409 | Dispute has already been resolved. |
+| `DISPUTE_NOT_AUTHORIZED` | 403 | Caller is not a party to this dispute. |
+
+### Properties — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `PROPERTY_NOT_FOUND` | 404 | No property matches the provided ID. |
+| `PROPERTY_NOT_AVAILABLE` | 422 | Property is not available for the requested dates. |
+| `PROPERTY_ALREADY_LISTED` | 409 | Property is already listed. |
+
+### Storage / File Upload — 4xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `FILE_TOO_LARGE` | 413 | Uploaded file exceeds the 10 MB limit. |
+| `UNSUPPORTED_FILE_TYPE` | 415 | File MIME type is not permitted. |
+| `STORAGE_UPLOAD_FAILED` | 500 | Cloud storage upload failed — retry. |
+
+### Rate Limiting — 429
+
+| Code | HTTP | Description |
+|---|---|---|
+| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests. See `Retry-After` header. |
+| `RATE_LIMIT_AUTH_EXCEEDED` | 429 | Authentication endpoint rate limit reached. |
+
+### Server Errors — 5xx
+
+| Code | HTTP | Description |
+|---|---|---|
+| `INTERNAL_SERVER_ERROR` | 500 | Unexpected server error. Retry with exponential back-off. |
+| `DATABASE_ERROR` | 500 | Database operation failed. |
+| `STELLAR_NODE_UNAVAILABLE` | 503 | Stellar Horizon is temporarily unavailable. |
+| `ANCHOR_SERVICE_UNAVAILABLE` | 503 | Anchor service is temporarily unavailable. |
+
+---
+
+## Handling Validation Errors
+
+When `VALIDATION_ERROR` is returned, a `details` array describes each field error:
+
+```json
+{
+  "statusCode": 400,
+  "error": "VALIDATION_ERROR",
+  "message": "Request validation failed",
+  "details": [
+    { "field": "amountStroops", "message": "amountStroops must be a positive integer" },
+    { "field": "memo", "message": "memo must not exceed 28 characters" }
+  ]
+}
+```
+
+---
+
+## Adding a New Error Code
+
+1. Add the code and description to the appropriate table above.
+2. Throw using the project's `AppException` helper so the global filter picks it up:
+
+```typescript
+throw new AppException('AGREEMENT_NOT_FOUND', HttpStatus.NOT_FOUND, {
+  agreementId,
+});
+```
+
+3. Add a corresponding `@ApiResponse` decorator to the affected endpoint(s).

--- a/backend/docs/api/PAGINATION.md
+++ b/backend/docs/api/PAGINATION.md
@@ -1,0 +1,97 @@
+# Pagination Standards
+
+All list endpoints use **offset-based pagination** by default. High-throughput or append-only resources (e.g. audit logs, payment history) additionally support **cursor-based pagination**.
+
+---
+
+## Offset Pagination
+
+### Query parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `page` | integer ≥ 1 | 1 | Page number |
+| `limit` | integer 1–100 | 20 | Items per page |
+| `sort` | string | `createdAt` | Field to sort by. Prefix with `-` for descending. |
+
+### Example request
+
+```
+GET /api/payments?page=2&limit=20&sort=-createdAt
+```
+
+### Response shape
+
+```json
+{
+  "data": [
+    { "id": "pay_01HN7K", "status": "COMPLETED", "amountStroops": 5000000000 }
+  ],
+  "meta": {
+    "total": 142,
+    "page": 2,
+    "limit": 20,
+    "totalPages": 8,
+    "hasNextPage": true,
+    "hasPreviousPage": true
+  }
+}
+```
+
+### Swagger declaration
+
+```typescript
+@ApiQuery({ name: 'page',  required: false, type: Number, example: 1,  description: 'Page number (1-indexed)' })
+@ApiQuery({ name: 'limit', required: false, type: Number, example: 20, description: 'Items per page (max 100)' })
+@ApiQuery({ name: 'sort',  required: false, type: String, example: '-createdAt', description: 'Sort field; prefix with - for descending' })
+@ApiResponse({ status: 200, type: PaginatedPaymentsDto })
+@Get()
+async list(@Query() query: PaginationQueryDto) {}
+```
+
+---
+
+## Cursor Pagination
+
+Used for streaming resources where total count is not required or page-jumping is not needed.
+
+### Query parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `cursor` | string | — | Opaque cursor from the previous page's `meta.nextCursor` |
+| `limit` | integer 1–100 | 20 | Items per page |
+| `direction` | `forward` \| `backward` | `forward` | Scroll direction |
+
+### Example request
+
+```
+GET /api/audit-logs?cursor=eyJpZCI6InBheV8wMSJ9&limit=20
+```
+
+### Response shape
+
+```json
+{
+  "data": [ { "id": "log_01HN7K", "action": "PAYMENT_CREATED" } ],
+  "meta": {
+    "limit": 20,
+    "nextCursor": "eyJpZCI6ImxvZ18wMiJ9",
+    "previousCursor": "eyJpZCI6ImxvZ18wMCJ9",
+    "hasNextPage": true,
+    "hasPreviousPage": false
+  }
+}
+```
+
+Cursors are **opaque** base64-encoded strings — clients must not construct them manually.
+
+---
+
+## Choosing a Pagination Type
+
+| Use case | Recommendation |
+|---|---|
+| Admin tables, search results | Offset — users need to jump to specific pages |
+| Audit logs, transaction history, feeds | Cursor — append-only, no page-jumping needed |
+| Real-time dashboards | Cursor with `direction: backward` for newest-first |

--- a/backend/docs/api/RATE-LIMITING.md
+++ b/backend/docs/api/RATE-LIMITING.md
@@ -1,0 +1,90 @@
+# Rate Limiting
+
+Chioma uses NestJS Throttler to protect all endpoints from abuse. Rate limits are applied per IP address (and per authenticated user for protected endpoints).
+
+---
+
+## Default Limits
+
+| Endpoint group | Window | Max requests | Notes |
+|---|---|---|---|
+| All endpoints | 1 minute | 100 | Global default |
+| `POST /api/auth/login` | 15 minutes | 10 | Per IP |
+| `POST /api/auth/register` | 1 hour | 5 | Per IP |
+| `POST /api/auth/forgot-password` | 1 hour | 3 | Per IP |
+| `POST /api/payments` | 1 minute | 20 | Per user |
+| `POST /api/auth/stellar/*` | 1 minute | 30 | Per IP |
+| `GET /api/*` (read operations) | 1 minute | 200 | Per user |
+
+---
+
+## Response Headers
+
+Every response includes rate-limit headers:
+
+```
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 87
+X-RateLimit-Reset: 1712053860
+Retry-After: 23          ← only present when limit is exceeded
+```
+
+| Header | Description |
+|---|---|
+| `X-RateLimit-Limit` | Maximum requests allowed in the current window |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp when the window resets |
+| `Retry-After` | Seconds to wait before retrying (only on 429) |
+
+---
+
+## Rate Limit Exceeded Response
+
+```json
+{
+  "statusCode": 429,
+  "error": "RATE_LIMIT_EXCEEDED",
+  "message": "Too many requests. Please wait 23 seconds before retrying.",
+  "timestamp": "2025-04-01T09:30:00Z",
+  "path": "/api/auth/login"
+}
+```
+
+---
+
+## Client Retry Strategy
+
+Use exponential back-off when a 429 is received:
+
+```typescript
+async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 3) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const res = await fetch(url, options);
+    if (res.status !== 429) return res;
+
+    const retryAfter = parseInt(res.headers.get('Retry-After') ?? '5', 10);
+    const delay = retryAfter * 1000 * Math.pow(2, attempt); // exponential
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  throw new Error('Rate limit retry budget exhausted');
+}
+```
+
+---
+
+## Documenting Rate Limits on Endpoints
+
+Every rate-limited endpoint should declare the `Retry-After` header in Swagger:
+
+```typescript
+@ApiResponse({
+  status: 429,
+  description: 'Too many requests',
+  headers: {
+    'Retry-After': {
+      description: 'Seconds until the rate limit window resets',
+      schema: { type: 'integer', example: 30 },
+    },
+  },
+})
+```

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -287,6 +287,69 @@ export default function SignupPage() {
 
           <WalletConnectButton className="w-full" />
 
+          {/* Demo Credentials */}
+          <div className="mt-2 p-4 rounded-lg bg-amber-500/10 border border-amber-500/30">
+            <p className="text-xs font-semibold text-amber-200 mb-1 text-center uppercase tracking-wide">
+              Demo Accounts
+            </p>
+            <p className="text-amber-200/60 text-xs text-center mb-3">
+              For testing only — click to auto-fill &amp; select role
+            </p>
+            <div className="space-y-2 text-xs">
+              {[
+                {
+                  role: 'TENANT' as const,
+                  label: 'Tenant',
+                  email:
+                    process.env.NODE_ENV === 'production'
+                      ? 'demo-tenant@chioma.demo'
+                      : 'demo-tenant@chioma.local',
+                  password: 'Tenant@Demo2024!',
+                  firstName: 'Demo',
+                  lastName: 'Tenant',
+                },
+                {
+                  role: 'LANDLORD' as const,
+                  label: 'Landlord',
+                  email:
+                    process.env.NODE_ENV === 'production'
+                      ? 'demo-landlord@chioma.demo'
+                      : 'demo-landlord@chioma.local',
+                  password: 'Landlord@Demo2024!',
+                  firstName: 'Demo',
+                  lastName: 'Landlord',
+                },
+              ].map(({ role, label, email, password, firstName, lastName }) => (
+                <button
+                  key={email}
+                  type="button"
+                  onClick={() => {
+                    setValue('firstName', firstName, { shouldValidate: true });
+                    setValue('lastName', lastName, { shouldValidate: true });
+                    setValue('email', email, { shouldValidate: true });
+                    setValue('password', password, { shouldValidate: true });
+                    setValue('role', role, { shouldValidate: true });
+                  }}
+                  className="w-full text-left px-3 py-2 rounded bg-white/5 hover:bg-white/10 text-amber-100 hover:text-amber-50 transition-colors flex justify-between items-center group"
+                >
+                  <span className="font-medium">{label}</span>
+                  <span className="font-mono text-amber-200/70 group-hover:text-amber-200 text-xs">
+                    {email}
+                  </span>
+                </button>
+              ))}
+            </div>
+            <p className="text-amber-200/60 text-xs mt-3 text-center">
+              Already have a demo account?{' '}
+              <Link
+                href="/login"
+                className="text-amber-300 font-semibold hover:text-amber-200 transition-colors"
+              >
+                Sign in instead
+              </Link>
+            </p>
+          </div>
+
           <p className="text-center text-white/60 text-sm pt-2">
             Already have an account?{' '}
             <Link


### PR DESCRIPTION
Add comprehensive backend API documentation standards and replace the boilerplate docs/README.md with a navigable documentation hub. Covers Swagger annotation conventions, error code registry, auth flows, rate limiting, and pagination patterns. Also adds demo credentials auto-fill to the signup page, matching the existing login page pattern.

Closes #679
Closes #678
Closes #672