### PR TITLE
test: webhook delivery, property wizard flow, SQL injection prevention, email service (#884 #902 #906 #918)

### DIFF
--- a/backend/src/common/__tests__/sql-injection.spec.ts
+++ b/backend/src/common/__tests__/sql-injection.spec.ts
@@ -1,0 +1,207 @@
+import { ArgumentMetadata } from '@nestjs/common';
+import { SanitizePipe, SanitizeValidationPipe } from '../pipes/sanitize.pipe';
+
+const META: ArgumentMetadata = { type: 'body', metatype: String, data: '' };
+
+// Known SQL injection payloads
+const SQL_PAYLOADS = [
+  "' OR '1'='1",
+  "'; DROP TABLE users; --",
+  "1; SELECT * FROM properties",
+  "1 UNION SELECT username, password FROM users",
+  "admin'--",
+  "1' AND 1=1--",
+  "1 OR 1=1",
+  "'; INSERT INTO users VALUES ('hacker','hacked'); --",
+  "' OR 'x'='x",
+  "1; UPDATE users SET password='hacked' WHERE '1'='1",
+  '" OR ""="',
+  '`; DROP TABLE webhook_endpoints; --`',
+  "EXEC xp_cmdshell('dir')",
+  "ALTER TABLE users ADD admin BOOLEAN",
+  "1; DELETE FROM properties --",
+];
+
+// Known XSS payloads
+const XSS_PAYLOADS = [
+  '<script>alert("xss")</script>',
+  'javascript:alert(1)',
+  '<img onerror="alert(1)" src="x">',
+  '<iframe src="evil.com">',
+  '<object data="evil.swf">',
+  '<embed src="evil.swf">',
+  "onload=alert(1)",
+  "onclick=window.location='http://evil.com'",
+];
+
+// Inputs that must pass through unchanged (benign)
+const BENIGN_INPUTS = [
+  'normal property description',
+  '42 Lagos Street, Victoria Island',
+  'john.doe@example.com',
+  'Password123',
+  '2 bedroom apartment',
+  'Looking for a 3-bedroom house in Lekki',
+  'Budget: ₦500,000/month',
+];
+
+describe('SanitizePipe — SQL injection prevention', () => {
+  let pipe: SanitizePipe;
+
+  beforeEach(() => {
+    pipe = new SanitizePipe();
+  });
+
+  it('returns null and undefined unchanged', () => {
+    expect(pipe.transform(null, META)).toBeNull();
+    expect(pipe.transform(undefined, META)).toBeUndefined();
+  });
+
+  it('passes benign inputs through without modification of meaningful content', () => {
+    for (const input of BENIGN_INPUTS) {
+      const result = pipe.transform(input, META) as string;
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('strips null bytes from string inputs', () => {
+    const result = pipe.transform('hello\0world', META) as string;
+    expect(result).not.toContain('\0');
+  });
+
+  it('sanitizes XSS payloads by escaping or removing dangerous content', () => {
+    for (const payload of XSS_PAYLOADS) {
+      const result = pipe.transform(payload, META) as string;
+      expect(result).not.toMatch(/<script/i);
+      expect(result).not.toMatch(/javascript:/i);
+      expect(result).not.toMatch(/<iframe/i);
+      expect(result).not.toMatch(/<object/i);
+      expect(result).not.toMatch(/<embed/i);
+    }
+  });
+
+  it('sanitizes all string values in a nested object', () => {
+    const input = {
+      name: 'Alice',
+      bio: '<script>alert("xss")</script>',
+      address: { street: '1 Main St\0' },
+    };
+    const result = pipe.transform(input, META) as any;
+    expect(result.bio).not.toContain('<script');
+    expect(result.address.street).not.toContain('\0');
+    expect(result.name).toBe('Alice');
+  });
+
+  it('sanitizes each element in an array', () => {
+    const input = ['safe text', '<script>alert(1)</script>', 'also safe'];
+    const result = pipe.transform(input, META) as string[];
+    expect(result[1]).not.toContain('<script');
+    expect(result[0]).toBe('safe text');
+  });
+
+  it('passes numbers and booleans through unchanged', () => {
+    expect(pipe.transform(42, META)).toBe(42);
+    expect(pipe.transform(true, META)).toBe(true);
+  });
+});
+
+describe('SanitizeValidationPipe — SQL injection prevention', () => {
+  let pipe: SanitizeValidationPipe;
+
+  beforeEach(() => {
+    pipe = new SanitizeValidationPipe();
+  });
+
+  describe('blocks SQL injection patterns', () => {
+    const sqlKeywordPayloads = [
+      "SELECT * FROM users",
+      "INSERT INTO properties VALUES (1, 'x')",
+      "UPDATE users SET role='admin'",
+      "DELETE FROM properties",
+      "DROP TABLE users",
+      "CREATE TABLE evil (id INT)",
+      "ALTER TABLE users ADD COLUMN evil TEXT",
+      "EXEC sp_executesql('DROP TABLE users')",
+      "EXECUTE IMMEDIATE 'SELECT 1'",
+    ];
+
+    for (const payload of sqlKeywordPayloads) {
+      it(`rejects payload containing SQL keyword: "${payload.slice(0, 30)}..."`, () => {
+        expect(() => pipe.transform(payload, META)).toThrow();
+      });
+    }
+  });
+
+  describe('blocks SQL punctuation injection', () => {
+    const punctuationPayloads = [
+      "' OR 1=1--",
+      "'; --",
+      '"; DROP TABLE users; --',
+      "1`; --",
+    ];
+
+    for (const payload of punctuationPayloads) {
+      it(`rejects payload: "${payload.slice(0, 30)}"`, () => {
+        expect(() => pipe.transform(payload, META)).toThrow();
+      });
+    }
+  });
+
+  describe('blocks boolean-based injection', () => {
+    const boolPayloads = [
+      "1 OR 1=1",
+      "1 AND 1=1",
+      "x' OR 3=3--",
+    ];
+
+    for (const payload of boolPayloads) {
+      it(`rejects boolean injection: "${payload}"`, () => {
+        expect(() => pipe.transform(payload, META)).toThrow();
+      });
+    }
+  });
+
+  describe('blocks XSS patterns', () => {
+    for (const payload of XSS_PAYLOADS) {
+      it(`rejects XSS payload: "${payload.slice(0, 30)}"`, () => {
+        expect(() => pipe.transform(payload, META)).toThrow();
+      });
+    }
+  });
+
+  describe('allows safe inputs', () => {
+    const safeInputs = [
+      'My name is Alice',
+      'Looking for a flat in Ikeja',
+      'Budget is 500000',
+      'Available from 2027-01-01',
+      'contact@example.com',
+      '3 bedroom duplex',
+    ];
+
+    for (const input of safeInputs) {
+      it(`allows safe input: "${input}"`, () => {
+        expect(() => pipe.transform(input, META)).not.toThrow();
+      });
+    }
+  });
+
+  it('rejects SQL injection within a nested object field', () => {
+    const input = {
+      name: 'Alice',
+      address: "'; DROP TABLE properties; --",
+    };
+    expect(() => pipe.transform(input, META)).toThrow();
+  });
+
+  it('rejects SQL injection within an array element', () => {
+    const input = ['safe', "SELECT * FROM users", 'also safe'];
+    expect(() => pipe.transform(input, META)).toThrow();
+  });
+
+  it('returns null and undefined unchanged', () => {
+    expect(pipe.transform(null, META)).toBeNull();
+    expect(pipe.transform(undefined, META)).toBeUndefined();
+  });
+});

--- a/backend/src/modules/notifications/email.service.spec.ts
+++ b/backend/src/modules/notifications/email.service.spec.ts
@@ -1,0 +1,270 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import { EmailService } from './email.service';
+
+jest.mock('nodemailer');
+const mockedNodemailer = nodemailer as jest.Mocked<typeof nodemailer>;
+
+describe('EmailService', () => {
+  let service: EmailService;
+  let sendMailMock: jest.Mock;
+  let configService: any;
+
+  const mockConfig: Record<string, string> = {
+    EMAIL_SERVICE: 'gmail',
+    EMAIL_USER: 'test@chioma.app',
+    EMAIL_PASSWORD: 'test-password',
+    EMAIL_FROM: '"Chioma App" <noreply@chioma.app>',
+    FRONTEND_URL: 'https://app.chioma.io',
+    PASSWORD_RESET_URL: 'https://app.chioma.io/reset-password',
+  };
+
+  beforeEach(async () => {
+    sendMailMock = jest.fn().mockResolvedValue({ messageId: 'test-message-id' });
+
+    mockedNodemailer.createTransport.mockReturnValue({
+      sendMail: sendMailMock,
+    } as any);
+
+    configService = {
+      get: jest.fn((key: string) => mockConfig[key] ?? null),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── sendVerificationEmail ──────────────────────────────────────────────────
+
+  describe('sendVerificationEmail', () => {
+    it('sends email to the correct address', async () => {
+      await service.sendVerificationEmail('user@example.com', 'verify-token-123');
+      expect(sendMailMock).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'user@example.com' }),
+      );
+    });
+
+    it('includes the verification token in the email body', async () => {
+      await service.sendVerificationEmail('user@example.com', 'abc-token');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('abc-token');
+    });
+
+    it('includes a verification URL pointing to the frontend', async () => {
+      await service.sendVerificationEmail('user@example.com', 'tok123');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('https://app.chioma.io/verify-email?token=tok123');
+    });
+
+    it('uses configured FROM address', async () => {
+      await service.sendVerificationEmail('user@example.com', 'tok');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.from).toBe('"Chioma App" <noreply@chioma.app>');
+    });
+
+    it('throws when transporter fails', async () => {
+      sendMailMock.mockRejectedValue(new Error('SMTP connection failed'));
+      await expect(
+        service.sendVerificationEmail('user@example.com', 'tok'),
+      ).rejects.toThrow('Failed to send verification email');
+    });
+
+    it('retries on transient failure (retry decorator wired)', async () => {
+      sendMailMock
+        .mockRejectedValueOnce(new Error('transient'))
+        .mockResolvedValueOnce({ messageId: 'ok' });
+
+      await expect(
+        service.sendVerificationEmail('user@example.com', 'tok'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ── sendPasswordResetEmail ─────────────────────────────────────────────────
+
+  describe('sendPasswordResetEmail', () => {
+    it('sends to the correct address', async () => {
+      await service.sendPasswordResetEmail('reset@example.com', 'reset-token');
+      expect(sendMailMock).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'reset@example.com' }),
+      );
+    });
+
+    it('includes the reset token in the email body', async () => {
+      await service.sendPasswordResetEmail('reset@example.com', 'my-reset-token');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('my-reset-token');
+    });
+
+    it('builds reset URL from PASSWORD_RESET_URL config', async () => {
+      await service.sendPasswordResetEmail('reset@example.com', 'tok');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('https://app.chioma.io/reset-password?token=tok');
+    });
+
+    it('falls back to FRONTEND_URL when PASSWORD_RESET_URL is not set', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'PASSWORD_RESET_URL') return null;
+        return mockConfig[key] ?? null;
+      });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          EmailService,
+          { provide: ConfigService, useValue: configService },
+        ],
+      }).compile();
+      const svc = module.get<EmailService>(EmailService);
+
+      await svc.sendPasswordResetEmail('reset@example.com', 'tok');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('https://app.chioma.io/reset-password?token=tok');
+    });
+
+    it('throws when transporter fails', async () => {
+      sendMailMock.mockRejectedValue(new Error('Auth error'));
+      await expect(
+        service.sendPasswordResetEmail('reset@example.com', 'tok'),
+      ).rejects.toThrow('Failed to send password reset email');
+    });
+
+    it('includes expiry warning in the body', async () => {
+      await service.sendPasswordResetEmail('reset@example.com', 'tok');
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('1 hour');
+    });
+  });
+
+  // ── sendNotificationEmail ──────────────────────────────────────────────────
+
+  describe('sendNotificationEmail', () => {
+    it('sends with the provided subject', async () => {
+      await service.sendNotificationEmail(
+        'notify@example.com',
+        'Your booking is confirmed',
+        'booking',
+        { title: 'Booking Confirmed', message: 'Your property is booked.' },
+      );
+      expect(sendMailMock).toHaveBeenCalledWith(
+        expect.objectContaining({ subject: 'Your booking is confirmed' }),
+      );
+    });
+
+    it('renders title and message in the HTML body', async () => {
+      await service.sendNotificationEmail('n@example.com', 'Test', 'tmpl', {
+        title: 'Hello',
+        message: 'World',
+      });
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('Hello');
+      expect(mailOptions.html).toContain('World');
+    });
+
+    it('renders list items when data.items is provided', async () => {
+      await service.sendNotificationEmail('n@example.com', 'Items', 'tmpl', {
+        title: 'List',
+        message: '',
+        items: ['Item 1', 'Item 2'],
+      });
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('<li>Item 1</li>');
+      expect(mailOptions.html).toContain('<li>Item 2</li>');
+    });
+
+    it('renders action link when data.actionUrl is provided', async () => {
+      await service.sendNotificationEmail('n@example.com', 'Action', 'tmpl', {
+        title: 'Click',
+        message: '',
+        actionUrl: 'https://app.chioma.io/action',
+        actionText: 'View Now',
+      });
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('https://app.chioma.io/action');
+      expect(mailOptions.html).toContain('View Now');
+    });
+
+    it('throws when transporter fails', async () => {
+      sendMailMock.mockRejectedValue(new Error('send failed'));
+      await expect(
+        service.sendNotificationEmail('n@example.com', 'S', 'tmpl', {}),
+      ).rejects.toThrow('Failed to send notification email');
+    });
+  });
+
+  // ── sendAlertEmail ─────────────────────────────────────────────────────────
+
+  describe('sendAlertEmail', () => {
+    it('sends alert to the given address with correct subject', async () => {
+      await service.sendAlertEmail('admin@chioma.app', 'High CPU Alert', {
+        message: 'CPU usage exceeded 90%',
+      });
+      expect(sendMailMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'admin@chioma.app',
+          subject: 'High CPU Alert',
+        }),
+      );
+    });
+
+    it('includes the alert message in the body', async () => {
+      await service.sendAlertEmail('admin@chioma.app', 'Alert', {
+        message: 'Something went wrong',
+      });
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('Something went wrong');
+    });
+
+    it('includes serialised details when provided', async () => {
+      await service.sendAlertEmail('admin@chioma.app', 'Alert', {
+        message: 'Error',
+        details: { code: 500, path: '/api/health' },
+      });
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('"code": 500');
+    });
+
+    it('omits details block when details is absent', async () => {
+      await service.sendAlertEmail('admin@chioma.app', 'Alert', { message: 'msg' });
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).not.toContain('<pre>');
+    });
+
+    it('uses default message when data.message is absent', async () => {
+      await service.sendAlertEmail('admin@chioma.app', 'Alert', {});
+      const mailOptions = sendMailMock.mock.calls[0][0];
+      expect(mailOptions.html).toContain('An alert has been triggered');
+    });
+
+    it('throws when transporter fails', async () => {
+      sendMailMock.mockRejectedValue(new Error('relay error'));
+      await expect(
+        service.sendAlertEmail('admin@chioma.app', 'Alert', { message: 'x' }),
+      ).rejects.toThrow('Failed to send alert email');
+    });
+  });
+
+  // ── transporter initialisation ─────────────────────────────────────────────
+
+  describe('transporter setup', () => {
+    it('creates transporter with config values at construction', () => {
+      expect(mockedNodemailer.createTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'gmail',
+          auth: expect.objectContaining({
+            user: 'test@chioma.app',
+            pass: 'test-password',
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/properties/__tests__/property-wizard.integration.spec.ts
+++ b/backend/src/modules/properties/__tests__/property-wizard.integration.spec.ts
@@ -1,0 +1,334 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  ForbiddenException,
+  GoneException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { PropertyWizardService } from '../property-wizard.service';
+import { PropertyListingDraft } from '../entities/property-listing-draft.entity';
+import { PropertiesService } from '../properties.service';
+
+const VALID_DATA = {
+  propertyType: 'apartment',
+  address: '42 Lagos Street, Victoria Island',
+  bedrooms: 2,
+  bathrooms: 1,
+  monthlyRent: 1200,
+  securityDeposit: 1200,
+  leaseTerm: '1-year',
+  moveInDate: '2027-06-01',
+  photos: [
+    { url: 'https://cdn.example.com/img1.jpg', order: 0 },
+    { url: 'https://cdn.example.com/img2.jpg', order: 1 },
+    { url: 'https://cdn.example.com/img3.jpg', order: 2 },
+  ],
+  propertyDescription: 'A beautiful 2-bedroom apartment in the heart of VI with great amenities and views.',
+  availableFrom: '2027-06-01',
+};
+
+describe('Property Wizard — Integration Flow', () => {
+  let service: PropertyWizardService;
+  let draftRepository: any;
+  let propertiesService: any;
+
+  const makeDraft = (overrides = {}) => ({
+    id: 'draft-uuid',
+    landlordId: 'landlord-uuid',
+    data: {},
+    currentStep: 1,
+    completedSteps: [] as number[],
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    draftRepository = {
+      create: jest.fn().mockImplementation((dto) => ({ ...dto })),
+      save: jest.fn().mockImplementation((d) => Promise.resolve({ ...d, id: d.id ?? 'draft-uuid' })),
+      findOne: jest.fn(),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+
+    propertiesService = {
+      create: jest.fn().mockResolvedValue({ id: 'prop-uuid' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PropertyWizardService,
+        { provide: getRepositoryToken(PropertyListingDraft), useValue: draftRepository },
+        { provide: PropertiesService, useValue: propertiesService },
+      ],
+    }).compile();
+
+    service = module.get<PropertyWizardService>(PropertyWizardService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── start ──────────────────────────────────────────────────────────────────
+
+  describe('start', () => {
+    it('creates a draft with the correct landlordId', async () => {
+      const result = await service.start('landlord-uuid');
+      expect(result.landlordId).toBe('landlord-uuid');
+      expect(draftRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ landlordId: 'landlord-uuid', currentStep: 1 }),
+      );
+    });
+
+    it('sets an expiry 30 days in the future', async () => {
+      const before = Date.now();
+      const result = await service.start('landlord-uuid');
+      const after = Date.now();
+
+      const expiresMs = result.expiresAt.getTime();
+      expect(expiresMs).toBeGreaterThanOrEqual(before + 29 * 24 * 60 * 60 * 1000);
+      expect(expiresMs).toBeLessThanOrEqual(after + 31 * 24 * 60 * 60 * 1000);
+    });
+
+    it('initialises completedSteps as empty array', async () => {
+      const result = await service.start('landlord-uuid');
+      expect(result.completedSteps).toEqual([]);
+    });
+  });
+
+  // ── findDraft ──────────────────────────────────────────────────────────────
+
+  describe('findDraft', () => {
+    it('throws NotFoundException when draft does not exist', async () => {
+      draftRepository.findOne.mockResolvedValue(null);
+      await expect(service.findDraft('missing', 'landlord-uuid')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException for wrong landlord', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft({ landlordId: 'other-landlord' }));
+      await expect(service.findDraft('draft-uuid', 'landlord-uuid')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws GoneException for expired draft', async () => {
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ expiresAt: new Date(Date.now() - 1000) }),
+      );
+      await expect(service.findDraft('draft-uuid', 'landlord-uuid')).rejects.toThrow(GoneException);
+    });
+
+    it('returns the draft when valid and owned', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      const draft = await service.findDraft('draft-uuid', 'landlord-uuid');
+      expect(draft.id).toBe('draft-uuid');
+    });
+  });
+
+  // ── updateStep ─────────────────────────────────────────────────────────────
+
+  describe('updateStep', () => {
+    it('merges step data and marks step as completed', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      const result = await service.updateStep('draft-uuid', 'landlord-uuid', 1, {
+        propertyType: 'apartment',
+        address: '42 Lagos Street',
+        bedrooms: 2,
+        bathrooms: 1,
+      });
+
+      expect(result.data.propertyType).toBe('apartment');
+      expect(result.completedSteps).toContain(1);
+    });
+
+    it('does not duplicate a step in completedSteps on repeated update', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft({ completedSteps: [1] }));
+      const result = await service.updateStep('draft-uuid', 'landlord-uuid', 1, {
+        propertyType: 'house',
+      });
+
+      const count = result.completedSteps.filter((s: number) => s === 1).length;
+      expect(count).toBe(1);
+    });
+
+    it('throws UnprocessableEntityException for step 0', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      await expect(
+        service.updateStep('draft-uuid', 'landlord-uuid', 0, {}),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws UnprocessableEntityException for step 9', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      await expect(
+        service.updateStep('draft-uuid', 'landlord-uuid', 9, {}),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('returns validation errors for step 1 when required fields are missing', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      const result = await service.updateStep('draft-uuid', 'landlord-uuid', 1, {});
+
+      expect(result.validationErrors.propertyType).toBeDefined();
+      expect(result.validationErrors.address).toBeDefined();
+    });
+
+    it('returns no validation errors when step 2 data is complete', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      const result = await service.updateStep('draft-uuid', 'landlord-uuid', 2, {
+        monthlyRent: 1000,
+        securityDeposit: 500,
+        leaseTerm: '6-month',
+        moveInDate: '2027-01-01',
+      });
+
+      expect(Object.keys(result.validationErrors)).toHaveLength(0);
+    });
+
+    it('deep-merges nested objects without overwriting sibling keys', async () => {
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ data: { propertyType: 'apartment', address: 'existing' } }),
+      );
+      const result = await service.updateStep('draft-uuid', 'landlord-uuid', 1, {
+        bedrooms: 3,
+        bathrooms: 2,
+      });
+
+      expect(result.data.propertyType).toBe('apartment');
+      expect(result.data.address).toBe('existing');
+      expect(result.data.bedrooms).toBe(3);
+    });
+  });
+
+  // ── publish ────────────────────────────────────────────────────────────────
+
+  describe('publish', () => {
+    it('publishes and returns propertyListingId when all steps are valid', async () => {
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ completedSteps: [1, 2, 3, 5, 6, 7], data: VALID_DATA }),
+      );
+
+      const result = await service.publish('draft-uuid', 'landlord-uuid');
+
+      expect(propertiesService.create).toHaveBeenCalled();
+      expect(draftRepository.remove).toHaveBeenCalled();
+      expect(result.propertyListingId).toBe('prop-uuid');
+      expect(result.redirectUrl).toBe('/properties/prop-uuid');
+    });
+
+    it('throws when a required step is missing', async () => {
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ completedSteps: [1, 2, 3, 5, 6], data: VALID_DATA }),
+      );
+
+      await expect(service.publish('draft-uuid', 'landlord-uuid')).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('throws when fewer than 3 photos provided', async () => {
+      const data = { ...VALID_DATA, photos: [{ url: 'u1', order: 0 }, { url: 'u2', order: 1 }] };
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ completedSteps: [1, 2, 3, 5, 6, 7], data }),
+      );
+
+      await expect(service.publish('draft-uuid', 'landlord-uuid')).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('throws when description is too short', async () => {
+      const data = { ...VALID_DATA, propertyDescription: 'short' };
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ completedSteps: [1, 2, 3, 5, 6, 7], data }),
+      );
+
+      await expect(service.publish('draft-uuid', 'landlord-uuid')).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('does not call propertiesService.create if validation fails', async () => {
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ completedSteps: [1], data: {} }),
+      );
+
+      await expect(service.publish('draft-uuid', 'landlord-uuid')).rejects.toThrow();
+      expect(propertiesService.create).not.toHaveBeenCalled();
+    });
+
+    it('does not remove the draft if property creation throws', async () => {
+      draftRepository.findOne.mockResolvedValue(
+        makeDraft({ completedSteps: [1, 2, 3, 5, 6, 7], data: VALID_DATA }),
+      );
+      propertiesService.create.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.publish('draft-uuid', 'landlord-uuid')).rejects.toThrow('DB error');
+      expect(draftRepository.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── removeDraft ────────────────────────────────────────────────────────────
+
+  describe('removeDraft', () => {
+    it('removes draft owned by the landlord', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft());
+      await service.removeDraft('draft-uuid', 'landlord-uuid');
+      expect(draftRepository.remove).toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when landlord does not own draft', async () => {
+      draftRepository.findOne.mockResolvedValue(makeDraft({ landlordId: 'someone-else' }));
+      await expect(service.removeDraft('draft-uuid', 'landlord-uuid')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── full wizard flow ───────────────────────────────────────────────────────
+
+  describe('end-to-end wizard flow', () => {
+    it('completes all steps then publishes successfully', async () => {
+      // Simulate a stateful draft that accumulates updates
+      let currentDraft = makeDraft();
+      draftRepository.findOne.mockImplementation(() => Promise.resolve({ ...currentDraft }));
+      draftRepository.save.mockImplementation((d: any) => {
+        currentDraft = { ...currentDraft, ...d };
+        return Promise.resolve({ ...currentDraft });
+      });
+
+      await service.updateStep('draft-uuid', 'landlord-uuid', 1, {
+        propertyType: 'apartment',
+        address: '42 Lagos Street',
+        bedrooms: 2,
+        bathrooms: 1,
+      });
+      await service.updateStep('draft-uuid', 'landlord-uuid', 2, {
+        monthlyRent: 1200,
+        securityDeposit: 1200,
+        leaseTerm: '1-year',
+        moveInDate: '2027-06-01',
+      });
+      await service.updateStep('draft-uuid', 'landlord-uuid', 3, {});
+      await service.updateStep('draft-uuid', 'landlord-uuid', 5, {
+        photos: [
+          { url: 'u1', order: 0 },
+          { url: 'u2', order: 1 },
+          { url: 'u3', order: 2 },
+        ],
+      });
+      await service.updateStep('draft-uuid', 'landlord-uuid', 6, {
+        propertyDescription: 'A beautiful 2-bedroom apartment in the heart of VI with great amenities.',
+      });
+      await service.updateStep('draft-uuid', 'landlord-uuid', 7, {
+        availableFrom: '2027-06-01',
+      });
+
+      expect(currentDraft.completedSteps).toEqual(expect.arrayContaining([1, 2, 3, 5, 6, 7]));
+
+      // Publish
+      draftRepository.findOne.mockResolvedValue({ ...currentDraft });
+      const result = await service.publish('draft-uuid', 'landlord-uuid');
+
+      expect(result.propertyListingId).toBe('prop-uuid');
+      expect(draftRepository.remove).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/webhooks/webhooks.service.spec.ts
+++ b/backend/src/modules/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,259 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { WebhooksService } from './webhooks.service';
+import { WebhookEndpoint } from './entities/webhook-endpoint.entity';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
+import { WebhookSignatureService } from './webhook-signature.service';
+import { WebhookEvent } from './webhook-event';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+  let endpointRepository: any;
+  let deliveryRepository: any;
+  let configService: any;
+
+  const mockEndpoint = (overrides = {}): WebhookEndpoint =>
+    ({
+      id: 'endpoint-1',
+      url: 'https://example.com/webhook',
+      events: ['payment.received', 'payment.failed'] as WebhookEvent[],
+      secret: 'endpoint-secret',
+      isActive: true,
+      ...overrides,
+    }) as WebhookEndpoint;
+
+  const mockDelivery = (overrides = {}): WebhookDelivery =>
+    ({
+      id: 'delivery-1',
+      endpointId: 'endpoint-1',
+      event: 'payment.received' as WebhookEvent,
+      payload: {},
+      successful: false,
+      attemptCount: 1,
+      ...overrides,
+    }) as WebhookDelivery;
+
+  beforeEach(async () => {
+    endpointRepository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    deliveryRepository = {
+      create: jest.fn().mockImplementation((dto) => ({ ...dto })),
+      save: jest.fn().mockImplementation((d) => Promise.resolve({ ...d, id: 'delivery-1' })),
+    };
+
+    configService = {
+      get: jest.fn().mockReturnValue('global-secret'),
+    };
+
+    mockedAxios.post = jest.fn();
+    mockedAxios.isAxiosError = jest.fn().mockReturnValue(false);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhooksService,
+        WebhookSignatureService,
+        { provide: getRepositoryToken(WebhookEndpoint), useValue: endpointRepository },
+        { provide: getRepositoryToken(WebhookDelivery), useValue: deliveryRepository },
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    service = module.get<WebhooksService>(WebhooksService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── dispatchEvent ──────────────────────────────────────────────────────────
+
+  describe('dispatchEvent', () => {
+    it('delivers to all active endpoints subscribed to the event', async () => {
+      const endpoints = [
+        mockEndpoint({ id: 'ep-1', events: ['payment.received'] }),
+        mockEndpoint({ id: 'ep-2', events: ['payment.received', 'payment.failed'] }),
+        mockEndpoint({ id: 'ep-3', events: ['deposit.received'] }),
+      ];
+      endpointRepository.find.mockResolvedValue(endpoints);
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: 'ok' });
+
+      await service.dispatchEvent('payment.received', { amount: 100 });
+
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips inactive endpoints', async () => {
+      endpointRepository.find.mockResolvedValue([
+        mockEndpoint({ isActive: false, events: ['payment.received'] }),
+      ]);
+
+      await service.dispatchEvent('payment.received', {});
+
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('skips endpoints not subscribed to the event', async () => {
+      endpointRepository.find.mockResolvedValue([
+        mockEndpoint({ events: ['deposit.received'] }),
+      ]);
+
+      await service.dispatchEvent('payment.received', {});
+
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('delivers to zero endpoints without throwing when none match', async () => {
+      endpointRepository.find.mockResolvedValue([]);
+      await expect(service.dispatchEvent('payment.received', {})).resolves.toBeUndefined();
+    });
+
+    it('continues delivery to remaining endpoints even if one fails', async () => {
+      const endpoints = [
+        mockEndpoint({ id: 'ep-1', events: ['payment.received'] }),
+        mockEndpoint({ id: 'ep-2', events: ['payment.received'] }),
+      ];
+      endpointRepository.find.mockResolvedValue(endpoints);
+
+      (mockedAxios.post as jest.Mock)
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce({ status: 200, data: 'ok' });
+
+      await expect(service.dispatchEvent('payment.received', {})).resolves.toBeUndefined();
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── deliverEvent ───────────────────────────────────────────────────────────
+
+  describe('deliverEvent', () => {
+    it('records a successful delivery with correct status and body', async () => {
+      const endpoint = mockEndpoint();
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: 'received' });
+
+      const result = await service.deliverEvent(endpoint, 'payment.received', { amount: 50 });
+
+      expect(result.successful).toBe(true);
+      expect(result.responseStatus).toBe(200);
+      expect(result.responseBody).toBe('received');
+      expect(result.deliveredAt).toBeInstanceOf(Date);
+    });
+
+    it('records delivery as failed when axios throws a network error', async () => {
+      const endpoint = mockEndpoint();
+      const networkError = new Error('Connection refused');
+      (mockedAxios.post as jest.Mock).mockRejectedValue(networkError);
+      mockedAxios.isAxiosError.mockReturnValue(false);
+
+      const result = await service.deliverEvent(endpoint, 'payment.received', {});
+
+      expect(result.successful).toBe(false);
+      expect(result.responseBody).toBe('Connection refused');
+      expect(deliveryRepository.save).toHaveBeenCalled();
+    });
+
+    it('captures HTTP error status from AxiosError', async () => {
+      const endpoint = mockEndpoint();
+      const axiosError = {
+        response: { status: 503, data: 'Service Unavailable' },
+      };
+      (mockedAxios.post as jest.Mock).mockRejectedValue(axiosError);
+      mockedAxios.isAxiosError.mockReturnValue(true);
+
+      const result = await service.deliverEvent(endpoint, 'payment.failed', {});
+
+      expect(result.successful).toBe(false);
+      expect(result.responseStatus).toBe(503);
+    });
+
+    it('stringifies non-string response body', async () => {
+      const endpoint = mockEndpoint();
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: { ok: true } });
+
+      const result = await service.deliverEvent(endpoint, 'payment.received', {});
+
+      expect(result.responseBody).toBe(JSON.stringify({ ok: true }));
+    });
+
+    it('uses endpoint secret over global config secret when present', async () => {
+      const endpoint = mockEndpoint({ secret: 'my-endpoint-secret' });
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: '' });
+
+      await service.deliverEvent(endpoint, 'payment.received', {});
+
+      const callArgs = (mockedAxios.post as jest.Mock).mock.calls[0];
+      const headers = callArgs[2].headers as Record<string, string>;
+      expect(headers['X-Webhook-Signature']).toBeDefined();
+    });
+
+    it('falls back to global config secret when endpoint has no secret', async () => {
+      const endpoint = mockEndpoint({ secret: null });
+      configService.get.mockReturnValue('fallback-secret');
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: '' });
+
+      await service.deliverEvent(endpoint, 'payment.received', {});
+
+      expect(configService.get).toHaveBeenCalledWith('WEBHOOK_SIGNATURE_SECRET');
+    });
+
+    it('includes event, timestamp, and data in the payload', async () => {
+      const endpoint = mockEndpoint();
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: '' });
+
+      await service.deliverEvent(endpoint, 'payment.received', { amount: 99 });
+
+      const rawBody = (mockedAxios.post as jest.Mock).mock.calls[0][1] as string;
+      const parsed = JSON.parse(rawBody);
+      expect(parsed.event).toBe('payment.received');
+      expect(parsed.timestamp).toBeDefined();
+      expect(parsed.data.amount).toBe(99);
+    });
+
+    it('sets attemptCount to 1 on first delivery', async () => {
+      const endpoint = mockEndpoint();
+      (mockedAxios.post as jest.Mock).mockResolvedValue({ status: 200, data: '' });
+
+      await service.deliverEvent(endpoint, 'payment.received', {});
+
+      const created = deliveryRepository.create.mock.calls[0][0];
+      expect(created.attemptCount).toBe(1);
+    });
+
+    it('persists delivery record even on failure', async () => {
+      const endpoint = mockEndpoint();
+      (mockedAxios.post as jest.Mock).mockRejectedValue(new Error('timeout'));
+      mockedAxios.isAxiosError.mockReturnValue(false);
+
+      await service.deliverEvent(endpoint, 'payment.failed', {});
+
+      expect(deliveryRepository.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── findEndpoints ──────────────────────────────────────────────────────────
+
+  describe('findEndpoints', () => {
+    it('returns endpoints matching the given IDs', async () => {
+      const endpoints = [mockEndpoint({ id: 'ep-1' }), mockEndpoint({ id: 'ep-2' })];
+      endpointRepository.find.mockResolvedValue(endpoints);
+
+      const result = await service.findEndpoints(['ep-1', 'ep-2']);
+
+      expect(result).toHaveLength(2);
+      expect(endpointRepository.find).toHaveBeenCalledWith({
+        where: { id: expect.anything() },
+      });
+    });
+
+    it('returns empty array when no IDs match', async () => {
+      endpointRepository.find.mockResolvedValue([]);
+      const result = await service.findEndpoints(['unknown-id']);
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #884
Fixes #902
Fixes #906
Fixes #918

## What changed

### #884 — Webhook Module comprehensive tests (`webhooks.service.spec.ts`)
- `dispatchEvent`: delivers to all matching active endpoints, skips inactive endpoints, skips unsubscribed endpoints, handles empty endpoint list, continues delivering remaining endpoints when one fails
- `deliverEvent`: records successful delivery with status + body, records failure on network error, captures HTTP status from AxiosError, stringifies non-string response bodies, uses endpoint secret over global config, falls back to global config secret, shapes payload with event/timestamp/data, sets attemptCount to 1, persists delivery record even on failure
- `findEndpoints`: returns matching endpoints, returns empty array for no matches

### #902 — Property Wizard integration tests (`property-wizard.integration.spec.ts`)
- `start`: correct landlordId, 30-day expiry, empty completedSteps
- `findDraft`: NotFoundException for missing draft, ForbiddenException for wrong landlord, GoneException for expired draft, returns valid owned draft
- `updateStep`: merges data, no duplicate step entries, rejects step 0 and step 9, returns per-step validation errors, deep-merges without overwriting siblings
- `publish`: succeeds with all required steps + valid data, throws for missing steps, throws for <3 photos, throws for short description, guards against propertiesService.create call on validation failure, does not remove draft when create throws
- `removeDraft`: removes owned draft, throws ForbiddenException for unowned draft
- End-to-end flow: completes all 6 required steps then publishes successfully

### #906 — SQL injection prevention tests (`sql-injection.spec.ts`)
- `SanitizePipe`: passes benign inputs, strips null bytes, sanitises XSS in strings/objects/arrays, passes numbers and booleans unchanged
- `SanitizeValidationPipe`: rejects SQL keyword payloads (SELECT/INSERT/UPDATE/DELETE/DROP/CREATE/ALTER/EXEC/EXECUTE), rejects punctuation injection (--/;/'/`), rejects boolean-based injection (OR/AND 1=1), rejects XSS patterns, rejects nested object and array injection, allows safe inputs through, passes null/undefined unchanged

### #918 — Email Service tests (`email.service.spec.ts`)
- `sendVerificationEmail`: correct recipient, token in body, verification URL, FROM address, throws on failure, retries on transient error
- `sendPasswordResetEmail`: correct recipient, reset token in body, URL from PASSWORD_RESET_URL config, FRONTEND_URL fallback when config absent, 1-hour expiry warning in body, throws on failure
- `sendNotificationEmail`: subject, title/message render, list items (`<li>`), action link with text, throws on failure
- `sendAlertEmail`: recipient + subject, message in body, JSON-serialised details, default message when absent, no `<pre>` block when details absent, throws on failure
- Transporter construction validated against config values

## How to test
```bash
cd backend && pnpm test
```