### PR TITLE
test(database): add missing test setup/teardown

### DIFF
--- a/backend/test/api-key.e2e-spec.ts
+++ b/backend/test/api-key.e2e-spec.ts
@@ -7,7 +7,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { DeveloperModule } from '../src/modules/developer/developer.module';
 import { ApiKey } from '../src/modules/developer/entities/api-key.entity';
 import { ApiKeyRotationHistory } from '../src/modules/developer/entities/api-key-rotation-history.entity';
-import { getTestDatabaseConfig } from './test-helpers';
+import { getTestDatabaseConfig, clearRepositories } from './test-helpers';
 
 describe('API Key E2E Tests', () => {
   let app: INestApplication;
@@ -61,13 +61,16 @@ describe('API Key E2E Tests', () => {
     jwtToken = loginResponse.body?.access_token || 'mock-token';
   });
 
+  beforeEach(async () => {
+    await clearRepositories([apiKeyRepository, rotationHistoryRepository]);
+  });
+
+  afterEach(async () => {
+    await clearRepositories([apiKeyRepository, rotationHistoryRepository]);
+  });
+
   afterAll(async () => {
-    if (apiKeyRepository) {
-      await apiKeyRepository.clear();
-    }
-    if (rotationHistoryRepository) {
-      await rotationHistoryRepository.clear();
-    }
+    await clearRepositories([apiKeyRepository, rotationHistoryRepository]);
     if (app) {
       await app.close();
     }

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -7,7 +7,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthModule } from '../src/modules/auth/auth.module';
 import { UsersModule } from '../src/modules/users/users.module';
 import { User } from '../src/modules/users/entities/user.entity';
-import { getTestDatabaseConfig } from './test-helpers';
+import { getTestDatabaseConfig, clearRepositories } from './test-helpers';
 
 describe.skip('Auth E2E Tests', () => {
   // Skipped: Requires PostgreSQL database (User entity uses enum types not supported by SQLite)
@@ -43,28 +43,18 @@ describe.skip('Auth E2E Tests', () => {
   });
 
   afterAll(async () => {
-    if (userRepository) {
-      await userRepository.clear();
-    }
+    await clearRepositories([userRepository]);
     if (app) {
       await app.close();
     }
   }, 60000);
 
+  beforeEach(async () => {
+    await clearRepositories([userRepository]);
+  }, 60000);
+
   afterEach(async () => {
-    if (userRepository) {
-      const users = await userRepository.find();
-      const testUser = users.find(
-        (u: any) => u.email === 'testuser@example.com',
-      );
-      if (testUser) {
-        await userRepository.remove(
-          users.filter((u: any) => u.email !== 'testuser@example.com'),
-        );
-      } else {
-        await userRepository.clear();
-      }
-    }
+    await clearRepositories([userRepository]);
   }, 60000);
 
   describe('POST /auth/register', () => {

--- a/backend/test/kyc.e2e-spec.ts
+++ b/backend/test/kyc.e2e-spec.ts
@@ -11,13 +11,16 @@ import { Repository } from 'typeorm';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from '../src/app.module';
 import { Kyc } from '../src/modules/kyc/kyc.entity';
+import { User } from '../src/modules/users/entities/user.entity';
 import { KycStatus } from '../src/modules/kyc/kyc-status.enum';
 import { UserRole } from '../src/modules/users/entities/user.entity';
 import { WebhookSignatureService } from '../src/modules/webhooks/webhook-signature.service';
+import { clearRepositories } from './test-helpers';
 
 describe('KYC (e2e)', () => {
   let app: INestApplication;
   let kycRepo: Repository<Kyc>;
+  let userRepo: Repository<User>;
   let webhookSig: WebhookSignatureService;
   let accessToken: string;
   let userId: string;
@@ -65,6 +68,7 @@ describe('KYC (e2e)', () => {
     await app.init();
 
     kycRepo = app.get(getRepositoryToken(Kyc));
+    userRepo = app.get(getRepositoryToken(User));
     webhookSig = app.get(WebhookSignatureService);
 
     const reg = await request(app.getHttpServer())
@@ -82,7 +86,16 @@ describe('KYC (e2e)', () => {
     userId = reg.body.user.id;
   }, 120000);
 
+  beforeEach(async () => {
+    await clearRepositories([kycRepo]);
+  }, 60000);
+
+  afterEach(async () => {
+    await clearRepositories([kycRepo]);
+  }, 60000);
+
   afterAll(async () => {
+    await clearRepositories([kycRepo, userRepo]);
     if (app) {
       await app.close();
     }

--- a/backend/test/rate-limiting.e2e-spec.ts
+++ b/backend/test/rate-limiting.e2e-spec.ts
@@ -28,6 +28,22 @@ describe('Rate Limiting E2E', () => {
     await app.init();
   });
 
+  beforeEach(async () => {
+    if (rateLimitService) {
+      await rateLimitService.reset?.().catch(() => {
+        // Ignore if reset is not available
+      });
+    }
+  });
+
+  afterEach(async () => {
+    if (rateLimitService) {
+      await rateLimitService.reset?.().catch(() => {
+        // Ignore if reset is not available
+      });
+    }
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/backend/test/stellar-auth-simple.e2e-spec.ts
+++ b/backend/test/stellar-auth-simple.e2e-spec.ts
@@ -13,7 +13,7 @@ import {
   Networks,
   Operation,
 } from '@stellar/stellar-sdk';
-import { getTestDatabaseConfig } from './test-helpers';
+import { getTestDatabaseConfig, clearRepositories } from './test-helpers';
 
 describe.skip('Stellar Authentication E2E', () => {
   // Skipped: Requires PostgreSQL database (User entity uses enum types not supported by SQLite)
@@ -57,12 +57,15 @@ describe.skip('Stellar Authentication E2E', () => {
   });
 
   beforeEach(async () => {
-    // Clean up test data before each test
-    await userRepository.delete({ walletAddress: validWalletAddress });
+    await clearRepositories([userRepository]);
+  }, 60000);
+
+  afterEach(async () => {
+    await clearRepositories([userRepository]);
   }, 60000);
 
   afterAll(async () => {
-    await userRepository.delete({ walletAddress: validWalletAddress });
+    await clearRepositories([userRepository]);
     if (app) {
       await app.close();
     }

--- a/backend/test/stellar-auth.e2e-spec.ts
+++ b/backend/test/stellar-auth.e2e-spec.ts
@@ -8,7 +8,7 @@ import { AuthModule } from '../src/modules/auth/auth.module';
 import { UsersModule } from '../src/modules/users/users.module';
 import { User } from '../src/modules/users/entities/user.entity';
 import { Keypair, TransactionBuilder, Networks } from '@stellar/stellar-sdk';
-import { getTestDatabaseConfig } from './test-helpers';
+import { getTestDatabaseConfig, clearRepositories } from './test-helpers';
 
 describe.skip('Stellar Authentication E2E', () => {
   // Skipped: Requires PostgreSQL database (User entity uses enum types not supported by SQLite)
@@ -52,12 +52,15 @@ describe.skip('Stellar Authentication E2E', () => {
   });
 
   beforeEach(async () => {
-    // Clean up test data before each test
-    await userRepository.delete({ walletAddress: validWalletAddress });
+    await clearRepositories([userRepository]);
+  }, 60000);
+
+  afterEach(async () => {
+    await clearRepositories([userRepository]);
   }, 60000);
 
   afterAll(async () => {
-    await userRepository.delete({ walletAddress: validWalletAddress });
+    await clearRepositories([userRepository]);
     if (app) {
       await app.close();
     }

--- a/backend/test/test-helpers.ts
+++ b/backend/test/test-helpers.ts
@@ -1,4 +1,5 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
 
 /**
  * Get TypeORM configuration for e2e tests using SQLite in-memory
@@ -12,4 +13,81 @@ export function getTestDatabaseConfig(entities: any[]): TypeOrmModuleOptions {
     dropSchema: false,
     logging: false,
   };
+}
+
+/**
+ * Clear all tables in a database connection for test cleanup.
+ * Essential for proper test isolation between test cases.
+ */
+export async function clearDatabase(dataSource: DataSource): Promise<void> {
+  if (!dataSource || !dataSource.isInitialized) {
+    return;
+  }
+
+  const queryRunner = dataSource.createQueryRunner();
+
+  try {
+    await queryRunner.connect();
+
+    const tables = dataSource.entityMetadatas.map((e) => e.tableName);
+
+    if (tables.length > 0) {
+      if (dataSource.driver.options.type === 'postgres') {
+        await queryRunner.query(
+          `TRUNCATE TABLE ${tables.map((t) => `"${t}"`).join(', ')} CASCADE`,
+        );
+      } else if (
+        dataSource.driver.options.type === 'mysql' ||
+        dataSource.driver.options.type === 'mariadb'
+      ) {
+        await queryRunner.query('SET FOREIGN_KEY_CHECKS=0');
+        for (const table of tables) {
+          await queryRunner.query(`TRUNCATE TABLE \`${table}\``);
+        }
+        await queryRunner.query('SET FOREIGN_KEY_CHECKS=1');
+      } else if (dataSource.driver.options.type === 'sqlite') {
+        for (const table of tables) {
+          await queryRunner.query(`DELETE FROM "${table}"`);
+        }
+      }
+    }
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+/**
+ * Clear specific repositories for more granular test cleanup
+ */
+export async function clearRepositories(
+  repositories: Repository<any>[],
+): Promise<void> {
+  for (const repo of repositories) {
+    if (repo) {
+      try {
+        await repo.delete({});
+      } catch (e) {
+        // Skip if delete fails (e.g., repo not initialized)
+      }
+    }
+  }
+}
+
+/**
+ * Wrapper to ensure database is clean before and after a test
+ */
+export async function cleanupDatabase(
+  callback: () => Promise<void>,
+  cleanup: () => Promise<void>,
+): Promise<void> {
+  try {
+    await cleanup();
+    await callback();
+    await cleanup();
+  } catch (e) {
+    await cleanup().catch(() => {
+      // Ignore cleanup errors if test already failed
+    });
+    throw e;
+  }
 }


### PR DESCRIPTION
## Summary

Add comprehensive database setup and teardown for all database-dependent e2e tests to ensure proper test isolation and prevent test data leakage.

## Changes

- Create database cleanup utilities in test-helpers with support for multiple database types
- Add beforeEach/afterEach hooks to all e2e tests that interact with databases
- Implement proper test isolation to prevent data pollution between test cases
- Fix incomplete cleanup in existing tests (auth, stellar-auth, kyc)
- Add state reset for rate-limiting service between tests

## Testing

- All test setup/teardown improvements follow Jest best practices
- Tests now properly clean database state between cases
- Support for PostgreSQL, MySQL, and SQLite database cleanup
- All e2e tests verified to have proper isolation hooks

Closes #929
