### PR TITLE
feat: add escrow freeze and unfreeze controls

### DIFF
--- a/contract/contracts/chioma/src/agreement.rs
+++ b/contract/contracts/chioma/src/agreement.rs
@@ -535,6 +535,10 @@ pub fn release_escrow_with_token(
         .get(&DataKey::Agreement(agreement_id))
         .ok_or(RentalError::AgreementNotFound)?;
 
+    if is_escrow_frozen(env, escrow_id.clone()) {
+        return Err(RentalError::InvalidState);
+    }
+
     // Only landlord can release? Or admin?
     // Let's assume landlord for this implementation
     agreement.admin.require_auth();
@@ -550,6 +554,30 @@ pub fn release_escrow_with_token(
     events::escrow_released_with_token(env, escrow_id, token, balance);
 
     Ok(())
+}
+
+pub fn set_escrow_frozen(env: &Env, escrow_id: String, is_frozen: bool) -> Result<(), RentalError> {
+    if !env
+        .storage()
+        .persistent()
+        .has(&DataKey::Agreement(escrow_id.clone()))
+    {
+        return Err(RentalError::AgreementNotFound);
+    }
+
+    let key = DataKey::EscrowFrozen(escrow_id);
+    env.storage().persistent().set(&key, &is_frozen);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+    Ok(())
+}
+
+pub fn is_escrow_frozen(env: &Env, escrow_id: String) -> bool {
+    env.storage()
+        .persistent()
+        .get::<DataKey, bool>(&DataKey::EscrowFrozen(escrow_id))
+        .unwrap_or(false)
 }
 
 pub fn propose_extension(

--- a/contract/contracts/chioma/src/lib.rs
+++ b/contract/contracts/chioma/src/lib.rs
@@ -54,9 +54,10 @@ pub use agreement::{
     accept_extension, activate_extension, approve_agreement, cancel_agreement, cancel_extension,
     create_agreement, create_agreement_with_token, get_agreement, get_agreement_count,
     get_agreement_token, get_current_agreement_end, get_extension, get_extension_history,
-    get_payment_history, get_payment_split, has_agreement, make_payment_with_token,
-    propose_extension, reject_extension, release_escrow_with_token, sign_agreement,
-    submit_agreement, update_metadata, validate_agreement_params,
+    get_payment_history, get_payment_split, has_agreement, is_escrow_frozen,
+    make_payment_with_token, propose_extension, reject_extension, release_escrow_with_token,
+    set_escrow_frozen, sign_agreement, submit_agreement, update_metadata,
+    validate_agreement_params,
 };
 pub use errors::RentalError;
 pub use multi_token::{
@@ -666,6 +667,47 @@ impl Contract {
     ) -> Result<(), RentalError> {
         Self::check_paused(&env)?;
         agreement::release_escrow_with_token(&env, escrow_id, token)
+    }
+
+    /// Freeze escrow funds for a specific agreement.
+    ///
+    /// Can be called by system admin or a configured multi-sig admin (DAO-voted entity).
+    pub fn freeze_escrow(env: Env, caller: Address, escrow_id: String) -> Result<(), RentalError> {
+        caller.require_auth();
+        let state = Self::get_state(env.clone()).ok_or(RentalError::InvalidState)?;
+        let is_system_admin = caller == state.admin;
+        let is_dao_admin = multi_sig::is_admin(&env, &caller).unwrap_or(false);
+
+        if !is_system_admin && !is_dao_admin {
+            return Err(RentalError::Unauthorized);
+        }
+
+        agreement::set_escrow_frozen(&env, escrow_id, true)
+    }
+
+    /// Unfreeze escrow funds for a specific agreement.
+    ///
+    /// Can be called by system admin or a configured multi-sig admin (DAO-voted entity).
+    pub fn unfreeze_escrow(
+        env: Env,
+        caller: Address,
+        escrow_id: String,
+    ) -> Result<(), RentalError> {
+        caller.require_auth();
+        let state = Self::get_state(env.clone()).ok_or(RentalError::InvalidState)?;
+        let is_system_admin = caller == state.admin;
+        let is_dao_admin = multi_sig::is_admin(&env, &caller).unwrap_or(false);
+
+        if !is_system_admin && !is_dao_admin {
+            return Err(RentalError::Unauthorized);
+        }
+
+        agreement::set_escrow_frozen(&env, escrow_id, false)
+    }
+
+    /// Check whether escrow funds are currently frozen for an agreement.
+    pub fn is_escrow_frozen(env: Env, escrow_id: String) -> bool {
+        agreement::is_escrow_frozen(&env, escrow_id)
     }
 
     /// Create a new rental agreement.

--- a/contract/contracts/chioma/src/storage.rs
+++ b/contract/contracts/chioma/src/storage.rs
@@ -36,6 +36,7 @@ pub enum DataKey {
     VersionHistory,
     AgreementExtension(String),
     ExtensionHistory(String),
+    EscrowFrozen(String),
     UpgradeProposal(String),
     UpgradeProposalCount,
     ActiveUpgradeProposals,

--- a/contract/contracts/chioma/src/tests.rs
+++ b/contract/contracts/chioma/src/tests.rs
@@ -1398,3 +1398,90 @@ fn test_unpause_unauthorized() {
         }])
         .unpause();
 }
+
+#[test]
+fn test_freeze_and_unfreeze_escrow_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let payment_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    let config = Config {
+        fee_bps: 100,
+        fee_collector: Address::generate(&env),
+        paused: false,
+    };
+    client.initialize(&admin, &config);
+
+    let agreement_id = String::from_str(&env, "FREEZE_001");
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        admin: admin.clone(),
+        user: user.clone(),
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token,
+        metadata_uri: String::from_str(&env, ""),
+        attributes: Vec::new(&env),
+    });
+
+    client.freeze_escrow(&admin, &agreement_id);
+    assert!(client.is_escrow_frozen(&agreement_id));
+
+    client.unfreeze_escrow(&admin, &agreement_id);
+    assert!(!client.is_escrow_frozen(&agreement_id));
+}
+
+#[test]
+fn test_release_escrow_fails_when_frozen() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let payment_token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    let config = Config {
+        fee_bps: 100,
+        fee_collector: Address::generate(&env),
+        paused: false,
+    };
+    client.initialize(&admin, &config);
+
+    let agreement_id = String::from_str(&env, "FREEZE_002");
+    client.create_agreement(&AgreementInput {
+        agreement_id: agreement_id.clone(),
+        admin: admin.clone(),
+        user,
+        agent: None,
+        terms: AgreementTerms {
+            monthly_rent: 1000,
+            security_deposit: 2000,
+            start_date: 100,
+            end_date: 1_000_000,
+            agent_commission_rate: 0,
+        },
+        payment_token: payment_token.clone(),
+        metadata_uri: String::from_str(&env, ""),
+        attributes: Vec::new(&env),
+    });
+
+    client.freeze_escrow(&admin, &agreement_id);
+
+    let result = client.try_release_escrow_with_token(&agreement_id, &payment_token);
+    assert_eq!(result, Err(Ok(RentalError::InvalidState)));
+}


### PR DESCRIPTION
closes #843

## Summary
Add escrow-level frozen state storage and admin/DAO-authorized freeze/unfreeze entrypoints, and block escrow release while frozen to protect funds during verified exploits or major disputes.

