### PR TITLE
refactor: align chioma agreement ABI to admin/user naming

### DIFF
--- a/backend/src/modules/stellar/services/chioma-contract.service.ts
+++ b/backend/src/modules/stellar/services/chioma-contract.service.ts
@@ -448,7 +448,7 @@ export class ChiomaContractService {
   private parsePaymentSplit(result: xdr.ScVal): PaymentSplit {
     const native = StellarSdk.scValToNative(result);
     return {
-      adminAmount: native.landlord_amount?.toString() || '0',
+      adminAmount: native.admin_amount?.toString() || '0',
       agentAmount: native.agent_amount?.toString() || '0',
       totalAmount: native.total_amount?.toString() || '0',
     };

--- a/contract/contracts/chioma/src/agreement.rs
+++ b/contract/contracts/chioma/src/agreement.rs
@@ -47,10 +47,10 @@ pub fn validate_agreement_params(
 #[allow(clippy::too_many_arguments)]
 pub fn create_agreement(env: &Env, input: crate::types::AgreementInput) -> Result<(), RentalError> {
     // Tenant MUST authorize creation
-    input.tenant.require_auth();
+    input.user.require_auth();
 
     // Rate limiting check
-    rate_limit::check_rate_limit(env, &input.tenant, "create_agreement")?;
+    rate_limit::check_rate_limit(env, &input.user, "create_agreement")?;
 
     create_agreement_internal(env, input)
 }
@@ -84,8 +84,8 @@ fn create_agreement_internal(
     // Initialize agreement
     let agreement = RentAgreement {
         agreement_id: agreement_id.clone(),
-        landlord: input.landlord.clone(),
-        tenant: input.tenant.clone(),
+        admin: input.admin.clone(),
+        user: input.user.clone(),
         agent: input.agent.clone(),
         monthly_rent: input.terms.monthly_rent,
         security_deposit: input.terms.security_deposit,
@@ -129,8 +129,8 @@ fn create_agreement_internal(
     events::agreement_created(
         env,
         agreement_id,
-        agreement.tenant.clone(),
-        agreement.landlord.clone(),
+        agreement.user.clone(),
+        agreement.admin.clone(),
         agreement.monthly_rent,
         agreement.security_deposit,
         agreement.start_date,
@@ -142,12 +142,12 @@ fn create_agreement_internal(
 }
 
 /// Sign an agreement as the tenant
-pub fn sign_agreement(env: &Env, tenant: Address, agreement_id: String) -> Result<(), RentalError> {
+pub fn sign_agreement(env: &Env, user: Address, agreement_id: String) -> Result<(), RentalError> {
     // Tenant MUST authorize signing
-    tenant.require_auth();
+    user.require_auth();
 
     // Rate limiting check
-    rate_limit::check_rate_limit(env, &tenant, "sign_agreement")?;
+    rate_limit::check_rate_limit(env, &user, "sign_agreement")?;
 
     // Retrieve the agreement
     let mut agreement: RentAgreement = env
@@ -157,7 +157,7 @@ pub fn sign_agreement(env: &Env, tenant: Address, agreement_id: String) -> Resul
         .ok_or(RentalError::AgreementNotFound)?;
 
     // Validate caller is the intended tenant
-    if agreement.tenant != tenant {
+    if agreement.user != user {
         return Err(RentalError::NotTenant);
     }
 
@@ -191,8 +191,8 @@ pub fn sign_agreement(env: &Env, tenant: Address, agreement_id: String) -> Resul
     events::agreement_signed(
         env,
         agreement_id,
-        tenant,
-        agreement.landlord.clone(),
+        user,
+        agreement.admin.clone(),
         current_time,
     );
 
@@ -249,10 +249,10 @@ pub fn approve_agreement(
 /// Submit a draft agreement for tenant signature (Draft → Pending)
 pub fn submit_agreement(
     env: &Env,
-    landlord: Address,
+    admin: Address,
     agreement_id: String,
 ) -> Result<(), RentalError> {
-    landlord.require_auth();
+    admin.require_auth();
 
     let mut agreement: RentAgreement = env
         .storage()
@@ -260,7 +260,7 @@ pub fn submit_agreement(
         .get(&DataKey::Agreement(agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    if agreement.landlord != landlord {
+    if agreement.admin != admin {
         return Err(RentalError::Unauthorized);
     }
 
@@ -279,7 +279,7 @@ pub fn submit_agreement(
         TTL_BUMP,
     );
 
-    events::agreement_submitted(env, agreement_id, landlord, agreement.tenant.clone());
+    events::agreement_submitted(env, agreement_id, admin, agreement.user.clone());
 
     Ok(())
 }
@@ -299,7 +299,7 @@ pub fn cancel_agreement(
         .ok_or(RentalError::AgreementNotFound)?;
 
     // Only landlord can cancel
-    if agreement.landlord != caller {
+    if agreement.admin != caller {
         return Err(RentalError::Unauthorized);
     }
 
@@ -322,7 +322,7 @@ pub fn cancel_agreement(
         TTL_BUMP,
     );
 
-    events::agreement_cancelled(env, agreement_id, caller, agreement.tenant.clone());
+    events::agreement_cancelled(env, agreement_id, caller, agreement.user.clone());
 
     Ok(())
 }
@@ -397,7 +397,7 @@ pub fn update_metadata(
         .get(&DataKey::Agreement(agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    agreement.landlord.require_auth();
+    agreement.admin.require_auth();
 
     agreement.metadata_uri = metadata_uri;
     agreement.attributes = attributes;
@@ -414,7 +414,7 @@ pub fn create_agreement_with_token(
     env: &Env,
     input: crate::types::AgreementInput,
 ) -> Result<String, RentalError> {
-    input.tenant.require_auth();
+    input.user.require_auth();
 
     // Check if token is supported
     if !crate::multi_token::is_token_supported(env.clone(), input.payment_token.clone())? {
@@ -467,7 +467,7 @@ pub fn make_payment_with_token(
         return Err(RentalError::AgreementNotActive);
     }
 
-    agreement.tenant.require_auth();
+    agreement.user.require_auth();
 
     // Convert amount to the agreement's base token if they differ
     let amount_in_base = if token != agreement.payment_token {
@@ -487,7 +487,7 @@ pub fn make_payment_with_token(
 
     // Transfer tokens from tenant to contract (escrow)
     let client = soroban_sdk::token::Client::new(env, &token);
-    client.transfer(&agreement.tenant, env.current_contract_address(), &amount);
+    client.transfer(&agreement.user, env.current_contract_address(), &amount);
 
     // Update agreement state
     agreement.total_rent_paid += amount_in_base;
@@ -495,11 +495,11 @@ pub fn make_payment_with_token(
 
     // Simple split for now: 100% to landlord
     let split = PaymentSplit {
-        landlord_amount: amount_in_base,
+        admin_amount: amount_in_base,
         platform_amount: 0,
         token: token.clone(),
         payment_date: env.ledger().timestamp(),
-        payer: agreement.tenant.clone(),
+        payer: agreement.user.clone(),
     };
 
     let record_key = DataKey::PaymentRecord(agreement_id.clone(), agreement.payment_count);
@@ -533,14 +533,14 @@ pub fn release_escrow_with_token(
 
     // Only landlord can release? Or admin?
     // Let's assume landlord for this implementation
-    agreement.landlord.require_auth();
+    agreement.admin.require_auth();
 
     let contract_addr = env.current_contract_address();
     let client = soroban_sdk::token::Client::new(env, &token);
     let balance = client.balance(&contract_addr);
 
     if balance > 0 {
-        client.transfer(&contract_addr, &agreement.landlord, &balance);
+        client.transfer(&contract_addr, &agreement.admin, &balance);
     }
 
     events::escrow_released_with_token(env, escrow_id, token, balance);

--- a/contract/contracts/chioma/src/agreement.rs
+++ b/contract/contracts/chioma/src/agreement.rs
@@ -568,7 +568,7 @@ pub fn propose_extension(
         .get(&DataKey::Agreement(agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    if caller != agreement.landlord && caller != agreement.tenant {
+    if caller != agreement.admin && caller != agreement.user {
         return Err(RentalError::Unauthorized);
     }
 
@@ -590,8 +590,8 @@ pub fn propose_extension(
         status: ExtensionStatus::Proposed,
         created_at: env.ledger().timestamp(),
         proposed_by: caller.clone(),
-        landlord_accepted: caller == agreement.landlord,
-        tenant_accepted: caller == agreement.tenant,
+        landlord_accepted: caller == agreement.admin,
+        tenant_accepted: caller == agreement.user,
         last_reason: None,
     };
 
@@ -646,9 +646,9 @@ pub fn accept_extension(
         .get(&DataKey::Agreement(extension.original_agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    if caller == agreement.landlord {
+    if caller == agreement.admin {
         extension.landlord_accepted = true;
-    } else if caller == agreement.tenant {
+    } else if caller == agreement.user {
         extension.tenant_accepted = true;
     } else {
         return Err(RentalError::Unauthorized);
@@ -686,7 +686,7 @@ pub fn reject_extension(
         .get(&DataKey::Agreement(extension.original_agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    if caller != agreement.landlord && caller != agreement.tenant {
+    if caller != agreement.admin && caller != agreement.user {
         return Err(RentalError::Unauthorized);
     }
 
@@ -726,7 +726,7 @@ pub fn activate_extension(
         .get(&DataKey::Agreement(extension.original_agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    if caller != agreement.landlord {
+    if caller != agreement.admin {
         return Err(RentalError::Unauthorized);
     }
 
@@ -769,7 +769,7 @@ pub fn cancel_extension(
         .get(&DataKey::Agreement(extension.original_agreement_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    if caller != agreement.landlord && caller != agreement.tenant {
+    if caller != agreement.admin && caller != agreement.user {
         return Err(RentalError::Unauthorized);
     }
 

--- a/contract/contracts/chioma/src/deposit_interest.rs
+++ b/contract/contracts/chioma/src/deposit_interest.rs
@@ -277,7 +277,7 @@ pub fn distribute_interest(env: Env, escrow_id: String) -> Result<(), RentalErro
         .get::<DataKey, crate::types::RentAgreement>(&DataKey::Agreement(escrow_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    let (tenant_share, landlord_share) = match config.interest_recipient {
+    let (user_share, admin_share) = match config.interest_recipient {
         InterestRecipient::Tenant => (total, 0_i128),
         InterestRecipient::Landlord => (0_i128, total),
         InterestRecipient::Split => {
@@ -290,11 +290,11 @@ pub fn distribute_interest(env: Env, escrow_id: String) -> Result<(), RentalErro
     let token_client = soroban_sdk::token::Client::new(&env, &agreement.payment_token);
     let contract_self = env.current_contract_address();
 
-    if tenant_share > 0 {
-        token_client.transfer(&contract_self, &agreement.tenant, &tenant_share);
+    if user_share > 0 {
+        token_client.transfer(&contract_self, &agreement.user, &user_share);
     }
-    if landlord_share > 0 {
-        token_client.transfer(&contract_self, &agreement.landlord, &landlord_share);
+    if admin_share > 0 {
+        token_client.transfer(&contract_self, &agreement.admin, &admin_share);
     }
 
     // Reset accrued interest; principal remains.
@@ -304,6 +304,6 @@ pub fn distribute_interest(env: Env, escrow_id: String) -> Result<(), RentalErro
         .persistent()
         .set(&DataKey::DepositInterest(escrow_id.clone()), &di);
 
-    events::interest_distributed(&env, escrow_id, tenant_share, landlord_share);
+    events::interest_distributed(&env, escrow_id, user_share, admin_share);
     Ok(())
 }

--- a/contract/contracts/chioma/src/events.rs
+++ b/contract/contracts/chioma/src/events.rs
@@ -153,12 +153,7 @@ pub(crate) fn agreement_signed(
 }
 
 /// Helper function to emit agreement submitted event
-pub(crate) fn agreement_submitted(
-    env: &Env,
-    agreement_id: String,
-    admin: Address,
-    user: Address,
-) {
+pub(crate) fn agreement_submitted(env: &Env, agreement_id: String, admin: Address, user: Address) {
     AgreementSubmitted {
         admin,
         user,
@@ -168,12 +163,7 @@ pub(crate) fn agreement_submitted(
 }
 
 /// Helper function to emit agreement cancelled event
-pub(crate) fn agreement_cancelled(
-    env: &Env,
-    agreement_id: String,
-    admin: Address,
-    user: Address,
-) {
+pub(crate) fn agreement_cancelled(env: &Env, agreement_id: String, admin: Address, user: Address) {
     AgreementCancelled {
         admin,
         user,

--- a/contract/contracts/chioma/src/events.rs
+++ b/contract/contracts/chioma/src/events.rs
@@ -13,13 +13,13 @@ pub struct ContractInitialized {
 }
 
 /// Event emitted when an agreement is created
-/// Topics: ["agreement_created", tenant: Address, landlord: Address]
+/// Topics: ["agreement_created", user: Address, admin: Address]
 #[contractevent(topics = ["agreement_created"])]
 pub struct AgreementCreated {
     #[topic]
-    pub tenant: Address,
+    pub user: Address,
     #[topic]
-    pub landlord: Address,
+    pub admin: Address,
     pub agreement_id: String,
     pub monthly_rent: i128,
     pub security_deposit: i128,
@@ -29,36 +29,36 @@ pub struct AgreementCreated {
 }
 
 /// Event emitted when an agreement is signed
-/// Topics: ["agreement_signed", tenant: Address, landlord: Address]
+/// Topics: ["agreement_signed", user: Address, admin: Address]
 #[contractevent(topics = ["agreement_signed"])]
 pub struct AgreementSigned {
     #[topic]
-    pub tenant: Address,
+    pub user: Address,
     #[topic]
-    pub landlord: Address,
+    pub admin: Address,
     pub agreement_id: String,
     pub signed_at: u64,
 }
 
 /// Event emitted when an agreement is submitted for signing
-/// Topics: ["agreement_submitted", landlord: Address, tenant: Address]
+/// Topics: ["agreement_submitted", admin: Address, user: Address]
 #[contractevent(topics = ["agreement_submitted"])]
 pub struct AgreementSubmitted {
     #[topic]
-    pub landlord: Address,
+    pub admin: Address,
     #[topic]
-    pub tenant: Address,
+    pub user: Address,
     pub agreement_id: String,
 }
 
 /// Event emitted when an agreement is cancelled
-/// Topics: ["agreement_cancelled", landlord: Address, tenant: Address]
+/// Topics: ["agreement_cancelled", admin: Address, user: Address]
 #[contractevent(topics = ["agreement_cancelled"])]
 pub struct AgreementCancelled {
     #[topic]
-    pub landlord: Address,
+    pub admin: Address,
     #[topic]
-    pub tenant: Address,
+    pub user: Address,
     pub agreement_id: String,
 }
 
@@ -114,8 +114,8 @@ pub(crate) fn contract_initialized(env: &Env, admin: Address, config: Config) {
 pub(crate) fn agreement_created(
     env: &Env,
     agreement_id: String,
-    tenant: Address,
-    landlord: Address,
+    user: Address,
+    admin: Address,
     monthly_rent: i128,
     security_deposit: i128,
     start_date: u64,
@@ -123,8 +123,8 @@ pub(crate) fn agreement_created(
     agent: Option<Address>,
 ) {
     AgreementCreated {
-        tenant,
-        landlord,
+        user,
+        admin,
         agreement_id,
         monthly_rent,
         security_deposit,
@@ -139,13 +139,13 @@ pub(crate) fn agreement_created(
 pub(crate) fn agreement_signed(
     env: &Env,
     agreement_id: String,
-    tenant: Address,
-    landlord: Address,
+    user: Address,
+    admin: Address,
     signed_at: u64,
 ) {
     AgreementSigned {
-        tenant,
-        landlord,
+        user,
+        admin,
         agreement_id,
         signed_at,
     }
@@ -156,12 +156,12 @@ pub(crate) fn agreement_signed(
 pub(crate) fn agreement_submitted(
     env: &Env,
     agreement_id: String,
-    landlord: Address,
-    tenant: Address,
+    admin: Address,
+    user: Address,
 ) {
     AgreementSubmitted {
-        landlord,
-        tenant,
+        admin,
+        user,
         agreement_id,
     }
     .publish(env);
@@ -171,12 +171,12 @@ pub(crate) fn agreement_submitted(
 pub(crate) fn agreement_cancelled(
     env: &Env,
     agreement_id: String,
-    landlord: Address,
-    tenant: Address,
+    admin: Address,
+    user: Address,
 ) {
     AgreementCancelled {
-        landlord,
-        tenant,
+        admin,
+        user,
         agreement_id,
     }
     .publish(env);
@@ -310,8 +310,8 @@ pub struct InterestAccruedEvent {
 #[contractevent]
 pub struct InterestDistributed {
     pub escrow_id: String,
-    pub tenant_share: i128,
-    pub landlord_share: i128,
+    pub user_share: i128,
+    pub admin_share: i128,
 }
 
 pub(crate) fn interest_config_set(env: &Env, agreement_id: String, annual_rate: u32) {
@@ -334,13 +334,13 @@ pub(crate) fn interest_accrued(env: &Env, escrow_id: String, amount: i128, total
 pub(crate) fn interest_distributed(
     env: &Env,
     escrow_id: String,
-    tenant_share: i128,
-    landlord_share: i128,
+    user_share: i128,
+    admin_share: i128,
 ) {
     InterestDistributed {
         escrow_id,
-        tenant_share,
-        landlord_share,
+        user_share,
+        admin_share,
     }
     .publish(env);
 }

--- a/contract/contracts/chioma/src/lib.rs
+++ b/contract/contracts/chioma/src/lib.rs
@@ -508,11 +508,11 @@ impl Contract {
     /// @return Ok(()) on success.
     pub fn sign_agreement(
         env: Env,
-        tenant: Address,
+        user: Address,
         agreement_id: String,
     ) -> Result<(), RentalError> {
         Self::check_paused(&env)?;
-        agreement::sign_agreement(&env, tenant, agreement_id)
+        agreement::sign_agreement(&env, user, agreement_id)
     }
 
     /// Approve a pending agreement as a witness (PendingApproval → Active).
@@ -542,11 +542,11 @@ impl Contract {
     /// @return Ok(()) on success.
     pub fn submit_agreement(
         env: Env,
-        landlord: Address,
+        admin: Address,
         agreement_id: String,
     ) -> Result<(), RentalError> {
         Self::check_paused(&env)?;
-        agreement::submit_agreement(&env, landlord, agreement_id)
+        agreement::submit_agreement(&env, admin, agreement_id)
     }
 
     /// Cancel an agreement while in Draft or Pending state.

--- a/contract/contracts/chioma/src/royalties.rs
+++ b/contract/contracts/chioma/src/royalties.rs
@@ -28,11 +28,11 @@ pub fn set_royalty(
         .get::<DataKey, crate::types::RentAgreement>(&DataKey::Agreement(token_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    agreement.landlord.require_auth();
+    agreement.admin.require_auth();
 
     let config = RoyaltyConfig {
         token_id: token_id.clone(),
-        creator: agreement.landlord.clone(),
+        creator: agreement.admin.clone(),
         royalty_percentage,
         royalty_recipient: royalty_recipient.clone(),
     };
@@ -84,7 +84,7 @@ pub fn transfer_with_royalty(
         .get::<DataKey, crate::types::RentAgreement>(&DataKey::Agreement(token_id.clone()))
         .ok_or(RentalError::AgreementNotFound)?;
 
-    let current_landlord = agreement.landlord.clone();
+    let current_landlord = agreement.admin.clone();
     current_landlord.require_auth();
     to.require_auth(); // Buyer must authorize the payment
 
@@ -131,7 +131,7 @@ pub fn transfer_with_royalty(
         .set(&DataKey::RoyaltyPayments(token_id.clone()), &payments);
 
     // 4. Update agreement landlord
-    agreement.landlord = to;
+    agreement.admin = to;
     env.storage()
         .persistent()
         .set(&DataKey::Agreement(token_id), &agreement);

--- a/contract/contracts/chioma/src/tests.rs
+++ b/contract/contracts/chioma/src/tests.rs
@@ -588,8 +588,8 @@ fn create_pending_agreement(
 ) {
     client.create_agreement(&AgreementInput {
         agreement_id: String::from_str(env, agreement_id).clone(),
-        admin: landlord.clone(),
-        user: tenant.clone(),
+        admin: admin.clone(),
+        user: user.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests.rs
+++ b/contract/contracts/chioma/src/tests.rs
@@ -248,8 +248,8 @@ fn test_create_agreement_success() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: agent.clone(),
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -286,8 +286,8 @@ fn test_create_agreement_with_agent() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: Some(agent.clone()),
         terms: AgreementTerms {
             monthly_rent: 1500,
@@ -316,8 +316,8 @@ fn test_create_agreement_without_agent() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1200,
@@ -347,8 +347,8 @@ fn test_negative_rent_rejected() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: -100,
@@ -378,8 +378,8 @@ fn test_zero_monthly_rent_rejected() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 0,
@@ -409,8 +409,8 @@ fn test_invalid_dates_rejected() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -446,8 +446,8 @@ fn test_backdated_agreement_rejected() {
     // Try to create agreement with start_date more than 1 day in the past
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -482,8 +482,8 @@ fn test_agreement_within_grace_period_accepted() {
     // Create agreement with start_date within grace period (less than 1 day ago)
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -515,8 +515,8 @@ fn test_duplicate_agreement_id() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -532,8 +532,8 @@ fn test_duplicate_agreement_id() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -563,8 +563,8 @@ fn test_invalid_commission_rate() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -583,13 +583,13 @@ fn create_pending_agreement(
     env: &Env,
     client: &ContractClient,
     agreement_id: &str,
-    tenant: &Address,
-    landlord: &Address,
+    user: &Address,
+    admin: &Address,
 ) {
     client.create_agreement(&AgreementInput {
         agreement_id: String::from_str(env, agreement_id).clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -635,7 +635,7 @@ fn test_sign_agreement_success() {
         .unwrap();
     assert_eq!(agreement.status, AgreementStatus::PendingApproval);
     assert!(agreement.signed_at.is_some());
-    assert_eq!(agreement.tenant, tenant);
+    assert_eq!(agreement.user, tenant);
 }
 
 #[test]
@@ -681,8 +681,8 @@ fn test_sign_agreement_invalid_state() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, agreement_id).clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -713,8 +713,8 @@ fn test_sign_agreement_expired() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, agreement_id).clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -796,8 +796,8 @@ fn test_submit_agreement_success() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -847,8 +847,8 @@ fn test_submit_agreement_unauthorized() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -894,8 +894,8 @@ fn test_cancel_agreement_success_draft() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -962,8 +962,8 @@ fn test_cancel_agreement_unauthorized() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -1016,8 +1016,8 @@ fn test_get_agreement() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -1033,8 +1033,8 @@ fn test_get_agreement() {
 
     let agreement = client.get_agreement(&agreement_id).unwrap();
     assert_eq!(agreement.monthly_rent, 1000);
-    assert_eq!(agreement.landlord, landlord);
-    assert_eq!(agreement.tenant, tenant);
+    assert_eq!(agreement.admin, landlord);
+    assert_eq!(agreement.user, tenant);
 }
 
 #[test]
@@ -1052,8 +1052,8 @@ fn test_has_agreement() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -1083,8 +1083,8 @@ fn test_get_agreement_count() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "COUNT_001").clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -1102,8 +1102,8 @@ fn test_get_agreement_count() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "COUNT_002").clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -1143,8 +1143,8 @@ proptest! {
         // Disable panic catching since we expect some combinations to fail
         let result = client.try_create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent,
@@ -1216,8 +1216,8 @@ fn test_contract_paused_operations() {
 
     let res = client.try_create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "agreement-paused").clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -1239,8 +1239,8 @@ fn test_contract_paused_operations() {
     let agreement_id = String::from_str(&env, agreement_id_str);
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests_deposit_interest.rs
+++ b/contract/contracts/chioma/src/tests_deposit_interest.rs
@@ -48,8 +48,8 @@ fn create_agreement_helper(
 
     client.create_agreement(&AgreementInput {
         agreement_id: id.clone(),
-        admin: landlord.clone(),
-        user: tenant.clone(),
+        admin: admin.clone(),
+        user: user.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests_deposit_interest.rs
+++ b/contract/contracts/chioma/src/tests_deposit_interest.rs
@@ -33,8 +33,8 @@ fn setup(env: &Env) -> (ContractClient<'_>, Address) {
 fn create_agreement_helper(
     env: &Env,
     client: &ContractClient<'_>,
-    tenant: &Address,
-    landlord: &Address,
+    user: &Address,
+    admin: &Address,
     deposit: i128,
 ) -> String {
     let id = String::from_str(env, "AGR001");
@@ -48,8 +48,8 @@ fn create_agreement_helper(
 
     client.create_agreement(&AgreementInput {
         agreement_id: id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -693,8 +693,8 @@ fn test_process_interest_accruals_batch() {
 
         client.create_agreement(&AgreementInput {
             agreement_id: id.clone(),
-            landlord: landlord.clone(),
-            tenant: tenant.clone(),
+            admin: landlord.clone(),
+            user: tenant.clone(),
             agent: None,
             terms: AgreementTerms {
                 monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests_multi_token.rs
+++ b/contract/contracts/chioma/src/tests_multi_token.rs
@@ -98,8 +98,8 @@ fn test_create_agreement_with_token() {
     let property_id = String::from_str(&env, "PROP1");
     let agreement_id = client.create_agreement_with_token(&AgreementInput {
         agreement_id: property_id.clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -156,8 +156,8 @@ fn test_make_payment_with_different_token() {
 
     let agreement_id = client.create_agreement_with_token(&AgreementInput {
         agreement_id: String::from_str(&env, "PROP1").clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1100,
@@ -204,8 +204,8 @@ fn test_create_agreement_success() {
 
     let result = client.try_create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -221,8 +221,8 @@ fn test_create_agreement_success() {
 
     assert!(result.is_ok());
     let agreement = client.get_agreement(&agreement_id).unwrap();
-    assert_eq!(agreement.tenant, tenant);
-    assert_eq!(agreement.landlord, landlord);
+    assert_eq!(agreement.user, tenant);
+    assert_eq!(agreement.admin, landlord);
 }
 
 #[test]
@@ -240,8 +240,8 @@ fn test_validate_agreement_monthly_rent_positive() {
     // monthly_rent = 0 should fail
     let result = client.try_create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "AGR-INVALID-1"),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 0,
@@ -273,8 +273,8 @@ fn test_validate_agreement_security_deposit_nonnegative() {
     // security_deposit = 0 should succeed
     let result = client.try_create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "AGR-ZERO-DEPOSIT"),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -306,8 +306,8 @@ fn test_validate_agreement_start_before_end() {
     // start_date >= end_date should fail
     let result = client.try_create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "AGR-INVALID-DATES"),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -339,8 +339,8 @@ fn test_validate_agreement_commission_rate_max_100() {
     // agent_commission_rate > 100 should fail
     let result = client.try_create_agreement(&AgreementInput {
         agreement_id: String::from_str(&env, "AGR-INVALID-COMMISSION"),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -372,8 +372,8 @@ fn test_sign_agreement_transitions_to_pending() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -409,8 +409,8 @@ fn test_cancel_agreement_from_draft() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -455,8 +455,8 @@ fn test_duplicate_agreement_prevention() {
 
     let input = AgreementInput {
         agreement_id: agreement_id.clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -606,8 +606,8 @@ fn test_create_agreement_with_token_stores_token() {
 
     client.create_agreement_with_token(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        tenant: tenant.clone(),
-        landlord: landlord.clone(),
+        user: tenant.clone(),
+        admin: landlord.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests_rate_limit.rs
+++ b/contract/contracts/chioma/src/tests_rate_limit.rs
@@ -38,8 +38,8 @@ fn make_input(
 ) -> AgreementInput {
     AgreementInput {
         agreement_id: String::from_str(env, agreement_id),
-        admin: landlord.clone(),
-        user: tenant.clone(),
+        admin: admin.clone(),
+        user: user.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 100_000,

--- a/contract/contracts/chioma/src/tests_rate_limit.rs
+++ b/contract/contracts/chioma/src/tests_rate_limit.rs
@@ -32,14 +32,14 @@ fn create_contract() -> (Env, ContractClient<'static>, Address, Address) {
 fn make_input(
     env: &Env,
     agreement_id: &str,
-    landlord: &Address,
-    tenant: &Address,
+    admin: &Address,
+    user: &Address,
     payment_token: &Address,
 ) -> AgreementInput {
     AgreementInput {
         agreement_id: String::from_str(env, agreement_id),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 100_000,

--- a/contract/contracts/chioma/src/tests_royalties.rs
+++ b/contract/contracts/chioma/src/tests_royalties.rs
@@ -39,8 +39,8 @@ fn create_agreement_with_token(
 ) {
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        admin: landlord.clone(),
-        user: tenant.clone(),
+        admin: admin.clone(),
+        user: user.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests_royalties.rs
+++ b/contract/contracts/chioma/src/tests_royalties.rs
@@ -33,14 +33,14 @@ fn create_agreement_with_token(
     client: &ContractClient<'_>,
     env: &Env,
     agreement_id: &String,
-    landlord: &Address,
-    tenant: &Address,
+    admin: &Address,
+    user: &Address,
     token: &Address,
 ) {
     client.create_agreement(&AgreementInput {
         agreement_id: agreement_id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -68,8 +68,8 @@ fn test_set_and_get_royalty() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -104,8 +104,8 @@ fn test_calculate_royalty() {
     let token = Address::generate(&env);
     client.create_agreement(&AgreementInput {
         agreement_id: id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -139,8 +139,8 @@ fn test_transfer_with_royalty() {
 
     client.create_agreement(&AgreementInput {
         agreement_id: id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,
@@ -175,7 +175,7 @@ fn test_transfer_with_royalty() {
 
     // Verify agreement owner updated
     let ag = client.get_agreement(&id).unwrap();
-    assert_eq!(ag.landlord, buyer);
+    assert_eq!(ag.admin, buyer);
 
     // Verify payments history
     let payments = client.get_royalty_payments(&id);
@@ -200,8 +200,8 @@ fn test_invalid_royalty_percentage_fails() {
     let token = Address::generate(&env);
     client.create_agreement(&AgreementInput {
         agreement_id: id.clone(),
-        landlord: landlord.clone(),
-        tenant: tenant.clone(),
+        admin: landlord.clone(),
+        user: tenant.clone(),
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/tests_version_pause.rs
+++ b/contract/contracts/chioma/src/tests_version_pause.rs
@@ -460,8 +460,8 @@ fn test_operations_blocked_when_paused() {
     // This should fail
     client.create_agreement(&AgreementInput {
         agreement_id,
-        landlord,
-        tenant,
+        admin: landlord,
+        user: tenant,
         agent: None,
         terms: AgreementTerms {
             monthly_rent: 1000,

--- a/contract/contracts/chioma/src/types.rs
+++ b/contract/contracts/chioma/src/types.rs
@@ -89,8 +89,8 @@ pub struct Attribute {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RentAgreement {
     pub agreement_id: String,
-    pub landlord: Address,
-    pub tenant: Address,
+    pub admin: Address,
+    pub user: Address,
     pub agent: Option<Address>,
     pub monthly_rent: i128,
     pub security_deposit: i128,
@@ -111,7 +111,7 @@ pub struct RentAgreement {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PaymentSplit {
-    pub landlord_amount: i128,
+    pub admin_amount: i128,
     pub platform_amount: i128,
     pub token: Address,
     pub payment_date: u64,
@@ -299,8 +299,8 @@ pub enum RateLimitReason {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AgreementInput {
     pub agreement_id: String,
-    pub landlord: Address,
-    pub tenant: Address,
+    pub admin: Address,
+    pub user: Address,
     pub agent: Option<Address>,
     pub terms: AgreementTerms,
     pub payment_token: Address,


### PR DESCRIPTION
closes #837
Rename chioma contract agreement and payment split party fields from landlord/tenant to admin/user, and update backend Soroban decoding to match the new XDR field names so contract calls and serialization stay compatible.

