### PR TITLE
docs: implement comprehensive API versioning strategy documentation

### DIFF
--- a/backend/docs/api/API-STANDARDS.md
+++ b/backend/docs/api/API-STANDARDS.md
@@ -209,6 +209,8 @@ Endpoints that create or mutate resources should support an `Idempotency-Key` he
 3. Log a warning in the controller if the deprecated path is hit.
 4. Record the deprecation in [API-CHANGELOG.md](./API-CHANGELOG.md) with a sunset date.
 
+For full details on our versioning lifecycle, deprecation notices (including `Sunset` headers), and migration procedures, refer to the [API Versioning Strategy](./API-VERSIONING.md).
+
 ```typescript
 @ApiOperation({
   summary: '[DEPRECATED] Get payment — use GET /api/payments/:id instead',

--- a/backend/docs/api/API-VERSIONING.md
+++ b/backend/docs/api/API-VERSIONING.md
@@ -1,22 +1,125 @@
 # API Versioning Strategy
 
-## Current version
+This document defines the strategy for versioning, deprecating, and migrating the Chioma API. Following these guidelines ensures stability for our clients and a predictable upgrade path for developers.
 
-- **API version:** 1.0
-- **Versioning type:** URI (path). Default version is `1`; future versions may use `/api/v2/...`.
+---
 
-## Policy
+## 1. Versioning Approach
 
-1. **Stability:** We avoid breaking changes to existing endpoints. New fields and new endpoints are added in a backward-compatible way.
-2. **Deprecation:** Deprecated endpoints or parameters are announced in this changelog and in OpenAPI `deprecated: true`. A minimum of one major version or 6 months notice is given before removal.
-3. **New versions:** Breaking changes are released under a new API version (e.g. v2). The previous version remains supported for a defined period.
+### URI-Based Versioning (Path)
+Chioma uses **URI Versioning** for major API versions. This approach makes it easy to track versions in server logs and enables side-by-side deployment of multiple versions.
 
-## Version in requests
+- **v1 (Current):** `https://api.chioma.app/api/...`
+- **v2 (Future):** `https://api.chioma.app/api/v2/...`
 
-- Base URL includes no version segment for v1: `https://api.chioma.app/api/...`
-- NestJS `enableVersioning(VersioningType.URI)` is configured with `defaultVersion: '1'`. Optional explicit versioning (e.g. `/api/v2/...`) can be added when v2 is introduced.
+> [!NOTE]
+> The `/api` prefix without a version segment defaults to **v1** via the NestJS `defaultVersion: '1'` configuration.
 
-## OpenAPI
+---
 
