### PR TITLE
Fix dashboard preview images across key modules

### DIFF
--- a/frontend/components/dashboard/PropertyPortfolio.tsx
+++ b/frontend/components/dashboard/PropertyPortfolio.tsx
@@ -150,6 +150,7 @@ const PropertyPortfolio = () => {
                           alt={property.name}
                           fill
                           sizes="64px"
+                          unoptimized
                           className="object-cover"
                         />
                       </div>
@@ -183,6 +184,7 @@ const PropertyPortfolio = () => {
                             alt={property.tenant.name}
                             fill
                             sizes="32px"
+                            unoptimized
                             className="object-cover"
                           />
                         </div>
@@ -245,6 +247,7 @@ const PropertyPortfolio = () => {
                     alt={property.name}
                     fill
                     sizes="80px"
+                    unoptimized
                     className="object-cover"
                   />
                 </div>
@@ -299,6 +302,7 @@ const PropertyPortfolio = () => {
                         alt={property.tenant.name}
                         fill
                         sizes="32px"
+                        unoptimized
                         className="object-cover"
                       />
                     </div>

--- a/frontend/components/dashboard/agent/DashboardLayout.tsx
+++ b/frontend/components/dashboard/agent/DashboardLayout.tsx
@@ -168,6 +168,7 @@ const DashboardLayout = ({ children }: DashboardLayoutProps) => {
                 alt="Sarah Jenks profile avatar"
                 width={40}
                 height={40}
+                unoptimized
                 className="object-cover"
               />
             </div>

--- a/frontend/components/dashboard/agent/NewLeads.tsx
+++ b/frontend/components/dashboard/agent/NewLeads.tsx
@@ -51,6 +51,7 @@ const NewLeads = () => {
                 alt={lead.name}
                 fill
                 sizes="36px"
+                unoptimized
                 className="object-cover"
               />
             </div>

--- a/frontend/components/dashboard/agent/RecentListings.tsx
+++ b/frontend/components/dashboard/agent/RecentListings.tsx
@@ -108,6 +108,7 @@ const RecentListings = () => {
                       alt={item.title}
                       fill
                       sizes="48px"
+                      unoptimized
                       className="object-cover"
                     />
                   </div>

--- a/frontend/components/dashboard/agent/contracts/ContractCard.tsx
+++ b/frontend/components/dashboard/agent/contracts/ContractCard.tsx
@@ -64,6 +64,7 @@ function PropertyPreviewImage({
         alt={alt}
         fill
         sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+        unoptimized
         className="object-cover"
         onError={() => setError(true)}
       />


### PR DESCRIPTION
## Summary
- render dashboard preview thumbnails and avatars with `unoptimized` image delivery so preview visuals do not fail due to image optimizer fetch issues
- apply the fix to property listing previews, agreement preview cards, notification-adjacent lead avatars, and dashboard analytics/overview surfaces using the same preview image pattern
- preserve existing card/button UI while making preview image rendering reliable across supported browsers

## Test plan
- Open dashboard pages that include property listing previews and confirm thumbnails render.
- Open contract/agreement cards and confirm preview images display.
- Open dashboard areas with lead/notification avatars and confirm images display.
- Validate no console image optimization errors for these preview assets.

Closes #777
Closes #778
Closes #779
Closes #786
