### PR TITLE
Fix dashboard previews, home search, and root seed script

### DIFF
--- a/frontend/app/properties/page.tsx
+++ b/frontend/app/properties/page.tsx
@@ -9,8 +9,8 @@ import PropertyCardSkeleton from '@/components/PropertyCardSkeleton';
 import PropertyCard from '@/components/properties/PropertyCard';
 import { PropertyListingHeader } from '@/components/properties/PropertyListingHeader';
 import { Filter, Bell, List, Map, ChevronLeft } from 'lucide-react';
-import { useState, useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { LOADING_KEYS, useLoading } from '@/store';
 import { Spinner } from '@/components/loading';
 import { MOCK_PROPERTIES } from '@/mocks/entities/properties';
@@ -32,6 +32,7 @@ type ViewMode = 'split' | 'list' | 'map';
 
 export default function PropertyListing() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const [searchAsIMove, setSearchAsIMove] = useState(true);
   const { isLoading, setLoading } = useLoading(LOADING_KEYS.pageProperties);
   const [viewMode, setViewMode] = useState<ViewMode>('list');
@@ -45,6 +46,21 @@ export default function PropertyListing() {
     () => searchParams.get('q') ?? '',
   );
   const observerTarget = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSearchQuery(searchParams.get('q') ?? '');
+  }, [searchParams]);
+
+  const applySearchToUrl = useCallback(
+    (raw: string) => {
+      const trimmed = raw.trim();
+      const next = trimmed
+        ? `/properties?q=${encodeURIComponent(trimmed)}`
+        : '/properties';
+      router.replace(next);
+    },
+    [router],
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -111,11 +127,13 @@ export default function PropertyListing() {
     });
   };
 
-  const filteredProperties = searchQuery.trim()
+  const qLower = searchQuery.trim().toLowerCase();
+  const filteredProperties = qLower
     ? properties.filter(
         (p) =>
-          p.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          p.location?.toLowerCase().includes(searchQuery.toLowerCase()),
+          p.title?.toLowerCase().includes(qLower) ||
+          p.location?.toLowerCase().includes(qLower) ||
+          p.category?.toLowerCase().includes(qLower),
       )
     : properties;
 
@@ -144,11 +162,18 @@ export default function PropertyListing() {
               {/* Filter Buttons & Advanced Filters Merge */}
               <div className="flex flex-wrap items-center gap-2 relative">
                 <input
-                  type="text"
+                  type="search"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="Search by location..."
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      applySearchToUrl(searchQuery);
+                    }
+                  }}
+                  placeholder="Search by location or property type..."
                   className="px-4 py-2 text-sm bg-slate-900/50 border border-white/10 rounded-xl text-white placeholder:text-blue-200/30 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+                  aria-label="Search properties"
                 />
 
                 {/* Dropdown Filters Mimicking original styling */}