-- The served spec at `/api/docs-json` and any generated `openapi.json` use `info.version` (e.g. `1.0`) to reflect the current API version.
-- Changelog and release notes are kept in [API-CHANGELOG.md](./API-CHANGELOG.md).
+## 2. Version Format
+
+We follow **Semantic Versioning (SemVer) 2.0.0** for our API releases, although only the **Major** version is reflected in the URI path.
+
+- **Major Version (vX):** Incremented for **breaking changes**. Requires a new URI path and a migration period.
+- **Minor Version (.Y):** Incremented for **backward-compatible features** (e.g., new endpoints, new optional fields).
+- **Patch Version (.Z):** Incremented for **backward-compatible bug fixes**.
+
+The full version (e.g., `1.2.3`) is documented in `API-CHANGELOG.md` and reflected in the `info.version` field of the OpenAPI specification.
+
+---
+
+## 3. Backward Compatibility
+
+Maintaining backward compatibility is our highest priority to protect client integrations.
+
+### Non-Breaking Changes (SAFE)
+- Adding new endpoints.
+- Adding new optional request parameters or headers.
+- Adding new properties to response JSON.
+- Changing the order of properties in response JSON (clients must handle JSON as unordered maps).
+- Adding new values to an Enum (clients must handle unknown values gracefully).
+
+### Breaking Changes (UNSAFE)
+- Removing or renaming endpoints or parameters.
+- Changing the data type of a property (e.g., String to Integer).
+- Making an optional parameter required.
+- Removing properties from response JSON.
+- Changing error codes or significant logic flow.
+- Changing authentication/authorization requirements.
+
+---
+
+## 4. Version Lifecycle
+
+Every API version progresses through the following stages:
+
+| Stage | Description |
+|---|---|
+| **Experimental** | Internal testing/Beta. Subject to change without notice. |
+| **Stable (Active)** | Current production version. Fully supported with backward compatibility. |
+| **Deprecated** | A newer version exists. Support continues but removal is scheduled. |
+| **End-of-Life (EOL)** | Version is no longer supported and may be removed from servers. |
+
+---
+
+## 5. Deprecation Policy
+
+When a breaking change is unavoidable, we follow a strict deprecation process.
+
+1.  **Notice Period:** A minimum of **6 months** notice is given before a version or endpoint is removed.
+2.  **OpenAPI Flag:** Mark the endpoint with `deprecated: true` in the controller.
+3.  **Deprecation Headers:** Every response from a deprecated endpoint carries:
+    -   `Deprecated: true`
+    -   `Sunset: [Date]` (The scheduled EOL date in HTTP-date format).
+    -   `Link: <replacement-url>; rel="successor-version"`
+4.  **Logging:** Backend logs should track the usage of deprecated endpoints to identify high-impact removals.
+
+---
+
+## 6. Migration Procedures
+
+1.  **Parallel Execution:** The new version (e.g., `v2`) is deployed alongside the old version (`v1`).
+2.  **Shadow Testing:** High-traffic endpoints are "shadowed" to compare outputs between versions before full release.
+3.  **Migration Guide:** Every major version increment must be accompanied by a dedicated migration guide in `backend/docs/api/migrations/v1-to-v2.md`.
+4.  **Client Support:** The "Stable" and "Deprecated" versions are maintained concurrently until the Sunset date.
+
+---
+
+## 7. Version Communication
+
+We communicate version changes through:
+
+-   **API-CHANGELOG.md:** The source of truth for all changes.
+-   **Developer Portal:** High-level announcements on the dashboard.
+-   **Email/Discord:** Bulletins sent to developers using affected keys.
+-   **OpenAPI spec:** Real-time updates at `/api/docs`.
+
+---
+
+## 8. Development Checklist
+
+When introducing changes that affect versioning:
+
+- [ ] Is this change backward compatible? If no, it **must** be tied to a new Major version.
+- [ ] Have I updated `API-CHANGELOG.md`?
+- [ ] For deprecations, is the `Sunset` header configured?
+- [ ] Are all new properties documented with `@ApiProperty` examples?
+- [ ] If introducing a new Major version, has the NestJS `VersioningType.URI` been updated?
+
+---
+
+## 9. Best Practices
+
+1.  **Design for Extensibility:** Use objects instead of primitives in responses to allow for future fields.
+2.  **Avoid Version Bloat:** Only increment major versions for truly breaking changes. Aggregate multiple breaking changes into a single milestone.
+3.  **Client Robustness:** Educate clients to ignore unknown properties (Postel's Law).
+4.  **Automated Testing:** Use Contract Testing (e.g., Pact) to ensure that updates don't inadvertently break existing client expectations.
+
+---
+
+## 10. Tools & Resources
+
+-   **OpenAPI/Swagger:** [Swagger UI](/api/docs)
+-   **Changelog:** [API-CHANGELOG.md](./API-CHANGELOG.md)
+-   **Standards:** [API-STANDARDS.md](./API-STANDARDS.md)


### PR DESCRIPTION
closes #708 

Branch: fix/708-api-versioning-strategy
Commit: 8c73768
Title: docs: implement comprehensive API versioning strategy documentation
Description: Implements full API versioning strategy including format, lifecycle, deprecation, and migration policies for the Chioma housing protocol.