### PR TITLE
Fix dashboard preview images and add testing docs

### DIFF
--- a/contract/docs/testing/DEBUGGING.md
+++ b/contract/docs/testing/DEBUGGING.md
@@ -1,0 +1,77 @@
+# Debugging Contract Tests
+
+## First Checks
+
+Start with the smallest failing command:
+
+```bash
+cd contract
+cargo test -p escrow release_escrow -- --nocapture
+```
+
+Then run the full contract suite before finishing:
+
+```bash
+cargo test
+```
+
+## Common Failures
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Unauthorized` | Missing auth mock or wrong actor | Use the correct actor and avoid `mock_all_auths` in auth-specific tests |
+| Missing storage value | Test did not initialize contract or used a different key | Check setup helper and `DataKey` variant |
+| Timeout test fails | Ledger timestamp/block was not advanced correctly | Set ledger info before action and advance across the boundary |
+| Event assertion fails | Topic order or payload shape changed | Compare emitted event with frontend/indexer contract |
+| Clippy failure | New warning introduced by tests or helpers | Fix warning; contract CI uses `-D warnings` |
+| WASM build failure | Host-only dependency or feature leaked into contract code | Gate host-only code with `#[cfg(test)]` or move it to tests |
+
+## Useful Commands
+
+Run one contract package:
+
+```bash
+cargo test -p chioma
+```
+
+Run one test by name:
+
+```bash
+cargo test escrow_timeout -- --nocapture
+```
+
+Run formatting:
+
+```bash
+cargo fmt --all
+```
+
+Run strict linting:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Run release WASM build:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+## Debugging Patterns
+
+- Print only temporary values while investigating; remove debug output before final checks unless it is part of a deliberate `--nocapture` troubleshooting example.
+- Reduce failing tests to one actor and one state transition before expanding the scenario.
+- Assert intermediate state after every important call in multi-step workflows.
+- If an auth test only passes with `mock_all_auths`, rewrite it with explicit mock auths.
+- If a time test is flaky, replace relative assumptions with explicit ledger timestamp setup.
+
+## PR Notes for Persistent Failures
+
+If a failure cannot be fixed in the same PR, document:
+
+- Exact command.
+- Exact error.
+- Whether the failure exists on the base branch.
+- Why the current change is or is not related.
+- Follow-up issue link.

--- a/contract/docs/testing/INTEGRATION-TESTS.md
+++ b/contract/docs/testing/INTEGRATION-TESTS.md
@@ -1,0 +1,82 @@
+# Integration Tests
+
+## Purpose
+
+Integration tests validate realistic workflows across multiple actors, state changes, and contract modules. They should prove the protocol flow works, not only that individual helpers compile.
+
+## Core Workflows
+
+| Workflow | Required assertions |
+|---|---|
+| Escrow creation and release | Deposit is created, approvals are recorded, release threshold is enforced, funds/state move once |
+| Escrow timeout | Timeout cannot execute early, succeeds at the correct boundary, emits timeout event |
+| Dispute lifecycle | Dispute opens, evidence is stored, arbiter decision updates final status, duplicate resolution is blocked |
+| Payment processing | Valid payment records state, failed payment does not mutate final balances, events are emitted |
+| Emergency pause | Paused contract rejects mutating calls and allows approved recovery/unpause flow |
+| Property registration | Owner can create/update property, unrelated users cannot mutate it |
+| User profile | Profile creation, update, and lookup remain consistent across repeated calls |
+
+## Actor Model
+
+Define actors in test setup and reuse the names in assertions:
+
+- `admin`
+- `tenant`
+- `landlord`
+- `agent`
+- `arbiter`
+- `attacker`
+
+Tests are easier to audit when the actor role is visible at the call site.
+
+## Ledger and Time Control
+
+For timeout or recurring-payment tests:
+
+- Set ledger timestamp before creating the record.
+- Advance the ledger to just before the deadline.
+- Assert the action fails.
+- Advance to the deadline or just after it.
+- Assert the action succeeds and cannot be repeated.
+
+## Event Assertions
+
+Integration tests should verify events for major externally observed actions. Assert both topics and important payload fields so indexers and dashboards remain compatible.
+
+## Example Flow
+
+```rust
+#[test]
+fn escrow_release_requires_two_distinct_approvals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let actors = setup_actors(&env);
+    let client = setup_escrow(&env, &actors.admin);
+
+    let escrow_id = client.create_escrow(
+        &actors.tenant,
+        &actors.landlord,
+        &actors.arbiter,
+        &1000_i128,
+    );
+
+    client.approve_release(&escrow_id, &actors.tenant);
+    assert!(client.try_release(&escrow_id).is_err());
+
+    client.approve_release(&escrow_id, &actors.landlord);
+    client.release(&escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+```
+
+## When to Add Integration Tests
+
+Add or update integration tests when a change:
+
+- Adds or changes a public method.
+- Changes authorization requirements.
+- Changes storage layout or migration behavior.
+- Changes timeout, payment, dispute, or escrow state machines.
+- Fixes a bug reported from a user workflow.

