### PR TITLE
fix: link property preview button to correct details page

### DIFF
--- a/frontend/app/host/listings/page.tsx
+++ b/frontend/app/host/listings/page.tsx
@@ -125,7 +125,7 @@ export default function HostListingsPage() {
                   </div>
                   <div className="flex gap-2">
                     <Link
-                      href={`/stays/${p.id}`}
+                      href={`/properties/${p.id}`}
                       className="flex-1 flex items-center justify-center gap-1 py-2 bg-white/5 border border-white/10 rounded-lg text-sm hover:bg-white/10 transition-colors"
                     >
                       <Eye size={14} /> View


### PR DESCRIPTION
# fix: link property preview button to correct details page

## Summary

The **View** button on the host listings dashboard was navigating to `/stays/:id` (the tenant-facing booking page) instead of `/properties/:id` (the property details page). This made it impossible for hosts to preview their own property details from the dashboard.

## Changes

- `frontend/app/host/listings/page.tsx` — updated the View button `href` from `/stays/${p.id}` to `/properties/${p.id}`

## Steps to Test

1. Log in as a host
2. Navigate to the host dashboard → **My Listings**
3. Click the **View** button on any property card
4. Confirm it navigates to the full property details page at `/properties/:id`

## Related

Closes #788 