### PR TITLE
Fix dashboard preview media rendering and agreement detail navigation

### DIFF
--- a/frontend/app/user/agreements/[id]/page.tsx
+++ b/frontend/app/user/agreements/[id]/page.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link';
+import { ArrowLeft, Calendar, FileText, Home } from 'lucide-react';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+const AGREEMENT_PREVIEW_FALLBACK =
+  'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80';
+
+const AGREEMENT_DETAILS: Record<
+  string,
+  { property: string; monthlyRent: string; dueDate: string; status: string; image: string }
+> = {
+  'AGR-4921': {
+    property: 'Sunset Apartments, Unit 4B',
+    monthlyRent: '$1,200',
+    dueDate: 'Oct 1, 2023',
+    status: 'Active',
+    image:
+      'https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=1200&q=80',
+  },
+  'AGR-4922': {
+    property: 'Downtown Loft, Unit 12',
+    monthlyRent: '$2,500',
+    dueDate: 'Nov 1, 2023',
+    status: 'Pending',
+    image:
+      'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80',
+  },
+};
+
+export default async function AgreementDetailsPage({ params }: PageProps) {
+  const { id } = await params;
+  const agreement = AGREEMENT_DETAILS[id] ?? {
+    property: 'Agreement details',
+    monthlyRent: 'Unavailable',
+    dueDate: 'Unavailable',
+    status: 'Unknown',
+    image: AGREEMENT_PREVIEW_FALLBACK,
+  };
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href="/user"
+        className="inline-flex items-center gap-2 text-sm font-bold text-blue-300 hover:text-white transition-colors"
+      >
+        <ArrowLeft size={16} />
+        Back to dashboard
+      </Link>
+
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-xl">
+        <div className="relative min-h-[300px]">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={agreement.image}
+            alt={`${agreement.property} agreement preview`}
+            className="absolute inset-0 h-full w-full object-cover"
+            referrerPolicy="no-referrer"
+            onError={(e) => {
+              e.currentTarget.src = AGREEMENT_PREVIEW_FALLBACK;
+            }}
+          />
+          <div className="absolute inset-0 bg-slate-950/65" />
+          <div className="relative z-10 flex min-h-[300px] flex-col justify-end p-6 sm:p-8">
+            <p className="text-xs font-bold uppercase tracking-widest text-blue-200/60">
+              Agreement Details
+            </p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight text-white">{id}</h1>
+            <p className="mt-1 text-sm text-blue-200/70">{agreement.property}</p>
+          </div>
+        </div>
+        <div className="grid gap-4 p-6 sm:grid-cols-3 sm:p-8">
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+            <div className="mb-2 flex items-center gap-2 text-blue-200/60">
+              <FileText size={16} />
+              <span className="text-[10px] font-bold uppercase tracking-widest">Rent</span>
+            </div>
+            <p className="text-xl font-bold text-white">{agreement.monthlyRent}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+            <div className="mb-2 flex items-center gap-2 text-blue-200/60">
+              <Calendar size={16} />
+              <span className="text-[10px] font-bold uppercase tracking-widest">Next Due</span>
+            </div>
+            <p className="text-xl font-bold text-white">{agreement.dueDate}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4">
+            <div className="mb-2 flex items-center gap-2 text-blue-200/60">
+              <Home size={16} />
+              <span className="text-[10px] font-bold uppercase tracking-widest">Status</span>
+            </div>
+            <p className="text-xl font-bold text-white">{agreement.status}</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -79,7 +79,8 @@ const dashboardPayments = [
 
 const dashboardDisputes = [
   {
-    id: 'DSP-901',
+    id: 'dis-001',
+    disputeReference: 'DSP-2026-001',
     property: 'Sunset Apartments, Unit 4B',
     status: 'Open',
     previewImage:
@@ -378,9 +379,22 @@ export default function UserDashboardOverview() {
                 </div>
                 <Link
                   href="/user/payments"
-                  className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
+                  className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
                   aria-label={`Preview payment ${payment.id}`}
                 >
+                  <span className="relative h-5 w-5 overflow-hidden rounded-md border border-white/10 bg-white/5">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={payment.previewImage}
+                      alt=""
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.currentTarget.src = DASHBOARD_IMAGE_FALLBACK;
+                      }}
+                    />
+                  </span>
                   <Eye size={12} />
                   Preview
                 </Link>
@@ -426,15 +440,28 @@ export default function UserDashboardOverview() {
                       {dispute.property}
                     </p>
                     <p className="text-xs text-blue-200/50">
-                      {dispute.id} · {dispute.status}
+                      {dispute.disputeReference} · {dispute.status}
                     </p>
                   </div>
                 </div>
                 <Link
                   href={`/user/disputes/${dispute.id}`}
-                  className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
-                  aria-label={`Preview dispute ${dispute.id}`}
+                  className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
+                  aria-label={`Preview dispute ${dispute.disputeReference}`}
                 >
+                  <span className="relative h-5 w-5 overflow-hidden rounded-md border border-white/10 bg-white/5">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={dispute.previewImage}
+                      alt=""
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.currentTarget.src = DASHBOARD_IMAGE_FALLBACK;
+                      }}
+                    />
+                  </span>
                   <Eye size={12} />
                   Preview
                 </Link>

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -8,6 +8,9 @@ import {
   ArrowUpRight,
   TrendingUp,
   BarChart3,
+  Eye,
+  ReceiptText,
+  AlertTriangle,
 } from 'lucide-react';
 import { AreaChart, Area, ResponsiveContainer, XAxis, Tooltip } from 'recharts';
 import { MicroCharts } from '@/components/dashboard/MicroCharts';
@@ -50,6 +53,38 @@ const analyticsPreviewData = [
   { month: 'Apr', views: 200 },
   { month: 'May', views: 320 },
   { month: 'Jun', views: 410 },
+];
+
+const DASHBOARD_IMAGE_FALLBACK =
+  'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=200&q=80';
+
+const dashboardPayments = [
+  {
+    id: 'PMT-2201',
+    property: 'Sunset Apartments, Unit 4B',
+    amount: '$1,200',
+    date: 'Oct 1, 2023',
+    previewImage:
+      'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=200&q=80',
+  },
+  {
+    id: 'PMT-2202',
+    property: 'Downtown Loft, Unit 12',
+    amount: '$2,500',
+    date: 'Nov 1, 2023',
+    previewImage:
+      'https://images.unsplash.com/photo-1554224155-8d04cb21cd6c?auto=format&fit=crop&w=200&q=80',
+  },
+];
+
+const dashboardDisputes = [
+  {
+    id: 'DSP-901',
+    property: 'Sunset Apartments, Unit 4B',
+    status: 'Open',
+    previewImage:
+      'https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=200&q=80',
+  },
 ];
 
 export default function UserDashboardOverview() {
@@ -298,6 +333,117 @@ export default function UserDashboardOverview() {
         </div>
       </div>
 
+      {/* Payment and Dispute previews */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-white/5 backdrop-blur-sm rounded-3xl shadow-xl border border-white/10 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-bold text-white tracking-tight">
+              Payment Preview
+            </h3>
+            <Link
+              href="/user/payments"
+              className="text-xs font-bold uppercase tracking-widest text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              View all
+            </Link>
+          </div>
+          <div className="space-y-3">
+            {dashboardPayments.map((payment) => (
+              <div
+                key={payment.id}
+                className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 p-3"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="relative h-11 w-11 overflow-hidden rounded-xl border border-white/10 bg-white/5 shrink-0">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={payment.previewImage}
+                      alt={`${payment.property} payment receipt preview`}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.currentTarget.src = DASHBOARD_IMAGE_FALLBACK;
+                      }}
+                    />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-white truncate">
+                      {payment.property}
+                    </p>
+                    <p className="text-xs text-blue-200/50">
+                      {payment.amount} · {payment.date}
+                    </p>
+                  </div>
+                </div>
+                <Link
+                  href="/user/payments"
+                  className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
+                  aria-label={`Preview payment ${payment.id}`}
+                >
+                  <Eye size={12} />
+                  Preview
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="bg-white/5 backdrop-blur-sm rounded-3xl shadow-xl border border-white/10 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-bold text-white tracking-tight">
+              Dispute Preview
+            </h3>
+            <Link
+              href="/user/disputes"
+              className="text-xs font-bold uppercase tracking-widest text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              View all
+            </Link>
+          </div>
+          <div className="space-y-3">
+            {dashboardDisputes.map((dispute) => (
+              <div
+                key={dispute.id}
+                className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 p-3"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="relative h-11 w-11 overflow-hidden rounded-xl border border-white/10 bg-white/5 shrink-0">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={dispute.previewImage}
+                      alt={`${dispute.property} dispute preview`}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.currentTarget.src = DASHBOARD_IMAGE_FALLBACK;
+                      }}
+                    />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-white truncate">
+                      {dispute.property}
+                    </p>
+                    <p className="text-xs text-blue-200/50">
+                      {dispute.id} · {dispute.status}
+                    </p>
+                  </div>
+                </div>
+                <Link
+                  href={`/user/disputes/${dispute.id}`}
+                  className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
+                  aria-label={`Preview dispute ${dispute.id}`}
+                >
+                  <Eye size={12} />
+                  Preview
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
       {/* Agreements Table */}
       <div className="bg-white/5 backdrop-blur-sm rounded-3xl shadow-xl border border-white/10 overflow-hidden">
         <div className="px-6 py-5 border-b border-white/5 flex items-center justify-between">
@@ -326,6 +472,9 @@ export default function UserDashboardOverview() {
                 </th>
                 <th className="px-6 py-4 font-bold uppercase tracking-widest text-[10px] text-right">
                   Status
+                </th>
+                <th className="px-6 py-4 font-bold uppercase tracking-widest text-[10px] text-right">
+                  Preview
                 </th>
               </tr>
             </thead>
@@ -373,6 +522,17 @@ export default function UserDashboardOverview() {
                         {agreement.status}
                       </span>
                     </div>
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    <Link
+                      href={`/user/agreements/${agreement.id}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="inline-flex items-center gap-1 rounded-xl border border-blue-500/30 bg-blue-500/10 px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-widest text-blue-300 hover:bg-blue-500/20 transition-colors"
+                      aria-label={`Preview agreement ${agreement.id}`}
+                    >
+                      <Eye size={12} />
+                      Preview
+                    </Link>
                   </td>
                 </tr>
               ))}

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import {
   Calendar,
   FileText,
@@ -93,8 +94,9 @@ export default function UserDashboardOverview() {
   // useRoleRedirect(['user']);
 
   const { openModal } = useModal();
+  const router = useRouter();
 
-  const handleAgreementClick = (agreement: (typeof mockAgreements)[0]) => {
+  const handleAgreementSign = (agreement: (typeof mockAgreements)[0]) => {
     openModal('agreementView', {
       agreement: {
         agreementId: agreement.id,
@@ -124,6 +126,10 @@ export default function UserDashboardOverview() {
         });
       },
     });
+  };
+
+  const handleAgreementPreview = (agreementId: string) => {
+    router.push(`/user/agreements/${encodeURIComponent(agreementId)}`);
   };
 
   return (
@@ -509,7 +515,7 @@ export default function UserDashboardOverview() {
               {agreements.map((agreement) => (
                 <tr
                   key={agreement.id}
-                  onClick={() => handleAgreementClick(agreement)}
+                  onClick={() => handleAgreementPreview(agreement.id)}
                   className="hover:bg-white/5 transition-colors group cursor-pointer"
                 >
                   <td className="px-6 py-4 font-bold text-white group-hover:text-blue-400 transition-colors">
@@ -530,7 +536,7 @@ export default function UserDashboardOverview() {
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            handleAgreementClick(agreement);
+                            handleAgreementSign(agreement);
                           }}
                           className="inline-flex items-center px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider bg-blue-500/10 text-blue-400 border border-blue-500/20 hover:bg-blue-500/20 transition-colors"
                         >

--- a/frontend/components/user/DisputesList.tsx
+++ b/frontend/components/user/DisputesList.tsx
@@ -34,6 +34,8 @@ interface DisputesListProps {
 }
 
 export function DisputesList({ className = '' }: DisputesListProps) {
+  const disputePreviewFallback =
+    'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=80&q=80';
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     [],
@@ -138,8 +140,18 @@ export function DisputesList({ className = '' }: DisputesListProps) {
         cell: ({ row }) => (
           <Link
             href={`/user/disputes/${row.original.id}`}
-            className="p-2 text-blue-300/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors inline-flex"
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-500/20 bg-blue-500/10 px-2 py-1 text-blue-300/70 hover:text-white hover:bg-blue-500/20 transition-colors"
+            aria-label={`Preview dispute ${row.original.disputeId}`}
           >
+            <span className="relative h-6 w-6 overflow-hidden rounded-md border border-white/10 bg-white/5">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={disputePreviewFallback}
+                alt=""
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            </span>
             <Eye className="h-4 w-4" />
           </Link>
         ),

--- a/frontend/components/user/DisputesList.tsx
+++ b/frontend/components/user/DisputesList.tsx
@@ -137,7 +137,7 @@ export function DisputesList({ className = '' }: DisputesListProps) {
         id: 'actions',
         cell: ({ row }) => (
           <Link
-            href={`/tenant/disputes/${row.original.id}`}
+            href={`/user/disputes/${row.original.id}`}
             className="p-2 text-blue-300/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors inline-flex"
           >
             <Eye className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- fix dashboard payment preview cards to always render visual thumbnails with safe image fallback handling
- fix dashboard dispute preview cards to render dispute-related images and route previews to dispute details
- wire agreement preview action from dashboard to a dedicated agreement details route and fix broken dispute detail links

## Test plan
- [ ] pnpm --filter frontend lint
- [ ] pnpm --filter frontend test

Closes #773
Closes #774
Closes #784
Closes #789