--- a/contract/docs/testing/TEST-COVERAGE.md
+++ b/contract/docs/testing/TEST-COVERAGE.md
@@ -1,0 +1,61 @@
+# Test Coverage Requirements
+
+## Coverage Policy
+
+Contract changes must include meaningful tests for changed behavior. The target is not only line coverage; tests must assert protocol invariants, authorization boundaries, and state transitions.
+
+## Required Coverage by Change Type
+
+| Change type | Required coverage |
+|---|---|
+| New public method | Success, invalid input, unauthorized caller, emitted event, storage state |
+| Bug fix | Regression test that fails before the fix and passes after it |
+| Storage change | Read/write behavior, missing key behavior, compatibility notes |
+| Error change | Exact error variant and caller-visible behavior |
+| Event change | Topic and payload assertion |
+| Timeout/rate limit change | Before boundary, at boundary, after boundary |
+| WASM-facing change | `cargo build --target wasm32-unknown-unknown --release` |
+
+## Critical Invariants
+
+Always protect these invariants with tests when touched:
+
+- Escrow funds cannot be released twice.
+- A single signer cannot satisfy multi-sig approval alone.
+- Disputes cannot be resolved more than once.
+- Paused contracts reject mutating operations.
+- Admin-only operations require admin authorization.
+- Payments cannot be marked complete without required state updates.
+- Property ownership cannot be changed by unrelated users.
+- User profiles cannot overwrite another user's profile.
+
+## Coverage Review Checklist
+
+- Does the test fail if the new behavior is removed?
+- Does it assert state, not just absence of panic?
+- Does it include a negative path?
+- Does it include the actor that should not be allowed?
+- Does it cover event payloads used by frontend/indexers?
+- Does it avoid sleeps, real network calls, and nondeterministic time?
+
+## Measuring Coverage
+
+Rust coverage tooling can vary by contributor environment. If coverage tooling is installed, use it as supporting evidence:
+
+```bash
+cd contract
+cargo llvm-cov --workspace --html
+```
+
+Coverage reports are useful, but PRs should not rely on coverage percentage alone. A small, high-signal invariant test is better than broad tests that do not assert contract behavior.
+
+## Known Gaps
+
+When a test cannot be added immediately, document the gap in the PR with:
+
+- The uncovered behavior.
+- Why it is blocked.
+- Manual verification performed.
+- Follow-up issue or owner.
+
+Do not merge contract changes with uncovered security-critical behavior unless maintainers explicitly accept the risk.

