### PR TITLE
test: add comprehensive tests for disputes, screening, stellar, and auth modules

### DIFF
--- a/backend/src/modules/auth/auth.comprehensive.spec.ts
+++ b/backend/src/modules/auth/auth.comprehensive.spec.ts
@@ -1,0 +1,389 @@
+import * as bcrypt from 'bcryptjs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { User, UserRole } from '../users/entities/user.entity';
+import { MfaDevice } from './entities/mfa-device.entity';
+import { EmailService } from '../notifications/email.service';
+import { MfaService } from './services/mfa.service';
+import { PasswordPolicyService } from './services/password-policy.service';
+import { ReferralService } from '../referral/referral.service';
+import { LoggerService } from '../../common/services/logger.service';
+import { LockService } from '../../common/lock';
+
+describe('AuthService — comprehensive coverage', () => {
+  let service: AuthService;
+
+  const mockUser: User = {
+    id: 'user-1',
+    email: 'user@example.com',
+    emailHash: 'hashed-email',
+    password: 'hashed-password',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    role: UserRole.USER,
+    isActive: true,
+    emailVerified: true,
+    failedLoginAttempts: 0,
+    accountLockedUntil: null,
+    resetToken: null,
+    resetTokenExpires: null,
+    refreshToken: 'hashed-refresh-token',
+    verificationToken: null,
+    lastLoginAt: new Date(),
+    loginCount: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    phoneNumber: null,
+    avatarUrl: null,
+  } as User;
+
+  const mockUserRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockJwtService = {
+    sign: jest.fn(),
+    verify: jest.fn(),
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      const cfg: Record<string, string> = {
+        JWT_SECRET: 'test-access-secret',
+        JWT_REFRESH_SECRET: 'test-refresh-secret',
+        JWT_EXPIRATION: '15m',
+        JWT_REFRESH_EXPIRATION: '7d',
+      };
+      return cfg[key];
+    }),
+  };
+
+  const mockMfaService = {
+    checkMfaRequired: jest.fn().mockResolvedValue(false),
+    generateMfaToken: jest.fn(),
+    verifyMfaToken: jest.fn(),
+  };
+
+  const mockPasswordPolicyService = {
+    validatePassword: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockEmailService = {
+    sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+    sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockReferralService = {
+    generateReferralCode: jest.fn().mockResolvedValue('REF12345'),
+    trackReferral: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockLoggerService = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getRepositoryToken(User), useValue: mockUserRepository },
+        { provide: getRepositoryToken(MfaDevice), useValue: { findOne: jest.fn(), save: jest.fn() } },
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: PasswordPolicyService, useValue: mockPasswordPolicyService },
+        { provide: EmailService, useValue: mockEmailService },
+        { provide: MfaService, useValue: mockMfaService },
+        { provide: ReferralService, useValue: mockReferralService },
+        { provide: LoggerService, useValue: mockLoggerService },
+        {
+          provide: LockService,
+          useValue: {
+            withLock: jest.fn(async (_k: string, _t: number, fn: () => Promise<unknown>) => fn()),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    jest.clearAllMocks();
+  });
+
+  // ── generateTokens ────────────────────────────────────────────────────────
+
+  describe('generateTokens', () => {
+    it('returns both accessToken and refreshToken', () => {
+      mockJwtService.sign
+        .mockReturnValueOnce('access-jwt')
+        .mockReturnValueOnce('refresh-jwt');
+
+      const result = service.generateTokens('user-1', 'user@example.com', UserRole.USER);
+
+      expect(result).toEqual({ accessToken: 'access-jwt', refreshToken: 'refresh-jwt' });
+    });
+
+    it('signs the access token with JWT_SECRET and type=access', () => {
+      mockJwtService.sign.mockReturnValue('token');
+
+      service.generateTokens('user-1', 'user@example.com', UserRole.USER);
+
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: 'user-1', type: 'access' }),
+        expect.objectContaining({ secret: 'test-access-secret' }),
+      );
+    });
+
+    it('signs the refresh token with JWT_REFRESH_SECRET and type=refresh', () => {
+      mockJwtService.sign.mockReturnValue('token');
+
+      service.generateTokens('user-1', 'user@example.com', UserRole.USER);
+
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: 'user-1', type: 'refresh' }),
+        expect.objectContaining({ secret: 'test-refresh-secret' }),
+      );
+    });
+  });
+
+  // ── sanitizeUser ──────────────────────────────────────────────────────────
+
+  describe('sanitizeUser', () => {
+    it('removes the password field', () => {
+      const sanitized = service.sanitizeUser(mockUser);
+      expect(sanitized).not.toHaveProperty('password');
+    });
+
+    it('removes the refreshToken field', () => {
+      const sanitized = service.sanitizeUser(mockUser);
+      expect(sanitized).not.toHaveProperty('refreshToken');
+    });
+
+    it('removes the resetToken field', () => {
+      const sanitized = service.sanitizeUser(mockUser);
+      expect(sanitized).not.toHaveProperty('resetToken');
+    });
+
+    it('removes the verificationToken field', () => {
+      const sanitized = service.sanitizeUser(mockUser);
+      expect(sanitized).not.toHaveProperty('verificationToken');
+    });
+
+    it('retains public fields like id, email, and role', () => {
+      const sanitized = service.sanitizeUser(mockUser);
+      expect(sanitized.id).toBe('user-1');
+      expect(sanitized.email).toBe('user@example.com');
+      expect(sanitized.role).toBe(UserRole.USER);
+    });
+  });
+
+  // ── refreshToken ──────────────────────────────────────────────────────────
+
+  describe('refreshToken', () => {
+    it('returns new tokens when the refresh token is valid', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'user-1',
+        email: 'user@example.com',
+        role: UserRole.USER,
+        type: 'refresh',
+      });
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('new-hashed-refresh' as never);
+      mockJwtService.sign
+        .mockReturnValueOnce('new-access-token')
+        .mockReturnValueOnce('new-refresh-token');
+      mockUserRepository.update.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.refreshToken({ refreshToken: 'valid-refresh-token' });
+
+      expect(result).toEqual({ accessToken: 'new-access-token', refreshToken: 'new-refresh-token' });
+      expect(mockUserRepository.update).toHaveBeenCalled();
+    });
+
+    it('throws UnauthorizedException when token type is not "refresh"', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'user-1',
+        email: 'user@example.com',
+        role: UserRole.USER,
+        type: 'access',
+      });
+
+      await expect(
+        service.refreshToken({ refreshToken: 'access-token-used-as-refresh' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when the stored refresh token is revoked (null)', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'user-1',
+        email: 'user@example.com',
+        role: UserRole.USER,
+        type: 'refresh',
+      });
+      mockUserRepository.findOne.mockResolvedValue({ ...mockUser, refreshToken: null });
+
+      await expect(
+        service.refreshToken({ refreshToken: 'revoked-token' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'ghost-user',
+        email: 'ghost@example.com',
+        role: UserRole.USER,
+        type: 'refresh',
+      });
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.refreshToken({ refreshToken: 'unknown-token' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when bcrypt comparison fails (token mismatch)', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'user-1',
+        email: 'user@example.com',
+        role: UserRole.USER,
+        type: 'refresh',
+      });
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await expect(
+        service.refreshToken({ refreshToken: 'tampered-token' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when jwtService.verify throws', async () => {
+      mockJwtService.verify.mockImplementation(() => {
+        throw new Error('jwt expired');
+      });
+
+      await expect(
+        service.refreshToken({ refreshToken: 'expired-token' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  // ── completeMfaLogin ──────────────────────────────────────────────────────
+
+  describe('completeMfaLogin', () => {
+    it('delegates to mfaService.verifyMfaToken and returns the result', async () => {
+      const expectedResponse = {
+        user: service.sanitizeUser(mockUser),
+        accessToken: 'mfa-access-token',
+        refreshToken: 'mfa-refresh-token',
+        mfaRequired: false,
+      };
+      mockMfaService.verifyMfaToken.mockResolvedValue(expectedResponse);
+
+      const result = await service.completeMfaLogin('mfa-otp-token');
+
+      expect(mockMfaService.verifyMfaToken).toHaveBeenCalledWith('mfa-otp-token', service);
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  // ── account lockout ───────────────────────────────────────────────────────
+
+  describe('account lockout behavior', () => {
+    it('increments failedLoginAttempts on each wrong password', async () => {
+      const user = { ...mockUser, failedLoginAttempts: 3 };
+      mockUserRepository.findOne.mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+      mockUserRepository.save.mockResolvedValue({ ...user, failedLoginAttempts: 4 });
+
+      await expect(
+        service.login({ email: 'user@example.com', password: 'wrong' }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ failedLoginAttempts: 4 }),
+      );
+    });
+
+    it('sets accountLockedUntil when failedLoginAttempts reaches 5', async () => {
+      const user = { ...mockUser, failedLoginAttempts: 4 };
+      mockUserRepository.findOne.mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+      mockUserRepository.save.mockImplementation(async (u: typeof user) => u);
+
+      await expect(
+        service.login({ email: 'user@example.com', password: 'wrong' }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failedLoginAttempts: 5,
+          accountLockedUntil: expect.any(Date),
+        }),
+      );
+    });
+
+    it('clears the lockout after the lockout period has passed', async () => {
+      const pastLockout = new Date(Date.now() - 1000);
+      const lockedUser = { ...mockUser, accountLockedUntil: pastLockout, failedLoginAttempts: 5 };
+      mockUserRepository.findOne.mockResolvedValue(lockedUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed' as never);
+      mockJwtService.sign
+        .mockReturnValueOnce('acc-token')
+        .mockReturnValueOnce('ref-token');
+      mockUserRepository.save.mockImplementation(async (u: typeof lockedUser) => u);
+      mockUserRepository.update.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.login({ email: 'user@example.com', password: 'correct' });
+
+      expect((result as any).accessToken).toBe('acc-token');
+    });
+
+    it('rejects login while account is still locked', async () => {
+      const futureLockout = new Date(Date.now() + 30 * 60 * 1000);
+      const lockedUser = { ...mockUser, accountLockedUntil: futureLockout };
+      mockUserRepository.findOne.mockResolvedValue(lockedUser);
+
+      await expect(
+        service.login({ email: 'user@example.com', password: 'any-password' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  // ── login with MFA required ───────────────────────────────────────────────
+
+  describe('login — MFA branch', () => {
+    it('delegates to mfaService.generateMfaToken when MFA is required', async () => {
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed' as never);
+      mockUserRepository.save.mockResolvedValue(mockUser);
+      mockUserRepository.update.mockResolvedValue({ affected: 1 } as any);
+      mockMfaService.checkMfaRequired.mockResolvedValue(true);
+      const mfaResponse = { mfaRequired: true, mfaToken: 'pending-mfa-token' };
+      mockMfaService.generateMfaToken.mockResolvedValue(mfaResponse);
+
+      const result = await service.login({ email: 'user@example.com', password: 'correct' });
+
+      expect(mockMfaService.generateMfaToken).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'user-1' }),
+        service,
+      );
+      expect((result as any).mfaRequired).toBe(true);
+    });
+  });
+
+  // ── service bootstrap ─────────────────────────────────────────────────────
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/modules/disputes/__tests__/disputes.resolution.spec.ts
+++ b/backend/src/modules/disputes/__tests__/disputes.resolution.spec.ts
@@ -1,0 +1,424 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { DisputesService } from '../disputes.service';
+import {
+  Dispute,
+  DisputeStatus,
+  DisputeType,
+} from '../entities/dispute.entity';
+import { DisputeEvidence } from '../entities/dispute-evidence.entity';
+import { DisputeComment } from '../entities/dispute-comment.entity';
+import {
+  RentAgreement,
+  AgreementStatus,
+} from '../../rent/entities/rent-contract.entity';
+import { User, UserRole } from '../../users/entities/user.entity';
+import { AuditService } from '../../audit/audit.service';
+import { LockService } from '../../../common/lock';
+import { IdempotencyService } from '../../../common/idempotency';
+import { ResolveDisputeDto } from '../dto/resolve-dispute.dto';
+import { AddCommentDto } from '../dto/add-comment.dto';
+
+describe('DisputesService — resolution, evidence, comments, agreements', () => {
+  let service: DisputesService;
+
+  const adminUser: User = {
+    id: 'admin-1',
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    role: UserRole.ADMIN,
+    isActive: true,
+  } as User;
+
+  const regularUser: User = {
+    id: 'user-1',
+    email: 'user@example.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    role: UserRole.USER,
+    isActive: true,
+  } as User;
+
+  const mockAgreement: any = {
+    id: '1',
+    agreementNumber: 'AGR-001',
+    adminId: 'landlord-1',
+    userId: 'user-1',
+    status: AgreementStatus.DISPUTED,
+  };
+
+  const openDispute: Dispute = {
+    id: 1,
+    disputeId: 'dispute-uuid-1',
+    agreementId: 1,
+    initiatedBy: 1,
+    disputeType: DisputeType.RENT_PAYMENT,
+    requestedAmount: 500,
+    description: 'Test dispute',
+    status: DisputeStatus.OPEN,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Dispute;
+
+  const underReviewDispute: Dispute = {
+    ...openDispute,
+    status: DisputeStatus.UNDER_REVIEW,
+    agreement: mockAgreement,
+  } as Dispute;
+
+  const resolvedDispute: Dispute = {
+    ...openDispute,
+    status: DisputeStatus.RESOLVED,
+  } as Dispute;
+
+  const mockDisputeRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    createQueryBuilder: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockEvidenceRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockCommentRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockAgreementRepository = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockUserRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockQueryRunner = {
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+    manager: {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const mockDataSource = {
+    createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DisputesService,
+        { provide: getRepositoryToken(Dispute), useValue: mockDisputeRepository },
+        { provide: getRepositoryToken(DisputeEvidence), useValue: mockEvidenceRepository },
+        { provide: getRepositoryToken(DisputeComment), useValue: mockCommentRepository },
+        { provide: getRepositoryToken(RentAgreement), useValue: mockAgreementRepository },
+        { provide: getRepositoryToken(User), useValue: mockUserRepository },
+        { provide: DataSource, useValue: mockDataSource },
+        { provide: AuditService, useValue: { log: jest.fn() } },
+        {
+          provide: LockService,
+          useValue: {
+            withLock: jest.fn(async (_k: string, _t: number, fn: () => Promise<unknown>) => fn()),
+          },
+        },
+        {
+          provide: IdempotencyService,
+          useValue: {
+            process: jest.fn(async (_k: string, _t: number, fn: () => Promise<unknown>) => fn()),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DisputesService>(DisputesService);
+    jest.clearAllMocks();
+    // Reset shared query runner mocks
+    mockQueryRunner.manager.findOne.mockReset();
+    mockQueryRunner.manager.create.mockReset();
+    mockQueryRunner.manager.save.mockReset();
+    mockQueryRunner.manager.update.mockReset();
+    mockQueryRunner.connect.mockReset();
+    mockQueryRunner.startTransaction.mockReset();
+    mockQueryRunner.commitTransaction.mockReset();
+    mockQueryRunner.rollbackTransaction.mockReset();
+    mockQueryRunner.release.mockReset();
+  });
+
+  // ── resolveDispute ──────────────────────────────────────────────────────────
+
+  describe('resolveDispute', () => {
+    const resolveDto: ResolveDisputeDto = { resolution: 'Dispute resolved in favour of tenant' };
+
+    it('throws ForbiddenException when a non-admin tries to resolve', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(underReviewDispute);
+      mockUserRepository.findOne.mockResolvedValue(regularUser);
+
+      await expect(
+        service.resolveDispute('dispute-uuid-1', resolveDto, 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws BadRequestException when dispute is OPEN (not UNDER_REVIEW)', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(openDispute);
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+
+      await expect(
+        service.resolveDispute('dispute-uuid-1', resolveDto, 'admin-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when dispute is already RESOLVED', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(resolvedDispute);
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+
+      await expect(
+        service.resolveDispute('dispute-uuid-1', resolveDto, 'admin-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('resolves an UNDER_REVIEW dispute and returns updated record', async () => {
+      jest
+        .spyOn(service, 'findByDisputeId')
+        .mockResolvedValueOnce(underReviewDispute)
+        .mockResolvedValueOnce({ ...underReviewDispute, status: DisputeStatus.RESOLVED });
+
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+      mockQueryRunner.manager.update.mockResolvedValue(undefined);
+      mockQueryRunner.manager.findOne.mockResolvedValue(mockAgreement);
+
+      const result = await service.resolveDispute('dispute-uuid-1', resolveDto, 'admin-1');
+
+      expect(result.status).toBe(DisputeStatus.RESOLVED);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+
+    it('rolls back the transaction on unexpected error during resolution', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(underReviewDispute);
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+      mockQueryRunner.manager.update.mockRejectedValue(new Error('DB failure'));
+
+      await expect(
+        service.resolveDispute('dispute-uuid-1', resolveDto, 'admin-1'),
+      ).rejects.toThrow('DB failure');
+
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+
+    it('includes a refundAmount when provided in the DTO', async () => {
+      const dtoWithRefund: ResolveDisputeDto = { resolution: 'Partial refund granted', refundAmount: 250 };
+      jest
+        .spyOn(service, 'findByDisputeId')
+        .mockResolvedValueOnce(underReviewDispute)
+        .mockResolvedValueOnce({ ...underReviewDispute, status: DisputeStatus.RESOLVED });
+
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+      mockQueryRunner.manager.update.mockResolvedValue(undefined);
+
+      const result = await service.resolveDispute('dispute-uuid-1', dtoWithRefund, 'admin-1');
+      expect(result.status).toBe(DisputeStatus.RESOLVED);
+    });
+  });
+
+  // ── addEvidence ─────────────────────────────────────────────────────────────
+
+  describe('addEvidence', () => {
+    const mockFile = {
+      path: '/tmp/evidence.pdf',
+      originalname: 'evidence.pdf',
+      mimetype: 'application/pdf',
+      size: 102400,
+    };
+
+    const mockEvidence = {
+      id: 10,
+      fileUrl: '/tmp/evidence.pdf',
+      fileName: 'evidence.pdf',
+    };
+
+    it('adds evidence to an open dispute', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(openDispute);
+      jest
+        .spyOn(service as any, 'checkDisputePermission')
+        .mockResolvedValue(undefined);
+      jest.spyOn(service as any, 'validateFile').mockReturnValue(undefined);
+
+      mockEvidenceRepository.create.mockReturnValue(mockEvidence);
+      mockEvidenceRepository.save.mockResolvedValue(mockEvidence);
+
+      const result = await service.addEvidence('dispute-uuid-1', mockFile, 'user-1');
+
+      expect(result).toEqual(mockEvidence);
+      expect(mockEvidenceRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: 'evidence.pdf',
+          fileType: 'application/pdf',
+        }),
+      );
+      expect(mockEvidenceRepository.save).toHaveBeenCalled();
+    });
+
+    it('includes the optional description when provided', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(openDispute);
+      jest.spyOn(service as any, 'checkDisputePermission').mockResolvedValue(undefined);
+      jest.spyOn(service as any, 'validateFile').mockReturnValue(undefined);
+
+      mockEvidenceRepository.create.mockReturnValue({ ...mockEvidence, description: 'Invoice copy' });
+      mockEvidenceRepository.save.mockResolvedValue({ ...mockEvidence, description: 'Invoice copy' });
+
+      const result = await service.addEvidence('dispute-uuid-1', mockFile, 'user-1', {
+        fileName: 'evidence.pdf',
+        fileType: 'application/pdf',
+        description: 'Invoice copy',
+      });
+
+      expect(result.description).toBe('Invoice copy');
+    });
+  });
+
+  // ── addComment ──────────────────────────────────────────────────────────────
+
+  describe('addComment', () => {
+    const publicCommentDto: AddCommentDto = { content: 'I have a question', isInternal: false };
+    const internalCommentDto: AddCommentDto = { content: 'Internal note', isInternal: true };
+
+    const mockComment = { id: 5, content: 'I have a question', isInternal: false };
+
+    it('allows any party to add a public comment', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(openDispute);
+      jest.spyOn(service as any, 'checkDisputePermission').mockResolvedValue(undefined);
+      mockUserRepository.findOne.mockResolvedValue(regularUser);
+      mockCommentRepository.create.mockReturnValue(mockComment);
+      mockCommentRepository.save.mockResolvedValue(mockComment);
+
+      const result = await service.addComment('dispute-uuid-1', publicCommentDto, 'user-1');
+
+      expect(result).toEqual(mockComment);
+      expect(mockCommentRepository.save).toHaveBeenCalled();
+    });
+
+    it('allows admins to add internal comments', async () => {
+      const internalComment = { id: 6, content: 'Internal note', isInternal: true };
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(openDispute);
+      jest.spyOn(service as any, 'checkDisputePermission').mockResolvedValue(undefined);
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+      mockCommentRepository.create.mockReturnValue(internalComment);
+      mockCommentRepository.save.mockResolvedValue(internalComment);
+
+      const result = await service.addComment('dispute-uuid-1', internalCommentDto, 'admin-1');
+
+      expect(result.isInternal).toBe(true);
+    });
+
+    it('throws ForbiddenException when a non-admin tries to add an internal comment', async () => {
+      jest.spyOn(service, 'findByDisputeId').mockResolvedValue(openDispute);
+      jest.spyOn(service as any, 'checkDisputePermission').mockResolvedValue(undefined);
+      mockUserRepository.findOne.mockResolvedValue(regularUser);
+
+      await expect(
+        service.addComment('dispute-uuid-1', internalCommentDto, 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ── getAgreementDisputes ────────────────────────────────────────────────────
+
+  describe('getAgreementDisputes', () => {
+    it('returns disputes for a valid agreement without userId', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(mockAgreement);
+      mockDisputeRepository.find.mockResolvedValue([openDispute]);
+
+      const result = await service.getAgreementDisputes('1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe(DisputeStatus.OPEN);
+    });
+
+    it('throws NotFoundException when agreement does not exist', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getAgreementDisputes('999')).rejects.toThrow(NotFoundException);
+    });
+
+    it('allows the landlord (adminId) to view disputes', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(mockAgreement);
+      mockUserRepository.findOne.mockResolvedValue({ ...regularUser, id: 'landlord-1' });
+      mockDisputeRepository.find.mockResolvedValue([openDispute]);
+
+      const result = await service.getAgreementDisputes('1', 'landlord-1');
+      expect(result).toHaveLength(1);
+    });
+
+    it('allows the tenant (userId) to view disputes', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(mockAgreement);
+      mockUserRepository.findOne.mockResolvedValue(regularUser); // id = 'user-1'
+      mockDisputeRepository.find.mockResolvedValue([openDispute]);
+
+      const result = await service.getAgreementDisputes('1', 'user-1');
+      expect(result).toHaveLength(1);
+    });
+
+    it('throws ForbiddenException when user is not a party to the agreement', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(mockAgreement);
+      mockUserRepository.findOne.mockResolvedValue({ ...regularUser, id: 'stranger', role: UserRole.USER });
+
+      await expect(service.getAgreementDisputes('1', 'stranger')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows admin to view any agreement disputes', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(mockAgreement);
+      mockUserRepository.findOne.mockResolvedValue(adminUser);
+      mockDisputeRepository.find.mockResolvedValue([openDispute, underReviewDispute]);
+
+      const result = await service.getAgreementDisputes('1', 'admin-1');
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns empty array when agreement has no disputes', async () => {
+      mockAgreementRepository.findOne.mockResolvedValue(mockAgreement);
+      mockDisputeRepository.find.mockResolvedValue([]);
+
+      const result = await service.getAgreementDisputes('1');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ── findOne edge cases ──────────────────────────────────────────────────────
+
+  describe('findOne — additional edge cases', () => {
+    it('throws NotFoundException for a non-existent numeric ID', async () => {
+      mockDisputeRepository.findOne.mockResolvedValue(null);
+      await expect(service.findOne(9999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── findByDisputeId edge cases ──────────────────────────────────────────────
+
+  describe('findByDisputeId — additional edge cases', () => {
+    it('throws NotFoundException for a non-existent UUID', async () => {
+      mockDisputeRepository.findOne.mockResolvedValue(null);
+      await expect(service.findByDisputeId('no-such-uuid')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/modules/screening/screening.comprehensive.spec.ts
+++ b/backend/src/modules/screening/screening.comprehensive.spec.ts
@@ -1,0 +1,334 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ScreeningService } from './screening.service';
+import { TenantScreeningRequest } from './entities/tenant-screening-request.entity';
+import { TenantScreeningConsent } from './entities/tenant-screening-consent.entity';
+import { TenantScreeningReport } from './entities/tenant-screening-report.entity';
+import { EncryptionService } from '../security/encryption.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { AuditService } from '../audit/audit.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import {
+  ScreeningCheckType,
+  UserScreeningProvider,
+  UserScreeningStatus,
+} from './screening.enums';
+import { UserRole } from '../users/entities/user.entity';
+
+describe('ScreeningService — comprehensive coverage', () => {
+  let service: ScreeningService;
+
+  const mockScreeningRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const mockConsentRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+  const mockReportRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const mockEncryptionService = {
+    encrypt: jest.fn((v: string) => `enc:${v}`),
+    decrypt: jest.fn((v: string) => v.replace(/^enc:/, '')),
+  };
+  const mockNotificationsService = { notify: jest.fn().mockResolvedValue(undefined) };
+  const mockAuditService = { log: jest.fn().mockResolvedValue(undefined) };
+  const mockWebhooksService = { dispatchEvent: jest.fn().mockResolvedValue(undefined) };
+
+  const mockConfigService = {
+    get: jest.fn((key: string, def?: string) => {
+      const cfg: Record<string, string> = {
+        TENANT_SCREENING_SANDBOX_MODE: 'true',
+        TENANT_SCREENING_DEFAULT_PROVIDER: UserScreeningProvider.TRANSUNION_SMARTMOVE,
+        TENANT_SCREENING_CONSENT_TTL_DAYS: '30',
+        TENANT_SCREENING_REPORT_TTL_DAYS: '30',
+      };
+      return cfg[key] ?? def;
+    }),
+  };
+
+  const tenantActor = { id: 'tenant-1', role: UserRole.USER };
+  const adminActor = { id: 'admin-1', role: UserRole.ADMIN };
+  const strangerActor = { id: 'stranger', role: UserRole.USER };
+
+  const pendingScreening = {
+    id: 'screening-1',
+    tenantId: 'tenant-1',
+    requestedByUserId: 'landlord-1',
+    provider: UserScreeningProvider.TRANSUNION_SMARTMOVE,
+    requestedChecks: [ScreeningCheckType.CREDIT],
+    status: UserScreeningStatus.PENDING_CONSENT,
+    consentExpiresAt: new Date('2026-12-31'),
+    encryptedApplicantData: 'enc:{"legalName":"Jane"}',
+  } as TenantScreeningRequest;
+
+  const consentedScreening = {
+    ...pendingScreening,
+    status: UserScreeningStatus.CONSENTED,
+  } as TenantScreeningRequest;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScreeningService,
+        { provide: getRepositoryToken(TenantScreeningRequest), useValue: mockScreeningRepository },
+        { provide: getRepositoryToken(TenantScreeningConsent), useValue: mockConsentRepository },
+        { provide: getRepositoryToken(TenantScreeningReport), useValue: mockReportRepository },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: EncryptionService, useValue: mockEncryptionService },
+        { provide: NotificationsService, useValue: mockNotificationsService },
+        { provide: AuditService, useValue: mockAuditService },
+        { provide: WebhooksService, useValue: mockWebhooksService },
+      ],
+    }).compile();
+
+    service = module.get(ScreeningService);
+    jest.clearAllMocks();
+  });
+
+  // ── createRequest ─────────────────────────────────────────────────────────
+
+  describe('createRequest', () => {
+    it('uses the default provider when none is specified', async () => {
+      mockScreeningRepository.create.mockReturnValue(pendingScreening);
+      mockScreeningRepository.save.mockResolvedValue(pendingScreening);
+
+      const result = await service.createRequest(adminActor, {
+        tenantId: 'tenant-1',
+        requestedChecks: [ScreeningCheckType.CREDIT],
+        applicantData: { legalName: 'Jane Tenant' },
+        consentVersion: 'v1',
+      });
+
+      expect(mockEncryptionService.encrypt).toHaveBeenCalledWith(
+        JSON.stringify({ legalName: 'Jane Tenant' }),
+      );
+      expect(result.status).toBe(UserScreeningStatus.PENDING_CONSENT);
+    });
+
+    it('uses the explicitly provided provider', async () => {
+      const screening = { ...pendingScreening, provider: UserScreeningProvider.CERTN };
+      mockScreeningRepository.create.mockReturnValue(screening);
+      mockScreeningRepository.save.mockResolvedValue(screening);
+
+      const result = await service.createRequest(adminActor, {
+        tenantId: 'tenant-1',
+        provider: UserScreeningProvider.CERTN,
+        requestedChecks: [ScreeningCheckType.CRIMINAL],
+        applicantData: { legalName: 'Bob' },
+        consentVersion: 'v1',
+      });
+
+      expect(result.provider).toBe(UserScreeningProvider.CERTN);
+    });
+
+    it('logs a SECURITY-level audit entry on creation', async () => {
+      mockScreeningRepository.create.mockReturnValue(pendingScreening);
+      mockScreeningRepository.save.mockResolvedValue(pendingScreening);
+
+      await service.createRequest(adminActor, {
+        tenantId: 'tenant-1',
+        requestedChecks: [ScreeningCheckType.CREDIT],
+        applicantData: { legalName: 'Jane' },
+        consentVersion: 'v1',
+      });
+
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'CREATE', entityType: 'TenantScreeningRequest' }),
+      );
+    });
+  });
+
+  // ── grantConsent ──────────────────────────────────────────────────────────
+
+  describe('grantConsent', () => {
+    it('throws ForbiddenException when a non-owner non-admin grants consent', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+
+      await expect(
+        service.grantConsent('screening-1', strangerActor, { consentTextVersion: 'v1' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws BadRequestException when consent has already been processed', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(consentedScreening);
+
+      await expect(
+        service.grantConsent('screening-1', tenantActor, { consentTextVersion: 'v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('allows an admin to grant consent on behalf of the tenant', async () => {
+      const screening = { ...pendingScreening };
+      mockScreeningRepository.findOne.mockResolvedValue(screening);
+      mockConsentRepository.create.mockImplementation((v) => v);
+      mockConsentRepository.save.mockResolvedValue(undefined);
+      mockScreeningRepository.save.mockImplementation(async (v) => v);
+      mockReportRepository.findOne.mockResolvedValue(null);
+      mockReportRepository.create.mockImplementation((v) => v);
+      mockReportRepository.save.mockResolvedValue(undefined);
+
+      const result = await service.grantConsent('screening-1', adminActor, {
+        consentTextVersion: 'v1',
+      });
+
+      expect(result.status).toBe(UserScreeningStatus.COMPLETED);
+    });
+
+    it('uses a custom expiresAt when provided', async () => {
+      const screening = { ...pendingScreening };
+      const customExpiry = '2027-01-01T00:00:00.000Z';
+      mockScreeningRepository.findOne.mockResolvedValue(screening);
+      mockConsentRepository.create.mockImplementation((v) => v);
+      mockConsentRepository.save.mockResolvedValue(undefined);
+      mockScreeningRepository.save.mockImplementation(async (v) => v);
+      mockReportRepository.findOne.mockResolvedValue(null);
+      mockReportRepository.create.mockImplementation((v) => v);
+      mockReportRepository.save.mockResolvedValue(undefined);
+
+      await service.grantConsent('screening-1', tenantActor, {
+        consentTextVersion: 'v1',
+        expiresAt: customExpiry,
+      });
+
+      expect(mockConsentRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ expiresAt: new Date(customExpiry) }),
+      );
+    });
+  });
+
+  // ── getScreening ──────────────────────────────────────────────────────────
+
+  describe('getScreening', () => {
+    it('returns the screening record for the owning tenant', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+
+      const result = await service.getScreening('screening-1', tenantActor);
+      expect(result).toEqual(pendingScreening);
+    });
+
+    it('returns the screening record for an admin', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+
+      const result = await service.getScreening('screening-1', adminActor);
+      expect(result).toEqual(pendingScreening);
+    });
+
+    it('throws NotFoundException when screening does not exist', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getScreening('no-such-id', adminActor)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when a non-owner non-admin requests a screening', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+
+      await expect(service.getScreening('screening-1', strangerActor)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── getScreeningReport ────────────────────────────────────────────────────
+
+  describe('getScreeningReport', () => {
+    const encryptedReport = {
+      id: 'report-1',
+      screeningId: 'screening-1',
+      riskLevel: 'low',
+      providerReportId: 'ext-report-123',
+      encryptedReport: 'enc:{"creditScore":750}',
+      accessExpiresAt: new Date('2026-12-31'),
+    };
+
+    it('returns decrypted report for the owning tenant', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+      mockReportRepository.findOne.mockResolvedValue(encryptedReport);
+
+      const result = await service.getScreeningReport('screening-1', tenantActor);
+
+      expect(result).toMatchObject({
+        screeningId: 'screening-1',
+        riskLevel: 'low',
+        providerReportId: 'ext-report-123',
+      });
+      expect(mockEncryptionService.decrypt).toHaveBeenCalledWith('enc:{"creditScore":750}');
+    });
+
+    it('logs a DATA_ACCESS audit entry when report is accessed', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+      mockReportRepository.findOne.mockResolvedValue(encryptedReport);
+
+      await service.getScreeningReport('screening-1', tenantActor);
+
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'DATA_ACCESS', entityType: 'TenantScreeningReport' }),
+      );
+    });
+
+    it('throws NotFoundException when no report exists for the screening', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+      mockReportRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getScreeningReport('screening-1', tenantActor)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws ForbiddenException for a non-owner non-admin', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(pendingScreening);
+
+      await expect(service.getScreeningReport('screening-1', strangerActor)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── handleProviderWebhook ─────────────────────────────────────────────────
+
+  describe('handleProviderWebhook', () => {
+    it('throws NotFoundException when providerReference does not match any screening', async () => {
+      mockScreeningRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.handleProviderWebhook({
+          providerReference: 'unknown-ref',
+          status: UserScreeningStatus.COMPLETED,
+          reportData: {},
+        } as any),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('updates the screening status from the webhook payload', async () => {
+      const screening = { ...consentedScreening, providerReference: 'ext-ref-1' };
+      mockScreeningRepository.findOne.mockResolvedValue(screening);
+      mockScreeningRepository.save.mockImplementation(async (v) => v);
+      mockReportRepository.findOne.mockResolvedValue(null);
+      mockReportRepository.create.mockImplementation((v) => v);
+      mockReportRepository.save.mockResolvedValue(undefined);
+
+      const result = await service.handleProviderWebhook({
+        providerReference: 'ext-ref-1',
+        status: UserScreeningStatus.COMPLETED,
+        reportData: { creditScore: 720 },
+      } as any);
+
+      expect(result.status).toBe(UserScreeningStatus.COMPLETED);
+    });
+  });
+
+  // ── service bootstrap ─────────────────────────────────────────────────────
+
+  describe('service initialisation', () => {
+    it('is defined', () => {
+      expect(service).toBeDefined();
+    });
+  });
+});

--- a/backend/src/modules/stellar/__tests__/stellar.comprehensive.spec.ts
+++ b/backend/src/modules/stellar/__tests__/stellar.comprehensive.spec.ts
@@ -1,0 +1,381 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
+import { StellarService } from '../services/stellar.service';
+import { EncryptionService } from '../services/encryption.service';
+import {
+  StellarAccount,
+  StellarAccountType,
+} from '../entities/stellar-account.entity';
+import {
+  StellarTransaction,
+  TransactionStatus,
+} from '../entities/stellar-transaction.entity';
+import { StellarEscrow, EscrowStatus } from '../entities/stellar-escrow.entity';
+
+// ── Stellar SDK mock ──────────────────────────────────────────────────────────
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    random: jest.fn(() => ({
+      publicKey: () => 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV',
+      secret: () => 'SABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV',
+    })),
+    fromSecret: jest.fn(() => ({
+      publicKey: () => 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV',
+      sign: jest.fn(),
+    })),
+  },
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: jest.fn().mockResolvedValue({
+        accountId: () => 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV',
+        sequenceNumber: () => '123456789',
+        balances: [{ asset_type: 'native', balance: '100.0000000' }],
+        subentry_count: 0,
+        thresholds: {},
+        signers: [],
+        flags: {},
+      }),
+      submitTransaction: jest.fn().mockResolvedValue({ hash: 'txhash123', ledger: 12345 }),
+    })),
+  },
+  Asset: { native: jest.fn(() => ({ code: 'XLM', issuer: null })) },
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    addMemo: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({
+      sign: jest.fn(),
+      hash: () => Buffer.from('transaction-hash'),
+      toEnvelope: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue('xdr') }),
+    }),
+  })),
+  Operation: {
+    payment: jest.fn(() => ({})),
+    createAccount: jest.fn(() => ({})),
+    accountMerge: jest.fn(() => ({})),
+    setOptions: jest.fn(() => ({})),
+    changeTrust: jest.fn(() => ({})),
+  },
+  Memo: {
+    text: jest.fn((t) => ({ type: 'text', value: t })),
+    id: jest.fn((i) => ({ type: 'id', value: i })),
+    hash: jest.fn((h) => ({ type: 'hash', value: h })),
+    return: jest.fn((r) => ({ type: 'return', value: r })),
+  },
+}));
+
+describe('StellarService — comprehensive coverage', () => {
+  let service: StellarService;
+
+  const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV';
+
+  const mockAccount: StellarAccount = {
+    id: 1,
+    userId: 'user-1',
+    publicKey: PUBLIC_KEY,
+    encryptedSecret: 'encrypted-secret',
+    accountType: StellarAccountType.USER,
+    isActive: true,
+    xlmBalance: '100.0000000',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as StellarAccount;
+
+  const mockTransaction: StellarTransaction = {
+    id: 1,
+    hash: 'txhash123',
+    fromAccountId: 1,
+    toAccountId: 2,
+    amount: '10.0000000',
+    assetCode: 'XLM',
+    status: TransactionStatus.COMPLETED,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as StellarTransaction;
+
+  const mockEscrow: StellarEscrow = {
+    id: 1,
+    agreementId: 'agreement-1',
+    buyerAccountId: 1,
+    escrowAccountId: 2,
+    amount: '50.0000000',
+    assetCode: 'XLM',
+    status: EscrowStatus.FUNDED,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as StellarEscrow;
+
+  const mockQueryRunner = {
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+    manager: {
+      save: jest.fn().mockImplementation((entity) => Promise.resolve({ ...entity, id: 1 })),
+    },
+  };
+
+  const mockAccountRepository = {
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation((e) => Promise.resolve({ ...e, id: 1 })),
+    findOne: jest.fn(),
+    find: jest.fn().mockResolvedValue([]),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    }),
+  };
+
+  const mockTransactionRepository = {
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation((e) => Promise.resolve({ ...e, id: 1 })),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    }),
+  };
+
+  const mockEscrowRepository = {
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation((e) => Promise.resolve({ ...e, id: 1 })),
+    findOne: jest.fn(),
+    find: jest.fn().mockResolvedValue([]),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    }),
+  };
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue({
+      network: 'testnet',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      baseFee: '100',
+      encryptionKey: 'test-key',
+      friendbotUrl: 'https://friendbot.stellar.org',
+    }),
+  };
+
+  const mockEncryptionService = {
+    encrypt: jest.fn().mockReturnValue('encrypted-secret'),
+    decrypt: jest.fn().mockReturnValue('SABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV'),
+    isConfigured: jest.fn().mockReturnValue(true),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarService,
+        { provide: getRepositoryToken(StellarAccount), useValue: mockAccountRepository },
+        { provide: getRepositoryToken(StellarTransaction), useValue: mockTransactionRepository },
+        { provide: getRepositoryToken(StellarEscrow), useValue: mockEscrowRepository },
+        { provide: DataSource, useValue: { createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner) } },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: EncryptionService, useValue: mockEncryptionService },
+      ],
+    }).compile();
+
+    service = module.get<StellarService>(StellarService);
+    jest.clearAllMocks();
+  });
+
+  // ── getTransactionById ────────────────────────────────────────────────────
+
+  describe('getTransactionById', () => {
+    it('returns a transaction when it exists', async () => {
+      mockTransactionRepository.findOne.mockResolvedValue(mockTransaction);
+
+      const result = await service.getTransactionById(1);
+      expect(result).toEqual(mockTransaction);
+    });
+
+    it('throws NotFoundException when transaction does not exist', async () => {
+      mockTransactionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getTransactionById(9999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── getTransactionByHash ──────────────────────────────────────────────────
+
+  describe('getTransactionByHash', () => {
+    it('returns a transaction by its hash', async () => {
+      mockTransactionRepository.findOne.mockResolvedValue(mockTransaction);
+
+      const result = await service.getTransactionByHash('txhash123');
+      expect(result.hash).toBe('txhash123');
+    });
+
+    it('throws NotFoundException for an unknown hash', async () => {
+      mockTransactionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getTransactionByHash('bad-hash')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── getEscrowById ─────────────────────────────────────────────────────────
+
+  describe('getEscrowById', () => {
+    it('returns an escrow when it exists', async () => {
+      mockEscrowRepository.findOne.mockResolvedValue(mockEscrow);
+
+      const result = await service.getEscrowById(1);
+      expect(result).toEqual(mockEscrow);
+    });
+
+    it('throws NotFoundException when escrow does not exist', async () => {
+      mockEscrowRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getEscrowById(9999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── getAccountsByUserId ───────────────────────────────────────────────────
+
+  describe('getAccountsByUserId', () => {
+    it('returns all accounts for a user', async () => {
+      mockAccountRepository.find.mockResolvedValue([mockAccount]);
+
+      const result = await service.getAccountsByUserId('user-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].userId).toBe('user-1');
+    });
+
+    it('returns an empty array when user has no accounts', async () => {
+      mockAccountRepository.find.mockResolvedValue([]);
+
+      const result = await service.getAccountsByUserId('user-no-accounts');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ── getAccountById ────────────────────────────────────────────────────────
+
+  describe('getAccountById', () => {
+    it('returns an account when found', async () => {
+      mockAccountRepository.findOne.mockResolvedValue(mockAccount);
+
+      const result = await service.getAccountById(1);
+      expect(result.publicKey).toBe(PUBLIC_KEY);
+    });
+
+    it('throws NotFoundException for unknown ID', async () => {
+      mockAccountRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getAccountById(9999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── getAccountByPublicKey ─────────────────────────────────────────────────
+
+  describe('getAccountByPublicKey', () => {
+    it('returns an account matching the given public key', async () => {
+      mockAccountRepository.findOne.mockResolvedValue(mockAccount);
+
+      const result = await service.getAccountByPublicKey(PUBLIC_KEY);
+      expect(result.publicKey).toBe(PUBLIC_KEY);
+    });
+
+    it('throws NotFoundException for an unknown public key', async () => {
+      mockAccountRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getAccountByPublicKey('GUNKNOWN')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── listEscrows ───────────────────────────────────────────────────────────
+
+  describe('listEscrows', () => {
+    it('returns paginated escrows with default params', async () => {
+      const qb = mockEscrowRepository.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[mockEscrow], 1]);
+
+      const result = await service.listEscrows({});
+      expect(result).toBeDefined();
+    });
+
+    it('filters by status when provided', async () => {
+      const qb = mockEscrowRepository.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[mockEscrow], 1]);
+
+      const result = await service.listEscrows({ status: EscrowStatus.FUNDED });
+      expect(result).toBeDefined();
+    });
+  });
+
+  // ── listTransactions ──────────────────────────────────────────────────────
+
+  describe('listTransactions', () => {
+    it('returns paginated transactions', async () => {
+      const qb = mockTransactionRepository.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[mockTransaction], 1]);
+
+      const result = await service.listTransactions({});
+      expect(result).toBeDefined();
+    });
+
+    it('filters by status when provided', async () => {
+      const qb = mockTransactionRepository.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[mockTransaction], 1]);
+
+      const result = await service.listTransactions({ status: TransactionStatus.COMPLETED });
+      expect(result).toBeDefined();
+    });
+  });
+
+  // ── createAccount ─────────────────────────────────────────────────────────
+
+  describe('createAccount', () => {
+    it('creates and persists a USER-type account', async () => {
+      mockAccountRepository.save.mockResolvedValue({ ...mockAccount, id: 2 });
+
+      const result = await service.createAccount({
+        userId: 'user-2',
+        accountType: StellarAccountType.USER,
+      });
+
+      expect(mockEncryptionService.encrypt).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+
+    it('creates an ESCROW-type account', async () => {
+      mockAccountRepository.save.mockResolvedValue({ ...mockAccount, accountType: StellarAccountType.ESCROW });
+
+      const result = await service.createAccount({
+        userId: 'user-3',
+        accountType: StellarAccountType.ESCROW,
+      });
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  // ── service bootstrap ─────────────────────────────────────────────────────
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
Adds comprehensive test coverage across four modules:

- **Disputes (#878)**: `resolveDispute` (admin-only, status guards, rollback on DB error, refundAmount), `addEvidence`, `addComment` (public/internal/ForbiddenException), `getAgreementDisputes` (access control for all roles)
- **Screening (#881)**: `createRequest` (default/explicit provider, audit logging), `grantConsent` (ForbiddenException, BadRequestException, admin grant, custom expiry), `getScreening`/`getScreeningReport` (owner, admin, NotFoundException, ForbiddenException), `handleProviderWebhook`
- **Stellar (#879)**: `getTransactionById/ByHash`, `getEscrowById`, `getAccountsByUserId/ById/ByPublicKey`, `listEscrows/Transactions` with status filters, `createAccount` (USER and ESCROW types)
- **Auth (#875)**: `generateTokens` (correct JWT sign calls), `sanitizeUser` (strips password/refreshToken/resetToken/verificationToken), `refreshToken` (token rotation, invalid type, revoked/null token, user not found, bcrypt mismatch, expired JWT), `completeMfaLogin`, account lockout (increment → lock at 5 attempts → expire → still-locked rejection), MFA login branch

Closes #878
Closes #881
Closes #879
closes #875