--- a/frontend/app/user/documents/page.tsx
+++ b/frontend/app/user/documents/page.tsx
@@ -39,6 +39,8 @@ const mockDocuments: Document[] = [
     uploadedAt: new Date('2024-03-15T10:30:00').toISOString(),
     category: 'lease',
     description: 'Annual lease agreement for property at 123 Main Street',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=320&q=80',
   },
   {
     id: '2',
@@ -51,6 +53,8 @@ const mockDocuments: Document[] = [
     uploadedAt: new Date('2024-03-10T14:20:00').toISOString(),
     category: 'inspection',
     description: 'Move-in inspection report with photos',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1564013799919-ab600027ffc6?auto=format&fit=crop&w=320&q=80',
   },
   {
     id: '3',
@@ -63,6 +67,8 @@ const mockDocuments: Document[] = [
     uploadedAt: new Date('2024-03-01T09:15:00').toISOString(),
     category: 'payment',
     description: 'Rent payment receipt for March 2024',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1554224155-6726b3ff858f?auto=format&fit=crop&w=320&q=80',
   },
 ];
 

--- a/frontend/app/user/financials/escrows/[id]/page.tsx
+++ b/frontend/app/user/financials/escrows/[id]/page.tsx
@@ -14,7 +14,7 @@ interface PageProps {
 }
 
 interface EscrowPreview {
-  hash: string;
+  displayHash: string;
   property: string;
   amount: number;
   status: string;
@@ -23,9 +23,37 @@ interface EscrowPreview {
   image: string;
 }
 
-const ESCROW_PREVIEWS: EscrowPreview[] = [
+const fallbackImage =
+  'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80';
+
+/** Stable slugs used by the financials ledger preview links. */
+const ESCROW_BY_SLUG: Record<string, EscrowPreview> = {
+  'escrow-deposit-refund-ikoyi': {
+    displayHash: 'GLMN5R7T…8C4D',
+    property: 'Glover Road, Ikoyi',
+    amount: 500000,
+    status: 'Processed',
+    date: 'Jun 05, 2025',
+    type: 'Deposit Refund',
+    image:
+      'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&w=1200&q=80',
+  },
+  'escrow-security-adeola': {
+    displayHash: 'GABD6E9F…4M5N',
+    property: '101 Adeola Odeku St',
+    amount: 2500000,
+    status: 'Held',
+    date: 'Apr 28, 2025',
+    type: 'Security Deposit',
+    image:
+      'https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=1200&q=80',
+  },
+};
+
+/** Legacy entries keyed by normalized display hash (alphanumeric only). */
+const ESCROW_BY_NORMALIZED_HASH: EscrowPreview[] = [
   {
-    hash: 'GLMN5R7T\u20268C4D',
+    displayHash: 'GLMN5R7T…8C4D',
     property: 'Glover Road, Ikoyi',
     amount: 500000,
     status: 'Processed',
@@ -35,7 +63,7 @@ const ESCROW_PREVIEWS: EscrowPreview[] = [
       'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&w=1200&q=80',
   },
   {
-    hash: 'GABD6E9F\u20264M5N',
+    displayHash: 'GABD6E9F…4M5N',
     property: '101 Adeola Odeku St',
     amount: 2500000,
     status: 'Held',
@@ -46,28 +74,32 @@ const ESCROW_PREVIEWS: EscrowPreview[] = [
   },
 ];
 
-const fallbackImage =
-  'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80';
-
 function normalizeHash(value: string): string {
   return value.replace(/[^a-z0-9]/gi, '').toUpperCase();
 }
 
 function findPreview(id: string): EscrowPreview {
   const decodedId = decodeURIComponent(id);
-  return (
-    ESCROW_PREVIEWS.find(
-      (preview) => normalizeHash(preview.hash) === normalizeHash(decodedId),
-    ) ?? {
-      hash: decodedId,
-      property: 'Security deposit escrow',
-      amount: 0,
-      status: 'Pending',
-      date: 'Pending confirmation',
-      type: 'Escrow Preview',
-      image: fallbackImage,
-    }
+  const bySlug = ESCROW_BY_SLUG[decodedId];
+  if (bySlug) {
+    return bySlug;
+  }
+  const norm = normalizeHash(decodedId);
+  const legacy = ESCROW_BY_NORMALIZED_HASH.find(
+    (p) => normalizeHash(p.displayHash) === norm,
   );
+  if (legacy) {
+    return legacy;
+  }
+  return {
+    displayHash: decodedId,
+    property: 'Security deposit escrow',
+    amount: 0,
+    status: 'Pending',
+    date: 'Pending confirmation',
+    type: 'Escrow Preview',
+    image: fallbackImage,
+  };
 }
 
 export default async function EscrowDetailPage({ params }: PageProps) {
@@ -91,6 +123,7 @@ export default async function EscrowDetailPage({ params }: PageProps) {
             src={escrow.image}
             alt={`${escrow.property} escrow preview`}
             className="absolute inset-0 h-full w-full object-cover"
+            referrerPolicy="no-referrer"
           />
           <div className="absolute inset-0 bg-slate-950/65" />
           <div className="relative z-10 flex min-h-[320px] flex-col justify-end p-6 sm:p-8">
@@ -142,7 +175,7 @@ export default async function EscrowDetailPage({ params }: PageProps) {
 
         <div className="border-t border-white/10 px-6 py-5 sm:px-8">
           <p className="break-all font-mono text-xs text-blue-200/50">
-            Stellar transaction: {escrow.hash}
+            Stellar transaction: {escrow.displayHash}
           </p>
         </div>
       </section>

--- a/frontend/app/user/financials/page.tsx
+++ b/frontend/app/user/financials/page.tsx
@@ -21,6 +21,8 @@ interface RevenueDataPoint {
 
 interface Transaction {
   hash: string;
+  /** Stable route segment for escrow preview detail (avoids hash/ellipsis mismatch). */
+  escrowPreviewId?: string;
   date: string;
   type: string;
   property: string;
@@ -83,6 +85,7 @@ const transactions: Transaction[] = [
   },
   {
     hash: 'GLMN5R7T…8C4D',
+    escrowPreviewId: 'escrow-deposit-refund-ikoyi',
     date: 'Jun 05, 2025',
     type: 'Deposit Refund',
     property: 'Glover Road, Ikoyi',
@@ -138,6 +141,7 @@ const transactions: Transaction[] = [
   },
   {
     hash: 'GABD6E9F…4M5N',
+    escrowPreviewId: 'escrow-security-adeola',
     date: 'Apr 28, 2025',
     type: 'Security Deposit',
     property: '101 Adeola Odeku St',
@@ -211,9 +215,16 @@ const StatusBadge = ({ status }: { status: string }) => (
   </span>
 );
 
-const EscrowPreviewLink = ({ tx }: { tx: Transaction }) => (
+const ESCROW_THUMB_FALLBACK =
+  'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=160&q=80';
+
+const EscrowPreviewLink = ({ tx }: { tx: Transaction }) => {
+  const previewSegment = encodeURIComponent(
+    tx.escrowPreviewId ?? tx.hash,
+  );
+  return (
   <Link
-    href={`/user/financials/escrows/${encodeURIComponent(tx.hash)}`}
+    href={`/user/financials/escrows/${previewSegment}`}
     className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 hover:text-white transition-all"
     aria-label={`Preview escrow for ${tx.property}`}
   >
@@ -224,6 +235,10 @@ const EscrowPreviewLink = ({ tx }: { tx: Transaction }) => (
         alt=""
         className="h-full w-full object-cover"
         loading="lazy"
+        referrerPolicy="no-referrer"
+        onError={(e) => {
+          e.currentTarget.src = ESCROW_THUMB_FALLBACK;
+        }}
       />
       <span className="absolute inset-0 flex items-center justify-center bg-slate-950/25">
         <ShieldCheck size={14} className="text-white" />
@@ -234,7 +249,8 @@ const EscrowPreviewLink = ({ tx }: { tx: Transaction }) => (
       Preview
     </span>
   </Link>
-);
+  );
+};
 
 // ─── Metric Card ──────────────────────────────────────────────────────────────
 

--- a/frontend/components/documents/DocumentCard.tsx
+++ b/frontend/components/documents/DocumentCard.tsx
@@ -77,6 +77,7 @@ export const DocumentCard: React.FC<DocumentCardProps> = ({
           {document.thumbnailUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
+              referrerPolicy="no-referrer"
               src={document.thumbnailUrl}
               alt={document.name}
               className="w-12 h-12 rounded-lg object-cover"

--- a/frontend/components/landing/Hero.tsx
+++ b/frontend/components/landing/Hero.tsx
@@ -18,9 +18,12 @@ export default function Hero() {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    const params = new URLSearchParams();
-    if (query.trim()) params.set('q', query.trim());
-    router.push(`/properties?${params.toString()}`);
+    const trimmed = query.trim();
+    if (trimmed) {
+      router.push(`/properties?q=${encodeURIComponent(trimmed)}`);
+    } else {
+      router.push('/properties');
+    }
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "seed": "pnpm --dir backend run seed"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",


### PR DESCRIPTION
## Summary
- **#770**: Escrow preview uses stable `escrowPreviewId` URLs aligned with the detail page; list thumbnails use `referrerPolicy` and an `onError` fallback image.
- **#775**: Mock documents include `thumbnailUrl` so the document preview tile shows an image; card thumbnails set `referrerPolicy` for external images.
- **#817**: Root `pnpm run seed` runs the existing backend comprehensive seed (`UserRole.ADMIN` / `UserRole.USER`, properties, agreements) via `pnpm --dir backend run seed`.
- **#828**: Hero search builds a clean `/properties?q=…` URL; listings page syncs `q` from the URL (back/forward), updates the URL on Enter, and matches **category** as well as title/location.

Closes #770
Closes #775
Closes #817
Closes #828