--- a/contract/docs/testing/TESTING-STRATEGY.md
+++ b/contract/docs/testing/TESTING-STRATEGY.md
@@ -1,0 +1,61 @@
+# Testing Strategy
+
+## Purpose
+
+Chioma contracts protect housing payments, escrow decisions, property records, and user profile data. The test strategy focuses on correctness first, then regression protection, gas-conscious design, and reproducible release checks.
+
+## Test Pyramid
+
+| Layer | Goal | Required for |
+|---|---|---|
+| Unit tests | Validate contract functions, storage helpers, events, and errors in isolation | Every new public method and every bug fix |
+| Integration tests | Validate multi-step flows across actors and contract state | Escrow, disputes, payments, pause controls, and admin workflows |
+| Regression tests | Lock behavior after a production bug or security finding | Every fixed defect |
+| Build checks | Prove contracts compile for host tests and WASM release target | Every PR touching `contract/` |
+
+## Minimum Coverage Expectations
+
+- Public contract methods: success path, authorization failure, invalid input, and relevant state transition.
+- Storage changes: write, read, overwrite or reject duplicate, and missing-record behavior.
+- Events: emitted topic and payload for user-visible state changes.
+- Errors: exact `ContractError` or domain error for expected failures.
+- Time-based logic: before timeout, at timeout boundary, and after timeout.
+- Admin-only logic: authorized admin, non-admin, and uninitialized or paused state when applicable.
+
+## Required Local Checks
+
+Run these before submitting a contract PR:
+
+```bash
+cd contract
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+cargo build --target wasm32-unknown-unknown --release
+```
+
+Use `./check-all.sh` when the script is available and executable in your environment.
+
+## Test Organization
+
+- Keep fast unit tests beside each contract in `contracts/<name>/src/tests.rs`.
+- Split large domains into focused files such as `tests_rate_limit.rs`, `tests_timelock.rs`, or `tests_errors.rs`.
+- Share setup helpers inside the contract test module rather than adding cross-contract coupling.
+- Name helpers by what they create, for example `create_initialized_env`, `register_agent`, or `create_funded_escrow`.
+
+## Pull Request Checklist
+
+- New behavior has unit tests.
+- Cross-actor workflows have integration-style tests.
+- Tests cover negative authorization paths.
+- Events and storage side effects are asserted.
+- `cargo test` passes locally.
+- Clippy passes with `-D warnings`.
+- WASM release build succeeds.
+
+## Documentation Map
+
+- [Unit Tests](./UNIT-TESTS.md)
+- [Integration Tests](./INTEGRATION-TESTS.md)
+- [Test Coverage](./TEST-COVERAGE.md)
+- [Debugging Tests](./DEBUGGING.md)

--- a/contract/docs/testing/UNIT-TESTS.md
+++ b/contract/docs/testing/UNIT-TESTS.md
@@ -1,0 +1,92 @@
+# Unit Tests
+
+## Standards
+
+Unit tests should exercise one behavior at a time and make the expected contract state obvious. Prefer small setup helpers over long repeated arrange blocks.
+
+## What to Test
+
+- Initialization: succeeds once, stores admin/config, rejects repeated initialization.
+- Authorization: `require_auth` paths for admin, owner, tenant, landlord, arbiter, and unrelated users.
+- Validation: empty IDs, invalid amounts, duplicate records, missing records, invalid statuses, and boundary values.
+- Storage helpers: all write and read functions, default values, and absence handling.
+- Events: emitted for create, update, release, pause, unpause, dispute, and payment lifecycle actions.
+- Errors: exact error variants, not only "it panics".
+
+## Naming Convention
+
+Use descriptive names with the expected behavior:
+
+```rust
+#[test]
+fn release_escrow_rejects_unapproved_signer() {
+    // ...
+}
+```
+
+Recommended patterns:
+
+- `function_succeeds_when_condition`
+- `function_rejects_when_condition`
+- `function_emits_event_when_condition`
+- `function_updates_storage_when_condition`
+
+## Structure
+
+Use Arrange, Act, Assert in that order:
+
+```rust
+#[test]
+fn create_profile_stores_profile_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let user = Address::generate(&env);
+    let client = UserProfileContractClient::new(&env, &env.register(UserProfileContract, ()));
+
+    client.create_profile(&user, &String::from_str(&env, "Ada"));
+
+    let profile = client.get_profile(&user);
+    assert_eq!(profile.name, String::from_str(&env, "Ada"));
+}
+```
+
+## Mocking and Fixtures
+
+- Use `Env::default()` for isolated test state.
+- Use `env.mock_all_auths()` only when the test is not specifically validating authorization.
+- Generate actors explicitly with names in setup helpers.
+- Keep fixture data minimal; include only fields needed by the behavior under test.
+- Avoid relying on test execution order or shared mutable state.
+
+## Boundary Cases
+
+Every numeric or time-sensitive function should test:
+
+- Zero or minimum accepted value.
+- Maximum realistic value.
+- One below and one above important thresholds.
+- Current ledger timestamp/block at, before, and after the boundary.
+
+## Good Test Example
+
+```rust
+#[test]
+fn pause_rejects_non_admin() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let client = setup_initialized_contract(&env, &admin);
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "pause",
+            args: vec![&env],
+            sub_invokes: &[],
+        },
+    }]);
+
+    assert_eq!(client.try_pause(), Err(Ok(ContractError::Unauthorized)));
+}
+```

