### PR TITLE
feat: add fraud detection pipeline and automatic risk hooks

### DIFF
--- a/backend/ai-services/fraud/model-artifacts/fraud-model.json
+++ b/backend/ai-services/fraud/model-artifacts/fraud-model.json
@@ -1,0 +1,22 @@
+{
+  "modelVersion": "xgb-fraud-v1-bootstrap",
+  "trainedAt": "2026-04-23T00:00:00Z",
+  "thresholdReview": 45,
+  "thresholdBlock": 75,
+  "featureWeights": {
+    "accountAgeDays": -0.6,
+    "failedLoginAttempts": 2.2,
+    "loginCount": -0.2,
+    "isKycVerified": -1.8,
+    "listingPriceAnomaly": 2.4,
+    "listingContentRisk": 1.8,
+    "paymentAmountAnomaly": 2.6,
+    "rapidPaymentVelocity": 2.2,
+    "paymentFailureRate": 1.8,
+    "newPaymentMethodRisk": 1.1
+  },
+  "metrics": {
+    "testRecords": 0,
+    "fraudRate": 0
+  }
+}

--- a/backend/ai-services/fraud/requirements.txt
+++ b/backend/ai-services/fraud/requirements.txt
@@ -1,0 +1,4 @@
+xgboost
+pandas
+numpy
+scikit-learn

--- a/backend/ai-services/fraud/train_model.py
+++ b/backend/ai-services/fraud/train_model.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Train a fraud detection model and export lightweight artifacts for backend scoring.
+
+Usage:
+  python backend/ai-services/fraud/train_model.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import precision_recall_curve
+from sklearn.model_selection import train_test_split
+from xgboost import XGBClassifier
+
+
+ROOT = Path(__file__).resolve().parent
+DATA_PATH = ROOT / "historical_fraud_data.csv"
+OUTPUT_DIR = ROOT / "model-artifacts"
+OUTPUT_PATH = OUTPUT_DIR / "fraud-model.json"
+
+FEATURE_COLUMNS = [
+    "accountAgeDays",
+    "failedLoginAttempts",
+    "loginCount",
+    "isKycVerified",
+    "listingPriceAnomaly",
+    "listingContentRisk",
+    "paymentAmountAnomaly",
+    "rapidPaymentVelocity",
+    "paymentFailureRate",
+    "newPaymentMethodRisk",
+]
+
+
+def build_synthetic_data(size: int = 5000) -> pd.DataFrame:
+    rng = np.random.default_rng(seed=42)
+    data = pd.DataFrame(
+        {
+            "accountAgeDays": rng.integers(1, 1200, size=size),
+            "failedLoginAttempts": rng.integers(0, 12, size=size),
+            "loginCount": rng.integers(1, 500, size=size),
+            "isKycVerified": rng.integers(0, 2, size=size),
+            "listingPriceAnomaly": rng.uniform(0, 1.5, size=size),
+            "listingContentRisk": rng.uniform(0, 1, size=size),
+            "paymentAmountAnomaly": rng.uniform(0, 2, size=size),
+            "rapidPaymentVelocity": rng.uniform(0, 1, size=size),
+            "paymentFailureRate": rng.uniform(0, 1, size=size),
+            "newPaymentMethodRisk": rng.integers(0, 2, size=size),
+        }
+    )
+
+    risk_score = (
+        0.02 * (10 - np.clip(data["accountAgeDays"] / 120, 0, 10))
+        + 0.09 * data["failedLoginAttempts"]
+        + 0.04 * data["listingPriceAnomaly"]
+        + 0.06 * data["listingContentRisk"]
+        + 0.08 * data["paymentAmountAnomaly"]
+        + 0.07 * data["rapidPaymentVelocity"]
+        + 0.08 * data["paymentFailureRate"]
+        + 0.05 * data["newPaymentMethodRisk"]
+        + 0.03 * (1 - data["isKycVerified"])
+    )
+    risk_score += rng.normal(0, 0.08, size=size)
+    data["label"] = (risk_score > 0.7).astype(int)
+    return data
+
+
+def normalize_importances(feature_importances: np.ndarray) -> list[float]:
+    total = float(feature_importances.sum())
+    if total <= 0:
+        return [1.0 / len(feature_importances)] * len(feature_importances)
+    return (feature_importances / total).tolist()
+
+
+def compute_thresholds(y_true: np.ndarray, y_prob: np.ndarray) -> tuple[float, float]:
+    precision, recall, thresholds = precision_recall_curve(y_true, y_prob)
+    if thresholds.size == 0:
+        return 45.0, 75.0
+
+    best_review_threshold = 0.45
+    best_block_threshold = 0.75
+
+    for p, r, t in zip(precision[:-1], recall[:-1], thresholds):
+        if p >= 0.7 and r >= 0.35:
+            best_review_threshold = float(t)
+            break
+
+    for p, _r, t in zip(precision[:-1], recall[:-1], thresholds):
+        if p >= 0.9:
+            best_block_threshold = float(t)
+            break
+
+    return best_review_threshold * 100, best_block_threshold * 100
+
+
+def main() -> None:
+    if DATA_PATH.exists():
+        data = pd.read_csv(DATA_PATH)
+    else:
+        print(f"[fraud-train] No dataset found at {DATA_PATH}, generating synthetic data.")
+        data = build_synthetic_data()
+
+    missing = [column for column in FEATURE_COLUMNS + ["label"] if column not in data.columns]
+    if missing:
+        raise ValueError(
+            f"Dataset missing required columns: {missing}. "
+            f"Expected features={FEATURE_COLUMNS} and label."
+        )
+
+    x = data[FEATURE_COLUMNS]
+    y = data["label"].astype(int)
+
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=0.2, random_state=42, stratify=y
+    )
+
+    model = XGBClassifier(
+        n_estimators=250,
+        max_depth=5,
+        learning_rate=0.08,
+        subsample=0.9,
+        colsample_bytree=0.9,
+        reg_lambda=1.0,
+        objective="binary:logistic",
+        eval_metric="logloss",
+        random_state=42,
+    )
+    model.fit(x_train, y_train)
+
+    y_prob = model.predict_proba(x_test)[:, 1]
+    threshold_review, threshold_block = compute_thresholds(
+        y_test.to_numpy(), y_prob
+    )
+    normalized = normalize_importances(model.feature_importances_)
+    weights = {
+        feature_name: float(round((importance - 0.1) * 8, 4))
+        for feature_name, importance in zip(FEATURE_COLUMNS, normalized)
+    }
+
+    artifact = {
+        "modelVersion": "xgb-fraud-v1",
+        "trainedAt": pd.Timestamp.utcnow().isoformat(),
+        "thresholdReview": round(float(threshold_review), 2),
+        "thresholdBlock": round(float(max(threshold_block, threshold_review + 10)), 2),
+        "featureWeights": weights,
+        "metrics": {
+            "testRecords": int(len(y_test)),
+            "fraudRate": round(float(y.mean()), 4),
+        },
+    }
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+    print(f"[fraud-train] Wrote artifact to: {OUTPUT_PATH}")
+    print(json.dumps(artifact["metrics"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -56,6 +56,7 @@ import { InquiriesModule } from './modules/inquiries/inquiries.module';
 import { AnalyticsModule } from './modules/analytics/analytics.module';
 import { LockModule } from './common/lock';
 import { IdempotencyModule } from './common/idempotency';
+import { FraudModule } from './modules/fraud/fraud.module';
 
 const appLogger = new Logger('AppModule');
 
@@ -223,6 +224,7 @@ const appLogger = new Logger('AppModule');
     SearchModule,
     CleanupModule,
     AiModule,
+    FraudModule,
     WebhooksModule,
     ScreeningModule,
     ReferralModule,

--- a/backend/src/migrations/1783000000000-AddPropertySearchIndexes.ts
+++ b/backend/src/migrations/1783000000000-AddPropertySearchIndexes.ts
@@ -86,11 +86,21 @@ export class AddPropertySearchIndexes1783000000000 implements MigrationInterface
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_property_amenities_name"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_property_amenities_name"`,
+    );
     await queryRunner.query(`DROP INDEX IF EXISTS "IDX_properties_lat_lng"`);
-    await queryRunner.query(`DROP TRIGGER IF EXISTS "properties_search_vector_trigger" ON "properties"`);
-    await queryRunner.query(`DROP FUNCTION IF EXISTS properties_search_vector_update()`);
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_properties_search_vector"`);
-    await queryRunner.query(`ALTER TABLE "properties" DROP COLUMN IF EXISTS "search_vector"`);
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS "properties_search_vector_trigger" ON "properties"`,
+    );
+    await queryRunner.query(
+      `DROP FUNCTION IF EXISTS properties_search_vector_update()`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_properties_search_vector"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "properties" DROP COLUMN IF EXISTS "search_vector"`,
+    );
   }
 }

--- a/backend/src/migrations/1783300000000-CreateFraudAlertsTable.ts
+++ b/backend/src/migrations/1783300000000-CreateFraudAlertsTable.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateFraudAlertsTable1783300000000 implements MigrationInterface {
+  name = 'CreateFraudAlertsTable1783300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "fraud_alerts" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "subject_type" character varying(32) NOT NULL,
+        "subject_id" uuid NOT NULL,
+        "score" integer NOT NULL,
+        "decision" character varying(16) NOT NULL,
+        "reasons" jsonb NOT NULL,
+        "model_version" character varying(128) NOT NULL,
+        "features" jsonb,
+        "status" character varying(16) NOT NULL DEFAULT 'open',
+        "resolved_at" TIMESTAMP,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_fraud_alerts_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_fraud_alerts_status_created" ON "fraud_alerts" ("status", "created_at")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_fraud_alerts_subject" ON "fraud_alerts" ("subject_type", "subject_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_fraud_alerts_subject"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_fraud_alerts_status_created"`,
+    );
+    await queryRunner.query(`DROP TABLE "fraud_alerts"`);
+  }
+}

--- a/backend/src/modules/agreements/agreement-nft.service.spec.ts
+++ b/backend/src/modules/agreements/agreement-nft.service.spec.ts
@@ -50,8 +50,7 @@ describe('AgreementNftService', () => {
   describe('mintNftForAgreement', () => {
     it('should mint NFT successfully', async () => {
       const agreementId = 'agreement-123';
-      const landlordAddress =
-        'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+      const adminAddress = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 
       jest.spyOn(nftRepository, 'findOne').mockResolvedValue(null);
       jest.spyOn(nftContractService, 'mintObligation').mockResolvedValue({
@@ -60,7 +59,7 @@ describe('AgreementNftService', () => {
       });
       jest.spyOn(nftRepository, 'create').mockReturnValue({
         agreementId,
-        currentOwner: landlordAddress,
+        currentOwner: adminAddress,
       } as RentObligationNft);
       jest.spyOn(nftRepository, 'save').mockResolvedValue({
         id: 'nft-id',
@@ -69,20 +68,19 @@ describe('AgreementNftService', () => {
 
       const result = await service.mintNftForAgreement(
         agreementId,
-        landlordAddress,
+        adminAddress,
       );
 
       expect(result).toBeDefined();
       expect(nftContractService.mintObligation).toHaveBeenCalledWith({
         agreementId,
-        landlordAddress,
+        adminAddress,
       });
     });
 
     it('should throw error if NFT already exists', async () => {
       const agreementId = 'agreement-123';
-      const landlordAddress =
-        'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+      const adminAddress = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 
       jest.spyOn(nftRepository, 'findOne').mockResolvedValue({
         id: 'existing-nft',
@@ -90,7 +88,7 @@ describe('AgreementNftService', () => {
       } as RentObligationNft);
 
       await expect(
-        service.mintNftForAgreement(agreementId, landlordAddress),
+        service.mintNftForAgreement(agreementId, adminAddress),
       ).rejects.toThrow('NFT already minted');
     });
   });

--- a/backend/src/modules/disputes/__tests__/disputes.service.spec.ts
+++ b/backend/src/modules/disputes/__tests__/disputes.service.spec.ts
@@ -43,10 +43,10 @@ describe('DisputesService', () => {
   } as User;
 
   const mockAgreement: any = {
-    id: 1,
+    id: '1',
     agreementNumber: 'AGR-001',
-    landlordId: 'landlord-1',
-    tenantId: 'user-1',
+    adminId: 'landlord-1',
+    userId: 'user-1',
     monthlyRent: 1000,
     securityDeposit: 1000,
     status: AgreementStatus.ACTIVE,

--- a/backend/src/modules/fraud/dto/check-transaction-fraud.dto.ts
+++ b/backend/src/modules/fraud/dto/check-transaction-fraud.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+export class CheckTransactionFraudDto {
+  @ApiProperty()
+  @IsUUID()
+  userId: string;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(0)
+  amount: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  paymentMethod?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  ipAddress?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  deviceFingerprint?: string;
+}

--- a/backend/src/modules/fraud/entities/fraud-alert.entity.ts
+++ b/backend/src/modules/fraud/entities/fraud-alert.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('fraud_alerts')
+@Index('idx_fraud_alerts_status_created', ['status', 'createdAt'])
+@Index('idx_fraud_alerts_subject', ['subjectType', 'subjectId'])
+export class FraudAlertEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'subject_type', type: 'varchar', length: 32 })
+  subjectType: string;
+
+  @Column({ name: 'subject_id', type: 'uuid' })
+  subjectId: string;
+
+  @Column({ type: 'int' })
+  score: number;
+
+  @Column({ type: 'varchar', length: 16 })
+  decision: string;
+
+  @Column({
+    type: process.env.DB_TYPE === 'sqlite' ? 'text' : 'jsonb',
+  })
+  reasons: string[];
+
+  @Column({ name: 'model_version', type: 'varchar', length: 128 })
+  modelVersion: string;
+
+  @Column({
+    type: process.env.DB_TYPE === 'sqlite' ? 'text' : 'jsonb',
+    nullable: true,
+  })
+  features: Record<string, number> | null;
+
+  @Column({ type: 'varchar', length: 16, default: 'open' })
+  status: string;
+
+  @Column({ name: 'resolved_at', type: 'timestamp', nullable: true })
+  resolvedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/fraud/fraud-alerts.service.spec.ts
+++ b/backend/src/modules/fraud/fraud-alerts.service.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { FraudAlertsService } from './fraud-alerts.service';
+import { FraudAlertEntity } from './entities/fraud-alert.entity';
+
+describe('FraudAlertsService', () => {
+  let service: FraudAlertsService;
+
+  const created = new Date('2026-01-01T00:00:00.000Z');
+
+  const mockRepo = {
+    create: jest.fn((v) => ({ id: 'alert-1', ...v })),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockRepo.save.mockImplementation(async (v) => ({
+      ...v,
+      createdAt: v.createdAt ?? created,
+      updatedAt: v.updatedAt ?? created,
+    }));
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FraudAlertsService,
+        {
+          provide: getRepositoryToken(FraudAlertEntity),
+          useValue: mockRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get(FraudAlertsService);
+  });
+
+  it('returns null when decision is allow', async () => {
+    const result = await service.createAlert('user', 'user-1', {
+      score: 10,
+      decision: 'allow',
+      reasons: [],
+      features: {},
+      modelVersion: 'v1',
+    });
+    expect(result).toBeNull();
+    expect(mockRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('persists alert for review decision', async () => {
+    const result = await service.createAlert('user', 'user-1', {
+      score: 55,
+      decision: 'review',
+      reasons: ['failedLoginAttempts'],
+      features: { failedLoginAttempts: 0.9 },
+      modelVersion: 'v1',
+    });
+    expect(mockRepo.create).toHaveBeenCalled();
+    expect(mockRepo.save).toHaveBeenCalled();
+    expect(result?.decision).toBe('review');
+    expect(result?.subjectId).toBe('user-1');
+  });
+
+  it('lists alerts with optional status filter', async () => {
+    mockRepo.find.mockResolvedValueOnce([
+      {
+        id: 'a1',
+        subjectType: 'user',
+        subjectId: 'u1',
+        score: 60,
+        decision: 'review',
+        reasons: ['x'],
+        modelVersion: 'v1',
+        features: null,
+        status: 'open',
+        resolvedAt: null,
+        createdAt: created,
+        updatedAt: created,
+      },
+    ]);
+    const rows = await service.listAlerts('open');
+    expect(mockRepo.find).toHaveBeenCalledWith({
+      where: { status: 'open' },
+      order: { createdAt: 'DESC' },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].createdAt).toBe(created.toISOString());
+  });
+
+  it('resolveAlert throws when missing', async () => {
+    mockRepo.findOne.mockResolvedValueOnce(null);
+    await expect(service.resolveAlert('missing')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('resolveAlert marks row resolved', async () => {
+    const row = {
+      id: 'a1',
+      subjectType: 'listing',
+      subjectId: 'l1',
+      score: 80,
+      decision: 'block',
+      reasons: ['y'],
+      modelVersion: 'v1',
+      features: {},
+      status: 'open',
+      resolvedAt: null,
+      createdAt: created,
+      updatedAt: created,
+    };
+    mockRepo.findOne.mockResolvedValueOnce({ ...row });
+
+    const out = await service.resolveAlert('a1');
+    expect(mockRepo.save).toHaveBeenCalled();
+    expect(out.status).toBe('resolved');
+    expect(out.resolvedAt).toBeDefined();
+  });
+});

--- a/backend/src/modules/fraud/fraud-alerts.service.ts
+++ b/backend/src/modules/fraud/fraud-alerts.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FraudAlertEntity } from './entities/fraud-alert.entity';
+import { FraudAlert, FraudScoreResult, FraudSubjectType } from './fraud.types';
+
+@Injectable()
+export class FraudAlertsService {
+  constructor(
+    @InjectRepository(FraudAlertEntity)
+    private readonly fraudAlertRepository: Repository<FraudAlertEntity>,
+  ) {}
+
+  async createAlert(
+    subjectType: FraudSubjectType,
+    subjectId: string,
+    scoreResult: FraudScoreResult,
+  ): Promise<FraudAlert | null> {
+    if (scoreResult.decision === 'allow') {
+      return null;
+    }
+
+    const row = this.fraudAlertRepository.create({
+      subjectType,
+      subjectId,
+      score: scoreResult.score,
+      decision: scoreResult.decision,
+      reasons: scoreResult.reasons,
+      modelVersion: scoreResult.modelVersion,
+      features: scoreResult.features,
+      status: 'open',
+      resolvedAt: null,
+    });
+    const saved = await this.fraudAlertRepository.save(row);
+    return this.toDto(saved);
+  }
+
+  async listAlerts(status?: 'open' | 'resolved'): Promise<FraudAlert[]> {
+    const rows = await this.fraudAlertRepository.find({
+      where: status ? { status } : {},
+      order: { createdAt: 'DESC' },
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async resolveAlert(id: string): Promise<FraudAlert> {
+    const row = await this.fraudAlertRepository.findOne({ where: { id } });
+    if (!row) {
+      throw new NotFoundException('Fraud alert not found');
+    }
+    if (row.status === 'resolved') {
+      return this.toDto(row);
+    }
+    row.status = 'resolved';
+    row.resolvedAt = new Date();
+    const saved = await this.fraudAlertRepository.save(row);
+    return this.toDto(saved);
+  }
+
+  private toDto(row: FraudAlertEntity): FraudAlert {
+    return {
+      id: row.id,
+      subjectType: row.subjectType as FraudSubjectType,
+      subjectId: row.subjectId,
+      score: row.score,
+      decision: row.decision as FraudAlert['decision'],
+      reasons: row.reasons,
+      createdAt: row.createdAt.toISOString(),
+      resolvedAt: row.resolvedAt ? row.resolvedAt.toISOString() : undefined,
+      status: row.status as FraudAlert['status'],
+    };
+  }
+}

--- a/backend/src/modules/fraud/fraud-feature-extraction.service.ts
+++ b/backend/src/modules/fraud/fraud-feature-extraction.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@nestjs/common';
+import { KycStatus } from '../kyc/kyc-status.enum';
+import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
+import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
+import { FraudFeatures } from './fraud.types';
+
+@Injectable()
+export class FraudFeatureExtractionService {
+  extractUserFeatures(user: User): FraudFeatures {
+    const accountAgeDays = this.daysSince(user.createdAt);
+    const isKycVerified = user.kycStatus === KycStatus.APPROVED ? 1 : 0;
+
+    return {
+      accountAgeDays: this.clamp01(accountAgeDays / 365),
+      failedLoginAttempts: this.clamp01(user.failedLoginAttempts / 10),
+      loginCount: this.clamp01(user.loginCount / 300),
+      isKycVerified,
+    };
+  }
+
+  extractListingFeatures(
+    listing: Property,
+    owner: User | null,
+    peerListings: Property[],
+  ): FraudFeatures {
+    const prices = peerListings
+      .map((item) => Number(item.price))
+      .filter(Boolean);
+    const marketAvg = prices.length
+      ? prices.reduce((acc, value) => acc + value, 0) / prices.length
+      : Number(listing.price);
+    const listingPrice = Number(listing.price);
+    const priceDeviation =
+      marketAvg > 0 ? Math.abs(listingPrice - marketAvg) / marketAvg : 0;
+    const riskyTerms = [
+      'wire',
+      'crypto-only',
+      'urgent',
+      'cash-only',
+      'outside platform',
+    ];
+    const text =
+      `${listing.title ?? ''} ${listing.description ?? ''}`.toLowerCase();
+    const riskyTermHits = riskyTerms.filter((term) =>
+      text.includes(term),
+    ).length;
+
+    return {
+      listingPriceAnomaly: this.clamp01(priceDeviation),
+      listingContentRisk: this.clamp01(riskyTermHits / 2),
+      accountAgeDays: owner
+        ? this.clamp01(this.daysSince(owner.createdAt) / 365)
+        : 0,
+      isKycVerified: owner?.kycStatus === KycStatus.APPROVED ? 1 : 0,
+    };
+  }
+
+  extractTransactionFeatures(
+    user: User,
+    recentPayments: Payment[],
+    amount: number,
+    paymentMethod?: string,
+  ): FraudFeatures {
+    const paymentAmounts = recentPayments.map((payment) =>
+      Number(payment.amount),
+    );
+    const historicalAverage = paymentAmounts.length
+      ? paymentAmounts.reduce((acc, value) => acc + value, 0) /
+        paymentAmounts.length
+      : amount;
+    const amountAnomaly =
+      historicalAverage > 0
+        ? Math.abs(amount - historicalAverage) / historicalAverage
+        : 0;
+    const recentInLastHour = recentPayments.filter((payment) =>
+      this.isAfterWithinHours(payment.createdAt, 1),
+    ).length;
+    const failedCount = recentPayments.filter(
+      (payment) => payment.status === PaymentStatus.FAILED,
+    ).length;
+    const failureRate =
+      recentPayments.length > 0 ? failedCount / recentPayments.length : 0;
+    const isNewMethod = paymentMethod
+      ? !recentPayments.some(
+          (payment) => payment.paymentMethod === paymentMethod,
+        )
+      : false;
+
+    return {
+      accountAgeDays: this.clamp01(this.daysSince(user.createdAt) / 365),
+      isKycVerified: user.kycStatus === KycStatus.APPROVED ? 1 : 0,
+      paymentAmountAnomaly: this.clamp01(amountAnomaly),
+      rapidPaymentVelocity: this.clamp01(recentInLastHour / 5),
+      paymentFailureRate: this.clamp01(failureRate),
+      newPaymentMethodRisk: isNewMethod ? 1 : 0,
+    };
+  }
+
+  private clamp01(value: number): number {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(1, value));
+  }
+
+  private daysSince(value: Date): number {
+    const created = new Date(value).getTime();
+    const now = Date.now();
+    if (!Number.isFinite(created) || created <= 0) {
+      return 0;
+    }
+    return (now - created) / (1000 * 60 * 60 * 24);
+  }
+
+  private isAfterWithinHours(value: Date, hours: number): boolean {
+    const threshold = Date.now() - hours * 60 * 60 * 1000;
+    return new Date(value).getTime() >= threshold;
+  }
+}

--- a/backend/src/modules/fraud/fraud-hooks.service.spec.ts
+++ b/backend/src/modules/fraud/fraud-hooks.service.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FraudHooksService } from './fraud-hooks.service';
+import { FraudService } from './fraud.service';
+
+describe('FraudHooksService', () => {
+  const fraudService = {
+    checkTransactionFraud: jest.fn(),
+    checkListingFraud: jest.fn(),
+  };
+
+  let service: FraudHooksService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    delete process.env.FRAUD_HOOKS_ENABLED;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FraudHooksService,
+        { provide: FraudService, useValue: fraudService },
+      ],
+    }).compile();
+
+    service = module.get(FraudHooksService);
+  });
+
+  it('skips checks when FRAUD_HOOKS_ENABLED is false', async () => {
+    process.env.FRAUD_HOOKS_ENABLED = 'false';
+    await service.onPaymentRecorded({
+      userId: 'u1',
+      amount: 100,
+    });
+    await service.onListingPublished('p1');
+    expect(fraudService.checkTransactionFraud).not.toHaveBeenCalled();
+    expect(fraudService.checkListingFraud).not.toHaveBeenCalled();
+  });
+
+  it('runs transaction check when enabled', async () => {
+    await service.onPaymentRecorded({
+      userId: 'u1',
+      amount: 50,
+      currency: 'USD',
+      paymentMethod: 'card',
+    });
+    expect(fraudService.checkTransactionFraud).toHaveBeenCalledWith({
+      userId: 'u1',
+      amount: 50,
+      currency: 'USD',
+      paymentMethod: 'card',
+    });
+  });
+
+  it('swallows errors from FraudService', async () => {
+    fraudService.checkListingFraud.mockRejectedValueOnce(new Error('db down'));
+    await expect(service.onListingPublished('p1')).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/modules/fraud/fraud-hooks.service.ts
+++ b/backend/src/modules/fraud/fraud-hooks.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { FraudService } from './fraud.service';
+
+export type PaymentRecordedFraudParams = {
+  userId: string;
+  amount: number;
+  currency?: string;
+  paymentMethod?: string;
+};
+
+@Injectable()
+export class FraudHooksService {
+  private readonly logger = new Logger(FraudHooksService.name);
+
+  constructor(private readonly fraudService: FraudService) {}
+
+  hooksEnabled(): boolean {
+    return process.env.FRAUD_HOOKS_ENABLED !== 'false';
+  }
+
+  /**
+   * Runs after a successful payment record. Never throws — failures are logged only.
+   */
+  async onPaymentRecorded(params: PaymentRecordedFraudParams): Promise<void> {
+    if (!this.hooksEnabled()) {
+      return;
+    }
+    try {
+      await this.fraudService.checkTransactionFraud({
+        userId: params.userId,
+        amount: params.amount,
+        currency: params.currency ?? 'NGN',
+        paymentMethod: params.paymentMethod,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Fraud transaction hook failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Runs after a listing is published. Never throws — failures are logged only.
+   */
+  async onListingPublished(propertyId: string): Promise<void> {
+    if (!this.hooksEnabled()) {
+      return;
+    }
+    try {
+      await this.fraudService.checkListingFraud(propertyId);
+    } catch (err) {
+      this.logger.warn(
+        `Fraud listing hook failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}

--- a/backend/src/modules/fraud/fraud-model.service.ts
+++ b/backend/src/modules/fraud/fraud-model.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FraudDecision, FraudFeatures } from './fraud.types';
+
+interface FraudModelArtifact {
+  modelVersion: string;
+  thresholdReview: number;
+  thresholdBlock: number;
+  featureWeights: Record<string, number>;
+}
+
+@Injectable()
+export class FraudModelService {
+  private readonly logger = new Logger(FraudModelService.name);
+
+  private readonly defaultModel: FraudModelArtifact = {
+    modelVersion: 'rules-v1',
+    thresholdReview: 45,
+    thresholdBlock: 75,
+    featureWeights: {
+      accountAgeDays: -0.6,
+      failedLoginAttempts: 2.2,
+      loginCount: -0.2,
+      isKycVerified: -1.8,
+      listingPriceAnomaly: 2.4,
+      listingContentRisk: 1.8,
+      paymentAmountAnomaly: 2.6,
+      rapidPaymentVelocity: 2.2,
+      paymentFailureRate: 1.8,
+      newPaymentMethodRisk: 1.1,
+    },
+  };
+
+  private readonly model: FraudModelArtifact;
+
+  constructor() {
+    this.model = this.loadModelArtifact();
+  }
+
+  getModelVersion(): string {
+    return this.model.modelVersion;
+  }
+
+  score(features: FraudFeatures): {
+    score: number;
+    decision: FraudDecision;
+    reasons: string[];
+  } {
+    let raw = 0;
+    const reasons: string[] = [];
+
+    for (const [featureName, featureValue] of Object.entries(features)) {
+      const weight = this.model.featureWeights[featureName] ?? 0;
+      raw += weight * featureValue;
+
+      if (weight > 0 && featureValue >= 0.8) {
+        reasons.push(featureName);
+      }
+    }
+
+    const normalizedScore = Math.max(
+      0,
+      Math.min(100, Math.round(50 + raw * 10)),
+    );
+    const decision =
+      normalizedScore >= this.model.thresholdBlock
+        ? 'block'
+        : normalizedScore >= this.model.thresholdReview
+          ? 'review'
+          : 'allow';
+
+    return {
+      score: normalizedScore,
+      decision,
+      reasons: reasons.length > 0 ? reasons : ['no_high_risk_signals'],
+    };
+  }
+
+  private loadModelArtifact(): FraudModelArtifact {
+    const artifactPath = path.resolve(
+      process.cwd(),
+      'ai-services/fraud/model-artifacts/fraud-model.json',
+    );
+
+    if (!fs.existsSync(artifactPath)) {
+      this.logger.warn(
+        'Fraud model artifact not found, using fallback scoring model.',
+      );
+      return this.defaultModel;
+    }
+
+    try {
+      const artifact = JSON.parse(
+        fs.readFileSync(artifactPath, 'utf-8'),
+      ) as FraudModelArtifact;
+
+      if (
+        !artifact.modelVersion ||
+        !artifact.featureWeights ||
+        typeof artifact.thresholdReview !== 'number' ||
+        typeof artifact.thresholdBlock !== 'number'
+      ) {
+        throw new Error('Fraud model artifact is missing required fields');
+      }
+
+      return artifact;
+    } catch (error) {
+      this.logger.error(
+        'Failed to load fraud model artifact, using fallback model.',
+        error instanceof Error ? error.stack : String(error),
+      );
+      return this.defaultModel;
+    }
+  }
+}

--- a/backend/src/modules/fraud/fraud.controller.ts
+++ b/backend/src/modules/fraud/fraud.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../users/entities/user.entity';
+import { CheckTransactionFraudDto } from './dto/check-transaction-fraud.dto';
+import { FraudAlertsService } from './fraud-alerts.service';
+import { FraudService } from './fraud.service';
+
+@ApiTags('Fraud')
+@Controller('fraud')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+@ApiBearerAuth('JWT-auth')
+export class FraudController {
+  constructor(
+    private readonly fraudService: FraudService,
+    private readonly fraudAlertsService: FraudAlertsService,
+  ) {}
+
+  @Get('user/:userId')
+  @ApiOperation({ summary: 'Check user fraud risk' })
+  @ApiParam({ name: 'userId', description: 'User ID to check' })
+  async checkUserFraud(@Param('userId') userId: string) {
+    return this.fraudService.checkUserFraud(userId);
+  }
+
+  @Get('listing/:listingId')
+  @ApiOperation({ summary: 'Check listing fraud risk' })
+  @ApiParam({ name: 'listingId', description: 'Listing ID to check' })
+  async checkListingFraud(@Param('listingId') listingId: string) {
+    return this.fraudService.checkListingFraud(listingId);
+  }
+
+  @Get('alerts')
+  @ApiOperation({ summary: 'Get fraud alerts' })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['open', 'resolved'],
+  })
+  getFraudAlerts(@Query('status') status?: 'open' | 'resolved') {
+    return this.fraudAlertsService.listAlerts(status);
+  }
+
+  @Patch('alerts/:alertId/resolve')
+  @ApiOperation({ summary: 'Resolve a fraud alert' })
+  @ApiParam({ name: 'alertId', description: 'Alert ID to resolve' })
+  @ApiResponse({
+    status: 200,
+    description: 'Alert resolved or already resolved',
+  })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  resolveFraudAlert(@Param('alertId') alertId: string) {
+    return this.fraudAlertsService.resolveAlert(alertId);
+  }
+
+  @Post('transaction')
+  @ApiOperation({ summary: 'Check transaction fraud risk' })
+  async checkTransactionFraud(@Body() payload: CheckTransactionFraudDto) {
+    return this.fraudService.checkTransactionFraud(payload);
+  }
+}

--- a/backend/src/modules/fraud/fraud.module.ts
+++ b/backend/src/modules/fraud/fraud.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Payment } from '../payments/entities/payment.entity';
+import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
+import { FraudAlertEntity } from './entities/fraud-alert.entity';
+import { FraudAlertsService } from './fraud-alerts.service';
+import { FraudController } from './fraud.controller';
+import { FraudFeatureExtractionService } from './fraud-feature-extraction.service';
+import { FraudHooksService } from './fraud-hooks.service';
+import { FraudModelService } from './fraud-model.service';
+import { FraudService } from './fraud.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, Property, Payment, FraudAlertEntity]),
+  ],
+  controllers: [FraudController],
+  providers: [
+    FraudService,
+    FraudFeatureExtractionService,
+    FraudModelService,
+    FraudAlertsService,
+    FraudHooksService,
+  ],
+  exports: [FraudService, FraudHooksService],
+})
+export class FraudModule {}

--- a/backend/src/modules/fraud/fraud.service.ts
+++ b/backend/src/modules/fraud/fraud.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Payment } from '../payments/entities/payment.entity';
+import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
+import { CheckTransactionFraudDto } from './dto/check-transaction-fraud.dto';
+import { FraudAlertsService } from './fraud-alerts.service';
+import { FraudFeatureExtractionService } from './fraud-feature-extraction.service';
+import { FraudModelService } from './fraud-model.service';
+import { FraudScoreResult } from './fraud.types';
+
+@Injectable()
+export class FraudService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    @InjectRepository(Property)
+    private readonly propertiesRepository: Repository<Property>,
+    @InjectRepository(Payment)
+    private readonly paymentsRepository: Repository<Payment>,
+    private readonly featureExtraction: FraudFeatureExtractionService,
+    private readonly modelService: FraudModelService,
+    private readonly alertsService: FraudAlertsService,
+  ) {}
+
+  async checkUserFraud(userId: string): Promise<FraudScoreResult> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const features = this.featureExtraction.extractUserFeatures(user);
+    const scored = this.modelService.score(features);
+    const result: FraudScoreResult = {
+      ...scored,
+      features,
+      modelVersion: this.modelService.getModelVersion(),
+    };
+    await this.alertsService.createAlert('user', userId, result);
+    return result;
+  }
+
+  async checkListingFraud(listingId: string): Promise<FraudScoreResult> {
+    const listing = await this.propertiesRepository.findOne({
+      where: { id: listingId },
+    });
+    if (!listing) {
+      throw new NotFoundException('Listing not found');
+    }
+
+    const ownerPromise = this.usersRepository.findOne({
+      where: { id: listing.ownerId },
+    });
+    const peerListingsPromise = listing.city
+      ? this.propertiesRepository.find({
+          where: { city: listing.city },
+          take: 30,
+        })
+      : this.propertiesRepository.find({
+          order: { createdAt: 'DESC' },
+          take: 30,
+        });
+
+    const [owner, peerListings] = await Promise.all([
+      ownerPromise,
+      peerListingsPromise,
+    ]);
+
+    const features = this.featureExtraction.extractListingFeatures(
+      listing,
+      owner,
+      peerListings,
+    );
+    const scored = this.modelService.score(features);
+    const result: FraudScoreResult = {
+      ...scored,
+      features,
+      modelVersion: this.modelService.getModelVersion(),
+    };
+    await this.alertsService.createAlert('listing', listingId, result);
+    return result;
+  }
+
+  async checkTransactionFraud(
+    payload: CheckTransactionFraudDto,
+  ): Promise<FraudScoreResult> {
+    const user = await this.usersRepository.findOne({
+      where: { id: payload.userId },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const recentPayments = await this.paymentsRepository.find({
+      where: { userId: payload.userId },
+      order: { createdAt: 'DESC' },
+      take: 50,
+    });
+
+    const features = this.featureExtraction.extractTransactionFeatures(
+      user,
+      recentPayments,
+      payload.amount,
+      payload.paymentMethod,
+    );
+    const scored = this.modelService.score(features);
+    const result: FraudScoreResult = {
+      ...scored,
+      features,
+      modelVersion: this.modelService.getModelVersion(),
+    };
+    await this.alertsService.createAlert('transaction', payload.userId, result);
+    return result;
+  }
+}

--- a/backend/src/modules/fraud/fraud.types.ts
+++ b/backend/src/modules/fraud/fraud.types.ts
@@ -1,0 +1,27 @@
+export type FraudSubjectType = 'user' | 'listing' | 'transaction';
+
+export type FraudDecision = 'allow' | 'review' | 'block';
+
+export interface FraudFeatures {
+  [featureName: string]: number;
+}
+
+export interface FraudScoreResult {
+  score: number;
+  decision: FraudDecision;
+  reasons: string[];
+  features: FraudFeatures;
+  modelVersion: string;
+}
+
+export interface FraudAlert {
+  id: string;
+  subjectType: FraudSubjectType;
+  subjectId: string;
+  score: number;
+  decision: FraudDecision;
+  reasons: string[];
+  createdAt: string;
+  resolvedAt?: string;
+  status: 'open' | 'resolved';
+}

--- a/backend/src/modules/payments/payment.controller.spec.ts
+++ b/backend/src/modules/payments/payment.controller.spec.ts
@@ -195,8 +195,8 @@ describe('Payment Controllers', () => {
 
   it('processes stellar rent payment with user id', async () => {
     const dto: ProcessStellarRentGatewayDto = {
-      tenantAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-      tenantSecret: 'SSECRET',
+      userAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      userSecret: 'SSECRET',
       agreementId: 'agreement_1',
       amount: '12.5',
     };

--- a/backend/src/modules/payments/payment.module.ts
+++ b/backend/src/modules/payments/payment.module.ts
@@ -15,6 +15,7 @@ import { PaymentSchedule } from './entities/payment-schedule.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { FraudModule } from '../fraud/fraud.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { StellarModule } from '../stellar/stellar.module';
     NotificationsModule,
     UsersModule,
     StellarModule,
+    FraudModule,
   ],
   controllers: [
     PaymentController,

--- a/backend/src/modules/payments/payment.service.spec.ts
+++ b/backend/src/modules/payments/payment.service.spec.ts
@@ -22,6 +22,7 @@ import { StellarService } from '../stellar/services/stellar.service';
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { LockService } from '../../common/lock';
 import { IdempotencyService } from '../../common/idempotency';
+import { FraudHooksService } from '../fraud/fraud-hooks.service';
 
 const mockPaymentRepository = () => ({
   findOne: jest.fn(),
@@ -100,6 +101,10 @@ const mockDataSource = {
   ),
 };
 
+const mockFraudHooksService = {
+  onPaymentRecorded: jest.fn().mockResolvedValue(undefined),
+};
+
 describe('PaymentService', () => {
   let service: PaymentService;
   let paymentRepository: Repository<Payment>;
@@ -153,6 +158,10 @@ describe('PaymentService', () => {
         {
           provide: DataSource,
           useValue: mockDataSource,
+        },
+        {
+          provide: FraudHooksService,
+          useValue: mockFraudHooksService,
         },
       ],
     }).compile();
@@ -216,6 +225,7 @@ describe('PaymentService', () => {
         id: 'pay_1',
         amount: 100,
         currency: 'NGN',
+        paymentMethod: 'card',
       });
 
       const dto: CreatePaymentRecordDto = {
@@ -233,6 +243,12 @@ describe('PaymentService', () => {
         expect.stringContaining('100'),
         'PAYMENT_RECEIVED',
       );
+      expect(mockFraudHooksService.onPaymentRecorded).toHaveBeenCalledWith({
+        userId: 'user_1',
+        amount: 100,
+        currency: 'NGN',
+        paymentMethod: 'card',
+      });
     });
 
     it('throws when gateway fails and records failed payment', async () => {
@@ -512,12 +528,15 @@ describe('PaymentService', () => {
       (paymentRepository.save as jest.Mock).mockResolvedValue({
         id: 'payment_xlm_1',
         status: PaymentStatus.COMPLETED,
+        amount: 25.5,
+        currency: 'XLM',
+        paymentMethod: null,
       });
 
       const result = await service.processStellarRentPayment(
         {
-          tenantAddress: tenantKeypair.publicKey(),
-          tenantSecret: tenantKeypair.secret(),
+          userAddress: tenantKeypair.publicKey(),
+          userSecret: tenantKeypair.secret(),
           agreementId: 'agreement_1',
           amount: '25.5',
         },
@@ -528,6 +547,12 @@ describe('PaymentService', () => {
       expect(
         mockPaymentProcessingService.processRentPayment,
       ).toHaveBeenCalled();
+      expect(mockFraudHooksService.onPaymentRecorded).toHaveBeenCalledWith({
+        userId: 'user_1',
+        amount: 25.5,
+        currency: 'XLM',
+        paymentMethod: undefined,
+      });
     });
 
     it('creates a stellar escrow deposit payment record', async () => {

--- a/backend/src/modules/payments/payment.service.ts
+++ b/backend/src/modules/payments/payment.service.ts
@@ -48,6 +48,7 @@ import {
 import { RefundEscrowDto, ReleaseEscrowDto } from '../stellar/dto/escrow.dto';
 import { TransactionStatus } from '../stellar/entities/stellar-transaction.entity';
 import { Idempotent, IdempotencyService } from '../../common/idempotency';
+import { FraudHooksService } from '../fraud/fraud-hooks.service';
 
 @Injectable()
 export class PaymentService {
@@ -67,6 +68,7 @@ export class PaymentService {
     private readonly lockService: LockService,
     private readonly idempotencyService: IdempotencyService,
     private readonly dataSource: DataSource,
+    private readonly fraudHooksService: FraudHooksService,
   ) {}
 
   @Locked({
@@ -176,6 +178,13 @@ export class PaymentService {
 
     const savedPayment = await this.paymentRepository.save(payment);
     this.logger.log(`Payment recorded: ${savedPayment.id}`);
+
+    void this.fraudHooksService.onPaymentRecorded({
+      userId,
+      amount: Number(savedPayment.amount),
+      currency: savedPayment.currency,
+      paymentMethod: savedPayment.paymentMethod ?? undefined,
+    });
 
     await this.notificationsService.notify(
       userId,
@@ -622,6 +631,12 @@ export class PaymentService {
       });
 
       const saved = await this.paymentRepository.save(payment);
+      void this.fraudHooksService.onPaymentRecorded({
+        userId,
+        amount: Number(saved.amount),
+        currency: saved.currency,
+        paymentMethod: saved.paymentMethod ?? undefined,
+      });
       await this.notificationsService.notify(
         userId,
         'Stellar rent payment processed',

--- a/backend/src/modules/properties/properties.module.ts
+++ b/backend/src/modules/properties/properties.module.ts
@@ -17,10 +17,12 @@ import { PropertyListingDraft } from './entities/property-listing-draft.entity';
 import { PropertyAvailability } from './entities/property-availability.entity';
 import { AvailabilityService } from './availability.service';
 import { AvailabilityController } from './availability.controller';
+import { FraudModule } from '../fraud/fraud.module';
 
 @Module({
   imports: [
     ScheduleModule,
+    FraudModule,
     TypeOrmModule.forFeature([
       Property,
       PropertyImage,

--- a/backend/src/modules/properties/properties.service.spec.ts
+++ b/backend/src/modules/properties/properties.service.spec.ts
@@ -20,6 +20,7 @@ import { RentalUnit } from './entities/rental-unit.entity';
 import { PropertyListingDraft } from './entities/property-listing-draft.entity';
 import { User, UserRole, AuthMethod } from '../users/entities/user.entity';
 import { KycStatus } from '../kyc/kyc-status.enum';
+import { FraudHooksService } from '../fraud/fraud-hooks.service';
 
 describe('PropertiesService', () => {
   let service: PropertiesService;
@@ -183,6 +184,10 @@ describe('PropertiesService', () => {
     remove: jest.fn(),
   };
 
+  const mockFraudHooksService = {
+    onListingPublished: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     mockCacheService.getOrSet.mockImplementation(
       async (_key: string, factory: () => Promise<unknown>) => factory(),
@@ -217,6 +222,10 @@ describe('PropertiesService', () => {
         {
           provide: CacheService,
           useValue: mockCacheService,
+        },
+        {
+          provide: FraudHooksService,
+          useValue: mockFraudHooksService,
         },
       ],
     }).compile();
@@ -541,6 +550,7 @@ describe('PropertiesService', () => {
     });
 
     it('should strip verificationStatus for non-admin owners', async () => {
+      const ownerUser = { ...mockOwner, role: UserRole.USER };
       const draft = { ...mockProperty, verificationStatus: null };
       mockPropertyRepository.findOne.mockResolvedValue(draft);
       mockPropertyRepository.save.mockImplementation((p) => Promise.resolve(p));
@@ -548,7 +558,7 @@ describe('PropertiesService', () => {
       await service.update(
         'property-id',
         { verificationStatus: 'verified', title: 'T' },
-        mockOwner,
+        ownerUser,
       );
 
       expect(mockPropertyRepository.save).toHaveBeenCalledWith(
@@ -609,6 +619,9 @@ describe('PropertiesService', () => {
       const result = await service.publish('property-id', mockOwner);
 
       expect(result.status).toBe(ListingStatus.PUBLISHED);
+      expect(mockFraudHooksService.onListingPublished).toHaveBeenCalledWith(
+        'property-id',
+      );
     });
 
     it('should throw BadRequestException if already published', async () => {

--- a/backend/src/modules/properties/properties.service.ts
+++ b/backend/src/modules/properties/properties.service.ts
@@ -27,6 +27,7 @@ import {
   CACHE_PREFIX_PROPERTIES_LIST,
   TTL_PUBLIC_PROPERTY_LIST_MS,
 } from '../../common/cache/cache.constants';
+import { FraudHooksService } from '../fraud/fraud-hooks.service';
 
 @Injectable()
 export class PropertiesService {
@@ -42,6 +43,7 @@ export class PropertiesService {
     @InjectRepository(PropertyListingDraft)
     private readonly propertyListingDraftRepository: Repository<PropertyListingDraft>,
     private readonly cacheService: CacheService,
+    private readonly fraudHooksService: FraudHooksService,
   ) {}
 
   private generateCacheKey(query: QueryPropertyDto): string {
@@ -320,6 +322,7 @@ export class PropertiesService {
     property.status = ListingStatus.PUBLISHED;
     const saved = await this.propertyRepository.save(property);
     await this.cacheService.invalidatePropertyDomainCaches(id);
+    void this.fraudHooksService.onListingPublished(saved.id);
     return saved;
   }
 

--- a/backend/src/modules/security/security-hardening.spec.ts
+++ b/backend/src/modules/security/security-hardening.spec.ts
@@ -220,14 +220,21 @@ describe('RbacService', () => {
     }
   });
 
-  it('landlord should be able to create properties', () => {
+  it('user should have READ but not CREATE on properties', () => {
     expect(
       service.hasPermission(
-        'landlord',
+        'user',
+        PermissionResource.PROPERTIES,
+        PermissionAction.READ,
+      ),
+    ).toBe(true);
+    expect(
+      service.hasPermission(
+        'user',
         PermissionResource.PROPERTIES,
         PermissionAction.CREATE,
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('tenant should NOT be able to delete properties', () => {

--- a/frontend/app/user/documents/[id]/page.tsx
+++ b/frontend/app/user/documents/[id]/page.tsx
@@ -4,8 +4,6 @@ interface PageProps {
   };
 }
 
-export default function UserDocumentDetailPage({
-  params: _params,
-}: PageProps) {
+export default function UserDocumentDetailPage({ params: _params }: PageProps) {
   return null;
 }

--- a/frontend/components/Properties-navbar.tsx
+++ b/frontend/components/Properties-navbar.tsx
@@ -105,7 +105,6 @@ const Navbar = () => {
                 </Link>
               );
             })}
-
           </div>
         </div>
       )}

--- a/frontend/components/admin-dashboard/navigation.ts
+++ b/frontend/components/admin-dashboard/navigation.ts
@@ -134,9 +134,9 @@ export function getAdminBreadcrumbItems(pathname: string): Array<{
       index === segments.length - 1
         ? undefined
         : `/${pathname
-          .split('/')
-          .filter(Boolean)
-          .slice(0, index + 1)
-          .join('/')}`,
+            .split('/')
+            .filter(Boolean)
+            .slice(0, index + 1)
+            .join('/')}`,
   }));
 }

--- a/frontend/components/landing/Hero.tsx
+++ b/frontend/components/landing/Hero.tsx
@@ -48,9 +48,9 @@ export default function Hero() {
             transition={{ duration: 0.5, delay: 0.2 }}
             className="text-xl md:text-2xl text-blue-100/90 max-w-3xl mx-auto leading-relaxed"
           >
-            Connect natively with users on the Stellar network.
-            Experience instant payouts and transparent contract tracking without
-            the paperwork.
+            Connect natively with users on the Stellar network. Experience
+            instant payouts and transparent contract tracking without the
+            paperwork.
           </motion.p>
 
           {/* Display Wallet Address if Connected */}

--- a/frontend/components/properties/PropertySearchFilters.tsx
+++ b/frontend/components/properties/PropertySearchFilters.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Search, Home, DollarSign, Calendar, ChevronDown, Filter, X } from 'lucide-react';
+import {
+  Search,
+  Home,
+  DollarSign,
+  Calendar,
+  ChevronDown,
+  Filter,
+  X,
+} from 'lucide-react';
 import { useState } from 'react';
 
 interface FilterOption {
@@ -58,10 +66,10 @@ export default function PropertySearchFilters() {
           <div className="relative flex-1">
             <Calendar className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-blue-200/50" />
             <input
-               type="date"
-               value={availability}
-               onChange={(e) => setAvailability(e.target.value)}
-               className="w-full appearance-none bg-slate-900/50 border border-white/5 rounded-2xl py-3.5 pl-12 pr-4 text-white placeholder:text-blue-200/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all cursor-pointer"
+              type="date"
+              value={availability}
+              onChange={(e) => setAvailability(e.target.value)}
+              className="w-full appearance-none bg-slate-900/50 border border-white/5 rounded-2xl py-3.5 pl-12 pr-4 text-white placeholder:text-blue-200/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all cursor-pointer"
             />
           </div>
 

--- a/frontend/components/user-dashboard/types.ts
+++ b/frontend/components/user-dashboard/types.ts
@@ -10,158 +10,158 @@ import type { LucideIcon } from 'lucide-react';
  * Navigation item for sidebar
  */
 export interface NavItem {
-    name: string;
-    href: string;
-    icon: LucideIcon;
-    badge?: number;
-    visibleFor?: ('user' | 'admin')[];
+  name: string;
+  href: string;
+  icon: LucideIcon;
+  badge?: number;
+  visibleFor?: ('user' | 'admin')[];
 }
 
 /**
  * KPI (Key Performance Indicator) data
  */
 export interface KPIData {
-    label: string;
-    value: string | number;
-    change?: number;
-    changeType?: 'increase' | 'decrease' | 'neutral';
-    icon?: ReactNode;
-    color?: 'blue' | 'green' | 'red' | 'yellow';
+  label: string;
+  value: string | number;
+  change?: number;
+  changeType?: 'increase' | 'decrease' | 'neutral';
+  icon?: ReactNode;
+  color?: 'blue' | 'green' | 'red' | 'yellow';
 }
 
 /**
  * Transaction record
  */
 export interface Transaction {
-    id: string;
-    type: 'rent' | 'deposit' | 'refund' | 'commission' | 'maintenance' | 'other';
-    amount: number;
-    currency: string;
-    status: 'completed' | 'pending' | 'failed';
-    date: string;
-    description: string;
-    reference?: string;
-    counterparty?: string;
+  id: string;
+  type: 'rent' | 'deposit' | 'refund' | 'commission' | 'maintenance' | 'other';
+  amount: number;
+  currency: string;
+  status: 'completed' | 'pending' | 'failed';
+  date: string;
+  description: string;
+  reference?: string;
+  counterparty?: string;
 }
 
 /**
  * Recent activity item
  */
 export interface ActivityItem {
-    id: string;
-    type: 'transaction' | 'dispute' | 'maintenance' | 'review' | 'document';
-    title: string;
-    description?: string;
-    timestamp: string;
-    icon?: ReactNode;
-    status?: 'pending' | 'completed' | 'failed';
+  id: string;
+  type: 'transaction' | 'dispute' | 'maintenance' | 'review' | 'document';
+  title: string;
+  description?: string;
+  timestamp: string;
+  icon?: ReactNode;
+  status?: 'pending' | 'completed' | 'failed';
 }
 
 /**
  * Property portfolio item
  */
 export interface PropertyPortfolioItem {
-    id: string;
-    name: string;
-    address: string;
-    image?: string;
-    status: 'active' | 'inactive' | 'maintenance';
-    occupancy?: number;
-    monthlyRevenue?: number;
-    tenants?: number;
+  id: string;
+  name: string;
+  address: string;
+  image?: string;
+  status: 'active' | 'inactive' | 'maintenance';
+  occupancy?: number;
+  monthlyRevenue?: number;
+  tenants?: number;
 }
 
 /**
  * Security deposit record
  */
 export interface SecurityDeposit {
-    id: string;
-    propertyId: string;
-    propertyName: string;
-    tenantName: string;
-    amount: number;
-    currency: string;
-    status: 'held' | 'released' | 'disputed';
-    releaseDate?: string;
-    notes?: string;
+  id: string;
+  propertyId: string;
+  propertyName: string;
+  tenantName: string;
+  amount: number;
+  currency: string;
+  status: 'held' | 'released' | 'disputed';
+  releaseDate?: string;
+  notes?: string;
 }
 
 /**
  * Dashboard layout props
  */
 export interface DashboardLayoutProps {
-    children: ReactNode;
-    sidebar?: ReactNode;
-    topbar?: ReactNode;
-    className?: string;
+  children: ReactNode;
+  sidebar?: ReactNode;
+  topbar?: ReactNode;
+  className?: string;
 }
 
 /**
  * Sidebar props
  */
 export interface SidebarProps {
-    navItems: NavItem[];
-    isOpen?: boolean;
-    onClose?: () => void;
-    userRole?: 'user' | 'admin';
-    className?: string;
+  navItems: NavItem[];
+  isOpen?: boolean;
+  onClose?: () => void;
+  userRole?: 'user' | 'admin';
+  className?: string;
 }
 
 /**
  * Topbar props
  */
 export interface TopbarProps {
-    pageTitle?: string;
-    showSearch?: boolean;
-    showNotifications?: boolean;
-    showUserMenu?: boolean;
-    className?: string;
+  pageTitle?: string;
+  showSearch?: boolean;
+  showNotifications?: boolean;
+  showUserMenu?: boolean;
+  className?: string;
 }
 
 /**
  * KPI Cards props
  */
 export interface KPICardsProps {
-    data: KPIData[];
-    columns?: 1 | 2 | 3 | 4;
-    className?: string;
+  data: KPIData[];
+  columns?: 1 | 2 | 3 | 4;
+  className?: string;
 }
 
 /**
  * Recent Activity props
  */
 export interface RecentActivityProps {
-    items: ActivityItem[];
-    maxItems?: number;
-    onItemClick?: (item: ActivityItem) => void;
-    className?: string;
+  items: ActivityItem[];
+  maxItems?: number;
+  onItemClick?: (item: ActivityItem) => void;
+  className?: string;
 }
 
 /**
  * Transactions Table props
  */
 export interface TransactionsTableProps {
-    transactions: Transaction[];
-    maxRows?: number;
-    onRowClick?: (transaction: Transaction) => void;
-    showFilters?: boolean;
-    className?: string;
+  transactions: Transaction[];
+  maxRows?: number;
+  onRowClick?: (transaction: Transaction) => void;
+  showFilters?: boolean;
+  className?: string;
 }
 
 /**
  * Property Portfolio props
  */
 export interface PropertyPortfolioProps {
-    properties: PropertyPortfolioItem[];
-    onPropertyClick?: (property: PropertyPortfolioItem) => void;
-    className?: string;
+  properties: PropertyPortfolioItem[];
+  onPropertyClick?: (property: PropertyPortfolioItem) => void;
+  className?: string;
 }
 
 /**
  * Security Deposits Section props
  */
 export interface SecurityDepositsSectionProps {
-    deposits: SecurityDeposit[];
-    onDepositClick?: (deposit: SecurityDeposit) => void;
-    className?: string;
+  deposits: SecurityDeposit[];
+  onDepositClick?: (deposit: SecurityDeposit) => void;
+  className?: string;
 }

--- a/frontend/components/user/ReviewDetail.tsx
+++ b/frontend/components/user/ReviewDetail.tsx
@@ -15,10 +15,7 @@ export default function ReviewDetail({ id }: { id: string }) {
 
   return (
     <div className="p-6 space-y-6">
-      <Link
-        href="/user/reviews"
-        className="text-blue-400 hover:text-blue-300"
-      >
+      <Link href="/user/reviews" className="text-blue-400 hover:text-blue-300">
         ← Back to Reviews
       </Link>
       <div className="bg-slate-800/50 border border-white/10 rounded-2xl p-6 shadow-xl">

--- a/frontend/components/user/ReviewForm.tsx
+++ b/frontend/components/user/ReviewForm.tsx
@@ -40,13 +40,15 @@ export function ReviewForm({ reviewId }: ReviewFormProps) {
       toast.error('Please connect your Web3 wallet to mint this rating.');
       return;
     }
-    
+
     setIsSubmitting(true);
-    toast.loading('Confirming transaction & minting NFT rating on-chain...', { id: 'mint' });
+    toast.loading('Confirming transaction & minting NFT rating on-chain...', {
+      id: 'mint',
+    });
     try {
       // Simulate blockchain minting interaction
-      await new Promise(r => setTimeout(r, 2000));
-      
+      await new Promise((r) => setTimeout(r, 2000));
+
       await updateReviewMutation.mutateAsync({
         id: reviewId,
         payload: { rating, comment },

--- a/frontend/data/user-nav-items.ts
+++ b/frontend/data/user-nav-items.ts
@@ -10,7 +10,7 @@ import {
   FileText,
   Users,
   Flag,
-  MessageSquare
+  MessageSquare,
 } from 'lucide-react';
 
 export const userNavItems: navItems[] = [

--- a/frontend/lib/admin-dispute-detail.ts
+++ b/frontend/lib/admin-dispute-detail.ts
@@ -412,9 +412,9 @@ export async function loadAdminDisputesList(): Promise<DashboardDispute[]> {
     const response = await apiClient.get<
       | DashboardDispute[]
       | {
-        disputes?: DashboardDispute[];
-        data?: DashboardDispute[];
-      }
+          disputes?: DashboardDispute[];
+          data?: DashboardDispute[];
+        }
     >('/admin/disputes');
     const body = response.data;
     const rows = Array.isArray(body)

--- a/frontend/lib/dashboard-data.ts
+++ b/frontend/lib/dashboard-data.ts
@@ -440,9 +440,7 @@ export async function loadLandlordDisputes(): Promise<DashboardDispute[]> {
   }
 }
 
-export async function loadReviewWorkspace(
-  role: 'user' | 'admin',
-): Promise<{
+export async function loadReviewWorkspace(role: 'user' | 'admin'): Promise<{
   targets: ReviewTarget[];
   reviews: DashboardReview[];
 }> {

--- a/frontend/mocks/entities/properties.ts
+++ b/frontend/mocks/entities/properties.ts
@@ -147,5 +147,5 @@ export const MOCK_PROPERTIES: Property[] = [
     latitude: 36.1147,
     longitude: -115.1728,
     amenities: ['Casino', 'Valet', '24/7 Security'],
-  }
+  },
 ];

--- a/frontend/mocks/entities/users.ts
+++ b/frontend/mocks/entities/users.ts
@@ -99,10 +99,7 @@ export function getUserByWalletAddress(
 ): User | undefined {
   if (!walletAddress) return undefined;
 
-  const allUsers = [
-    ...MOCK_USERS.users,
-    ...MOCK_USERS.admins,
-  ];
+  const allUsers = [...MOCK_USERS.users, ...MOCK_USERS.admins];
 
   return allUsers.find(
     (user) => user.walletAddress?.toLowerCase() === walletAddress.toLowerCase(),

--- a/frontend/store/wizard-store.ts
+++ b/frontend/store/wizard-store.ts
@@ -70,7 +70,9 @@ export const useWizardStore = create<WizardStore>()(
           const { useAuthStore } = await import('@/store/authStore');
           const { accessToken } = useAuthStore.getState();
 
-          const headers = accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+          const headers = accessToken
+            ? { Authorization: `Bearer ${accessToken}` }
+            : {};
 
           if (draftId) {
             const response = await axios.get(
@@ -147,7 +149,9 @@ export const useWizardStore = create<WizardStore>()(
           const { useAuthStore } = await import('@/store/authStore');
           const { accessToken } = useAuthStore.getState();
 
-          const headers = accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+          const headers = accessToken
+            ? { Authorization: `Bearer ${accessToken}` }
+            : {};
 
           const response = await axios.patch(
             `/api/property-listings/wizard/${draftId}/step`,


### PR DESCRIPTION
closes #529

## Summary
Implement a dedicated fraud module with model-backed scoring, persistent alerts, and admin APIs, and trigger fraud checks automatically on payment and listing publish flows. Align related tests/fixtures and frontend formatting so backend and frontend CI checks pass end-to-end.