--- a/frontend/app/user/financials/escrows/[id]/page.tsx
+++ b/frontend/app/user/financials/escrows/[id]/page.tsx
@@ -1,9 +1,151 @@
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  Calendar,
+  FileText,
+  ShieldCheck,
+  Wallet,
+} from 'lucide-react';
+
 interface PageProps {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
-export default function EscrowDetailPage({ params: _params }: PageProps) {
-  return null;
+interface EscrowPreview {
+  hash: string;
+  property: string;
+  amount: number;
+  status: string;
+  date: string;
+  type: string;
+  image: string;
+}
+
+const ESCROW_PREVIEWS: EscrowPreview[] = [
+  {
+    hash: 'GLMN5R7T\u20268C4D',
+    property: 'Glover Road, Ikoyi',
+    amount: 500000,
+    status: 'Processed',
+    date: 'Jun 05, 2025',
+    type: 'Deposit Refund',
+    image:
+      'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&w=1200&q=80',
+  },
+  {
+    hash: 'GABD6E9F\u20264M5N',
+    property: '101 Adeola Odeku St',
+    amount: 2500000,
+    status: 'Held',
+    date: 'Apr 28, 2025',
+    type: 'Security Deposit',
+    image:
+      'https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=1200&q=80',
+  },
+];
+
+const fallbackImage =
+  'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80';
+
+function normalizeHash(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, '').toUpperCase();
+}
+
+function findPreview(id: string): EscrowPreview {
+  const decodedId = decodeURIComponent(id);
+  return (
+    ESCROW_PREVIEWS.find(
+      (preview) => normalizeHash(preview.hash) === normalizeHash(decodedId),
+    ) ?? {
+      hash: decodedId,
+      property: 'Security deposit escrow',
+      amount: 0,
+      status: 'Pending',
+      date: 'Pending confirmation',
+      type: 'Escrow Preview',
+      image: fallbackImage,
+    }
+  );
+}
+
+export default async function EscrowDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const escrow = findPreview(id);
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href="/user/financials"
+        className="inline-flex items-center gap-2 text-sm font-bold text-blue-300 hover:text-white transition-colors"
+      >
+        <ArrowLeft size={16} />
+        Back to financials
+      </Link>
+
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-xl">
+        <div className="relative min-h-[320px]">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={escrow.image}
+            alt={`${escrow.property} escrow preview`}
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+          <div className="absolute inset-0 bg-slate-950/65" />
+          <div className="relative z-10 flex min-h-[320px] flex-col justify-end p-6 sm:p-8">
+            <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-emerald-400/30 bg-emerald-500/15 text-emerald-300">
+              <ShieldCheck size={28} />
+            </div>
+            <p className="text-xs font-bold uppercase tracking-widest text-blue-200/60">
+              {escrow.type}
+            </p>
+            <h1 className="mt-2 max-w-3xl text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              {escrow.property}
+            </h1>
+          </div>
+        </div>
+
+        <div className="grid gap-4 p-6 sm:grid-cols-3 sm:p-8">
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+            <div className="mb-3 flex items-center gap-2 text-blue-200/60">
+              <Wallet size={16} />
+              <span className="text-[10px] font-bold uppercase tracking-widest">
+                Amount
+              </span>
+            </div>
+            <p className="text-xl font-bold text-white">
+              {escrow.amount > 0
+                ? `$${escrow.amount.toLocaleString()} USDC`
+                : 'Awaiting amount'}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+            <div className="mb-3 flex items-center gap-2 text-blue-200/60">
+              <FileText size={16} />
+              <span className="text-[10px] font-bold uppercase tracking-widest">
+                Status
+              </span>
+            </div>
+            <p className="text-xl font-bold text-white">{escrow.status}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+            <div className="mb-3 flex items-center gap-2 text-blue-200/60">
+              <Calendar size={16} />
+              <span className="text-[10px] font-bold uppercase tracking-widest">
+                Date
+              </span>
+            </div>
+            <p className="text-xl font-bold text-white">{escrow.date}</p>
+          </div>
+        </div>
+
+        <div className="border-t border-white/10 px-6 py-5 sm:px-8">
+          <p className="break-all font-mono text-xs text-blue-200/50">
+            Stellar transaction: {escrow.hash}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/frontend/app/user/financials/page.tsx
+++ b/frontend/app/user/financials/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { Eye, ShieldCheck } from 'lucide-react';
 import {
   AreaChart,
   Area,
@@ -26,6 +27,7 @@ interface Transaction {
   amount: number;
   status: string;
   inflow: boolean;
+  previewImage: string;
 }
 
 // ─── Mock Data ────────────────────────────────────────────────────────────────
@@ -54,6 +56,8 @@ const transactions: Transaction[] = [
     amount: 2500000,
     status: 'Confirmed',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GDFE2L8M…3Q9Z',
@@ -63,6 +67,8 @@ const transactions: Transaction[] = [
     amount: 3800000,
     status: 'Confirmed',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GHJK9P1N…4W2B',
@@ -72,6 +78,8 @@ const transactions: Transaction[] = [
     amount: 38000,
     status: 'Deducted',
     inflow: false,
+    previewImage:
+      'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GLMN5R7T…8C4D',
@@ -81,6 +89,8 @@ const transactions: Transaction[] = [
     amount: 500000,
     status: 'Processed',
     inflow: false,
+    previewImage:
+      'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GPQR2S6V…1E5F',
@@ -90,6 +100,8 @@ const transactions: Transaction[] = [
     amount: 1800000,
     status: 'Confirmed',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1512915922686-57c11dde9b6b?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GSTU8X3Y…6G7H',
@@ -99,6 +111,8 @@ const transactions: Transaction[] = [
     amount: 2500000,
     status: 'Confirmed',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1501183638710-841dd1904471?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GUVW4Z0A…9I2J',
@@ -108,6 +122,8 @@ const transactions: Transaction[] = [
     amount: 25000,
     status: 'Deducted',
     inflow: false,
+    previewImage:
+      'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GXYZ1B5C…2K3L',
@@ -117,6 +133,8 @@ const transactions: Transaction[] = [
     amount: 3800000,
     status: 'Confirmed',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GABD6E9F…4M5N',
@@ -126,6 +144,8 @@ const transactions: Transaction[] = [
     amount: 2500000,
     status: 'Held',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=160&q=80',
   },
   {
     hash: 'GCDF2G7H…6O8P',
@@ -135,6 +155,8 @@ const transactions: Transaction[] = [
     amount: 1800000,
     status: 'Confirmed',
     inflow: true,
+    previewImage:
+      'https://images.unsplash.com/photo-1512915922686-57c11dde9b6b?auto=format&fit=crop&w=160&q=80',
   },
 ];
 
@@ -187,6 +209,31 @@ const StatusBadge = ({ status }: { status: string }) => (
   >
     {status}
   </span>
+);
+
+const EscrowPreviewLink = ({ tx }: { tx: Transaction }) => (
+  <Link
+    href={`/user/financials/escrows/${encodeURIComponent(tx.hash)}`}
+    className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 hover:text-white transition-all"
+    aria-label={`Preview escrow for ${tx.property}`}
+  >
+    <span className="relative h-7 w-7 overflow-hidden rounded-lg border border-white/10 bg-white/5">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={tx.previewImage}
+        alt=""
+        className="h-full w-full object-cover"
+        loading="lazy"
+      />
+      <span className="absolute inset-0 flex items-center justify-center bg-slate-950/25">
+        <ShieldCheck size={14} className="text-white" />
+      </span>
+    </span>
+    <span className="inline-flex items-center gap-1">
+      <Eye size={12} />
+      Preview
+    </span>
+  </Link>
 );
 
 // ─── Metric Card ──────────────────────────────────────────────────────────────
@@ -456,12 +503,7 @@ export default function FinancialsPage() {
                   <StatusBadge status={tx.status} />
                   {(tx.type === 'Security Deposit' ||
                     tx.type === 'Deposit Refund') && (
-                    <Link
-                      href={`/landlords/financials/escrows/${encodeURIComponent(tx.hash)}`}
-                      className="inline-flex items-center rounded-lg border border-blue-500/30 bg-blue-500/10 px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 hover:text-white transition-all"
-                    >
-                      Preview
-                    </Link>
+                    <EscrowPreviewLink tx={tx} />
                   )}
                 </div>
               </div>

--- a/frontend/components/admin/BulkUserOperations.tsx
+++ b/frontend/components/admin/BulkUserOperations.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
   X,
 } from 'lucide-react';
+import { UserAvatar } from '@/components/admin/users/UserAvatar';
 import type { User, PaginatedResponse } from '@/types';
 
 interface BulkUserOperationsProps {
@@ -254,9 +255,11 @@ export const BulkUserOperations: React.FC<BulkUserOperationsProps> = ({
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-3">
-                        <div className="w-9 h-9 rounded-full bg-white/5 border border-white/10 flex items-center justify-center text-sm font-bold text-white uppercase flex-shrink-0">
-                          {(user.name ?? user.email).charAt(0)}
-                        </div>
+                        <UserAvatar
+                          name={user.name}
+                          email={user.email}
+                          src={user.avatar}
+                        />
                         <div>
                           <Link
                             href={`/admin/users/${user.id}`}

--- a/frontend/components/admin/users/AdminUserDetailView.tsx
+++ b/frontend/components/admin/users/AdminUserDetailView.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { ActivityTimeline } from '@/components/admin/ActivityTimeline';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { UserAvatar } from '@/components/admin/users/UserAvatar';
 import { useAdminUserDetailBundle } from '@/lib/query/hooks/use-admin-user-detail';
 import { useUserTransactions } from '@/lib/query/hooks/use-transactions';
 import {
@@ -26,7 +27,6 @@ import {
   Mail,
   Phone,
   Shield,
-  User,
   UserCheck,
 } from 'lucide-react';
 import { format } from 'date-fns';
@@ -197,18 +197,14 @@ export function AdminUserDetailView({ userId }: AdminUserDetailViewProps) {
         <div className="xl:col-span-1 space-y-6">
           <div className="bg-slate-900/90 border border-slate-800 rounded-3xl p-6 shadow-xl space-y-6">
             <div className="flex flex-col items-center text-center space-y-4">
-              <div className="w-24 h-24 rounded-full bg-slate-800 border-4 border-slate-700 flex items-center justify-center overflow-hidden">
-                {user.avatar ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img
-                    src={user.avatar}
-                    alt=""
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <User size={40} className="text-slate-500" />
-                )}
-              </div>
+              <UserAvatar
+                name={user.name}
+                email={user.email}
+                src={user.avatar}
+                sizeClassName="w-24 h-24 border-4 border-slate-700 bg-slate-800"
+                textClassName="text-3xl"
+                iconSize={40}
+              />
               <div>
                 <h2 className="text-xl font-bold text-white">
                   {user.name || 'Unknown'}

--- a/frontend/components/admin/users/UserAvatar.tsx
+++ b/frontend/components/admin/users/UserAvatar.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { User } from 'lucide-react';
+
+interface UserAvatarProps {
+  name?: string | null;
+  email?: string | null;
+  src?: string | null;
+  sizeClassName?: string;
+  textClassName?: string;
+  iconSize?: number;
+}
+
+function getInitial(value?: string | null): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.charAt(0).toUpperCase() : '';
+}
+
+export function UserAvatar({
+  name,
+  email,
+  src,
+  sizeClassName = 'w-9 h-9',
+  textClassName = 'text-sm',
+  iconSize = 18,
+}: UserAvatarProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const initial = getInitial(name) || getInitial(email);
+  const canShowImage = Boolean(src) && !imageFailed;
+
+  return (
+    <div
+      className={`${sizeClassName} rounded-full bg-white/5 border border-white/10 flex items-center justify-center font-bold text-white uppercase flex-shrink-0 overflow-hidden`}
+      aria-hidden="true"
+    >
+      {canShowImage ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={src ?? ''}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+          onError={() => setImageFailed(true)}
+        />
+      ) : initial ? (
+        <span className={textClassName}>{initial}</span>
+      ) : (
+        <User size={iconSize} className="text-slate-500" />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #780
Closes #781
Closes #782
Closes #738

## Changes
- Render dashboard user/admin avatar images with resilient fallback initials for missing or broken profile images.
- Fix escrow preview links to use the existing financials escrow route and add visual thumbnails to the preview action.
- Replace the empty escrow preview detail route with a populated preview page.
- Add contract testing strategy documentation covering unit tests, integration tests, coverage, and debugging.

## Testing
- cargo fmt --all -- --check
- git diff --check
- Not run locally: frontend pnpm checks, because pnpm is unavailable and Corepack could not download it in this environment.
- Not run locally: contract clippy/test/build, because this Windows toolchain is missing MSVC link.exe; GitHub Actions uses Ubuntu with its own Rust setup.