### PR TITLE
fix: add backend operational maintenance tasks

### DIFF
--- a/backend/docs/DEPENDENCY_MANAGEMENT.md
+++ b/backend/docs/DEPENDENCY_MANAGEMENT.md
@@ -307,3 +307,18 @@ Actions:
 - Separate security updates from feature work unless the user explicitly wants them bundled.
 - Prefer removal over replacement, and replacement over addition.
 - Re-audit after every major framework upgrade.
+
+## 13. Scheduled Security Patch Checks
+
+The backend registers `SecurityPatchManagementService` in the cleanup module.
+It runs daily at 02:00 and executes the workspace package-manager audit command
+(`pnpm audit --json` for pnpm workspaces, otherwise `npm audit --json`). The
+service classifies findings as:
+
+- `urgent_patch` for high or critical vulnerabilities.
+- `scheduled_patch` for moderate or low vulnerabilities.
+- `none` when no vulnerable packages are reported.
+
+High and critical findings should be patched in a dedicated security update PR.
+Moderate and low findings can be grouped into the next scheduled maintenance
+window unless an advisory is exploitable in Chioma's runtime path.

--- a/backend/docs/database/DATABASE_DOCUMENTATION_GUIDE.md
+++ b/backend/docs/database/DATABASE_DOCUMENTATION_GUIDE.md
@@ -262,3 +262,17 @@ Docker and non-Docker flows, and both plain SQL and gzipped dumps.
 - run `EXPLAIN ANALYZE` for slow queries and compare with documented indexes
 - verify `DB_*` vars and `BACKUP_DIR` permissions when backup or restore fails
 - verify active encryption keys and hashed lookup columns when encrypted field lookups fail
+
+## Scheduled Maintenance
+
+`DatabaseMaintenanceService` runs from the backend cleanup module every day at
+03:00. For PostgreSQL deployments it:
+
+- Reads `pg_stat_user_tables` to identify tables with accumulated dead tuples.
+- Runs `VACUUM (ANALYZE)` so PostgreSQL can reclaim space and refresh planner
+  statistics.
+- Skips maintenance automatically for non-PostgreSQL test databases.
+
+Run the service during low-traffic windows. If dead tuple counts remain high
+after repeated runs, review long-running transactions, autovacuum settings, and
+table-specific write patterns before increasing maintenance frequency.

--- a/backend/src/common/cache/cache-maintenance.service.spec.ts
+++ b/backend/src/common/cache/cache-maintenance.service.spec.ts
@@ -1,0 +1,15 @@
+import { CacheMaintenanceService } from './cache-maintenance.service';
+import { CacheService } from './cache.service';
+
+describe('CacheMaintenanceService', () => {
+  it('runs expired dependency metadata cleanup', async () => {
+    const cacheService = {
+      cleanupExpiredDependencies: jest.fn().mockResolvedValue(2),
+    } as unknown as CacheService;
+    const service = new CacheMaintenanceService(cacheService);
+
+    await service.cleanupExpiredDependencyMetadata();
+
+    expect(cacheService.cleanupExpiredDependencies).toHaveBeenCalled();
+  });
+});

--- a/backend/src/common/cache/cache-maintenance.service.ts
+++ b/backend/src/common/cache/cache-maintenance.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CacheService } from './cache.service';
+
+@Injectable()
+export class CacheMaintenanceService {
+  private readonly logger = new Logger(CacheMaintenanceService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupExpiredDependencyMetadata(): Promise<void> {
+    const cleaned = await this.cacheService.cleanupExpiredDependencies();
+    if (cleaned > 0) {
+      this.logger.log(`Cleaned ${cleaned} expired cache dependency records`);
+    }
+  }
+}

--- a/backend/src/common/cache/cache.module.ts
+++ b/backend/src/common/cache/cache.module.ts
@@ -1,9 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { CacheService } from './cache.service';
+import { CacheMaintenanceService } from './cache-maintenance.service';
 
 @Global()
 @Module({
-  providers: [CacheService],
+  providers: [CacheService, CacheMaintenanceService],
   exports: [CacheService],
 })
 export class AppCacheModule {}

--- a/backend/src/common/cache/cache.service.spec.ts
+++ b/backend/src/common/cache/cache.service.spec.ts
@@ -97,6 +97,40 @@ describe('CacheService', () => {
     });
   });
 
+  describe('invalidateDependencies', () => {
+    it('deletes keys registered for matching dependency tags', async () => {
+      await service.set('property:list:1', { a: 1 }, 5000, ['property:p1']);
+
+      await service.invalidateDependencies(['property:p1']);
+
+      expect(mockDel).toHaveBeenCalledWith('property:list:1');
+      expect(service.getStats().dependencyTrackedKeys).toBe(0);
+    });
+  });
+
+  describe('cleanupExpiredDependencies', () => {
+    it('removes dependency metadata for expired cache entries', async () => {
+      mockCacheManager.get.mockResolvedValue(undefined);
+      await service.set('expired-key', { a: 1 }, 1000, ['property:p2']);
+
+      const cleaned = await service.cleanupExpiredDependencies(Date.now() + 2000);
+
+      expect(cleaned).toBe(1);
+      expect(service.getStats().cleanups).toBe(1);
+      expect(service.getStats().dependencyTrackedKeys).toBe(0);
+    });
+
+    it('keeps dependency metadata when the backing cache still has a value', async () => {
+      mockCacheManager.get.mockResolvedValue({ a: 1 });
+      await service.set('live-key', { a: 1 }, 1000, ['property:p3']);
+
+      const cleaned = await service.cleanupExpiredDependencies(Date.now() + 2000);
+
+      expect(cleaned).toBe(0);
+      expect(service.getStats().dependencyTrackedKeys).toBe(1);
+    });
+  });
+
   describe('invalidatePropertyDomainCaches', () => {
     it('invalidates list, search, suggest, and optional property key', async () => {
       const inv = jest

--- a/backend/src/common/cache/cache.service.ts
+++ b/backend/src/common/cache/cache.service.ts
@@ -20,12 +20,15 @@ export class CacheService {
     misses: 0,
     sets: 0,
     evictions: 0,
+    cleanups: 0,
   };
 
   /** tag -> cache keys that must be cleared when the tag is invalidated */
   private readonly depToKeys = new Map<string, Set<string>>();
   /** cache key -> dependency tags */
   private readonly keyToDeps = new Map<string, string[]>();
+  /** cache key -> epoch milliseconds when local dependency metadata expires */
+  private readonly keyExpiresAt = new Map<string, number>();
 
   private readonly inflight = new Map<string, Promise<unknown>>();
 
@@ -49,6 +52,11 @@ export class CacheService {
   ): Promise<void> {
     if (dependencies?.length) {
       this.registerKeyDependencies(key, dependencies);
+    }
+    if (ttlMs && ttlMs > 0) {
+      this.keyExpiresAt.set(key, Date.now() + ttlMs);
+    } else {
+      this.keyExpiresAt.delete(key);
     }
     await this.cacheManager.set(key, value, ttlMs);
     this.stats.sets++;
@@ -108,6 +116,45 @@ export class CacheService {
   }
 
   /**
+   * Invalidates cache entries registered against one or more dependency tags.
+   */
+  async invalidateDependencies(dependencies: string[]): Promise<void> {
+    const keys = new Set<string>();
+    for (const dependency of dependencies) {
+      for (const key of this.keysFromDependencyTags(dependency)) {
+        keys.add(key);
+      }
+    }
+
+    await Promise.all([...keys].map((key) => this.deleteKey(key)));
+  }
+
+  /**
+   * Removes dependency metadata for keys that expired from the backing cache.
+   * This keeps in-memory invalidation maps bounded without flushing Redis.
+   */
+  async cleanupExpiredDependencies(now = Date.now()): Promise<number> {
+    let cleaned = 0;
+
+    for (const [key, expiresAt] of [...this.keyExpiresAt]) {
+      if (expiresAt > now) {
+        continue;
+      }
+
+      const value = await this.cacheManager.get(key);
+      if (value !== undefined && value !== null) {
+        continue;
+      }
+
+      this.unregisterKey(key);
+      cleaned++;
+    }
+
+    this.stats.cleanups += cleaned;
+    return cleaned;
+  }
+
+  /**
    * Clears all application-namespaced property/search caches (does not flush the entire Redis DB).
    */
   async invalidateAll(): Promise<void> {
@@ -143,6 +190,7 @@ export class CacheService {
       misses: this.stats.misses,
       sets: this.stats.sets,
       evictions: this.stats.evictions,
+      cleanups: this.stats.cleanups,
       hitRate,
       missRate,
       dependencyTrackedKeys: this.keyToDeps.size,
@@ -154,6 +202,7 @@ export class CacheService {
     this.stats.misses = 0;
     this.stats.sets = 0;
     this.stats.evictions = 0;
+    this.stats.cleanups = 0;
   }
 
   private registerKeyDependencies(key: string, dependencies: string[]): void {
@@ -180,6 +229,7 @@ export class CacheService {
       }
     }
     this.keyToDeps.delete(key);
+    this.keyExpiresAt.delete(key);
   }
 
   private keysFromDependencyTags(pattern: string): string[] {

--- a/backend/src/common/cache/cache.types.ts
+++ b/backend/src/common/cache/cache.types.ts
@@ -3,6 +3,7 @@ export interface CacheStats {
   misses: number;
   sets: number;
   evictions: number;
+  cleanups: number;
   hitRate: number;
   missRate: number;
   /** Keys tracked for dependency-based invalidation (approximate) */

--- a/backend/src/common/services/log-maintenance.service.spec.ts
+++ b/backend/src/common/services/log-maintenance.service.spec.ts
@@ -1,0 +1,15 @@
+import { LogMaintenanceService } from './log-maintenance.service';
+import { LoggerService } from './logger.service';
+
+describe('LogMaintenanceService', () => {
+  it('runs old log file cleanup', async () => {
+    const loggerService = {
+      cleanupOldLogFiles: jest.fn().mockResolvedValue(1),
+    } as unknown as LoggerService;
+    const service = new LogMaintenanceService(loggerService);
+
+    await service.cleanupOldLogs();
+
+    expect(loggerService.cleanupOldLogFiles).toHaveBeenCalled();
+  });
+});

--- a/backend/src/common/services/log-maintenance.service.ts
+++ b/backend/src/common/services/log-maintenance.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { LoggerService } from './logger.service';
+
+@Injectable()
+export class LogMaintenanceService {
+  private readonly logger = new Logger(LogMaintenanceService.name);
+
+  constructor(private readonly loggerService: LoggerService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_1AM)
+  async cleanupOldLogs(): Promise<void> {
+    const removed = await this.loggerService.cleanupOldLogFiles();
+    if (removed > 0) {
+      this.logger.log(`Removed ${removed} expired log files`);
+    }
+  }
+}

--- a/backend/src/common/services/logger.module.ts
+++ b/backend/src/common/services/logger.module.ts
@@ -2,6 +2,7 @@ import { Module, Global } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { LoggerService } from './logger.service';
 import { RetryService } from './retry.service';
+import { LogMaintenanceService } from './log-maintenance.service';
 
 /**
  * Global logger module that provides LoggerService and RetryService throughout the application
@@ -9,7 +10,7 @@ import { RetryService } from './retry.service';
 @Global()
 @Module({
   imports: [ConfigModule],
-  providers: [LoggerService, RetryService],
+  providers: [LoggerService, RetryService, LogMaintenanceService],
   exports: [LoggerService, RetryService],
 })
 export class LoggerModule {}

--- a/backend/src/common/services/logger.service.spec.ts
+++ b/backend/src/common/services/logger.service.spec.ts
@@ -1,4 +1,7 @@
 import { LoggerService } from './logger.service';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 describe('LoggerService', () => {
   let service: LoggerService;
@@ -78,5 +81,25 @@ describe('LoggerService', () => {
       'Verbose message',
       expect.any(Object),
     );
+  });
+
+  it('removes log files older than retention', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'chioma-logs-'));
+    const oldLog = path.join(tempDir, 'application-2026-01-01.log');
+    const freshLog = path.join(tempDir, 'application-2026-05-26.log');
+
+    await fs.writeFile(oldLog, 'old');
+    await fs.writeFile(freshLog, 'fresh');
+
+    const oldTime = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+    await fs.utimes(oldLog, oldTime, oldTime);
+
+    const removed = await service.cleanupOldLogFiles(tempDir, 1);
+
+    expect(removed).toBe(1);
+    await expect(fs.access(oldLog)).rejects.toThrow();
+    await expect(fs.access(freshLog)).resolves.toBeUndefined();
+
+    await fs.rm(tempDir, { recursive: true, force: true });
   });
 });

--- a/backend/src/common/services/logger.service.ts
+++ b/backend/src/common/services/logger.service.ts
@@ -6,6 +6,8 @@ import {
 import * as winston from 'winston';
 import * as DailyRotateFile from 'winston-daily-rotate-file';
 import { ConfigService } from '@nestjs/config';
+import { promises as fs } from 'fs';
+import * as path from 'path';
 
 type AnyRecord = Record<string, any>;
 
@@ -39,6 +41,13 @@ function getRedactKeysFromEnv(value: string | undefined): string[] {
     .split(',')
     .map((k) => normalizeKey(k))
     .filter(Boolean);
+}
+
+function parseRetentionDays(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const match = value.trim().match(/^(\d+)(d)?$/i);
+  if (!match) return fallback;
+  return Math.max(1, Number(match[1]));
 }
 
 function createRedactor(options: {
@@ -126,6 +135,20 @@ export class LoggerService implements NestLoggerService {
       this.configService?.get('LOG_FORMAT') ||
       process.env.LOG_FORMAT ||
       (env === 'production' ? 'json' : 'simple');
+    const logDir =
+      this.configService?.get('LOG_DIR') || process.env.LOG_DIR || 'logs';
+    const logMaxSize =
+      this.configService?.get('LOG_MAX_SIZE') ||
+      process.env.LOG_MAX_SIZE ||
+      '20m';
+    const logMaxFiles =
+      this.configService?.get('LOG_MAX_FILES') ||
+      process.env.LOG_MAX_FILES ||
+      '14d';
+    const errorLogMaxFiles =
+      this.configService?.get('LOG_ERROR_MAX_FILES') ||
+      process.env.LOG_ERROR_MAX_FILES ||
+      '30d';
 
     const redactKeys = [
       ...DEFAULT_REDACT_KEYS,
@@ -203,10 +226,10 @@ export class LoggerService implements NestLoggerService {
       // Combined logs with rotation
       transports.push(
         new DailyRotateFile({
-          filename: 'logs/application-%DATE%.log',
+          filename: path.join(logDir, 'application-%DATE%.log'),
           datePattern: 'YYYY-MM-DD',
-          maxSize: '20m',
-          maxFiles: '14d',
+          maxSize: logMaxSize,
+          maxFiles: logMaxFiles,
           level: logLevel,
           format: winston.format.combine(
             winston.format.timestamp(),
@@ -218,10 +241,10 @@ export class LoggerService implements NestLoggerService {
       // Error logs with rotation
       transports.push(
         new DailyRotateFile({
-          filename: 'logs/error-%DATE%.log',
+          filename: path.join(logDir, 'error-%DATE%.log'),
           datePattern: 'YYYY-MM-DD',
-          maxSize: '20m',
-          maxFiles: '30d',
+          maxSize: logMaxSize,
+          maxFiles: errorLogMaxFiles,
           level: 'error',
           format: winston.format.combine(
             winston.format.timestamp(),
@@ -352,5 +375,41 @@ export class LoggerService implements NestLoggerService {
   child(context: string): LoggerService {
     const childLogger = new LoggerService(this.configService, context);
     return childLogger;
+  }
+
+  async cleanupOldLogFiles(
+    logDir =
+      this.configService?.get('LOG_DIR') || process.env.LOG_DIR || 'logs',
+    retentionDays = parseRetentionDays(
+      this.configService?.get('LOG_MAX_FILES') || process.env.LOG_MAX_FILES,
+      14,
+    ),
+  ): Promise<number> {
+    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+    let removed = 0;
+
+    try {
+      const entries = await fs.readdir(logDir, { withFileTypes: true });
+      await Promise.all(
+        entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith('.log'))
+          .map(async (entry) => {
+            const filePath = path.join(logDir, entry.name);
+            const stat = await fs.stat(filePath);
+            if (stat.mtimeMs >= cutoff) {
+              return;
+            }
+
+            await fs.unlink(filePath);
+            removed++;
+          }),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.warn('Log cleanup failed', { error: (error as Error).message });
+      }
+    }
+
+    return removed;
   }
 }

--- a/backend/src/modules/cleanup/cleanup.module.ts
+++ b/backend/src/modules/cleanup/cleanup.module.ts
@@ -8,6 +8,8 @@ import { AutomatedRefactoringService } from './automated-refactoring.service';
 import { DependencyManagementService } from './dependency-management.service';
 import { TempFileCleanupService } from './temp-file-cleanup.service';
 import { DataArchivalService } from './data-archival.service';
+import { SecurityPatchManagementService } from './security-patch-management.service';
+import { DatabaseMaintenanceService } from './database-maintenance.service';
 import { TenantScreeningRequest } from '../screening/entities/tenant-screening-request.entity';
 import { TenantScreeningReport } from '../screening/entities/tenant-screening-report.entity';
 import { TenantScreeningConsent } from '../screening/entities/tenant-screening-consent.entity';
@@ -28,7 +30,13 @@ import { TenantScreeningConsent } from '../screening/entities/tenant-screening-c
     DependencyManagementService,
     TempFileCleanupService,
     DataArchivalService,
+    SecurityPatchManagementService,
+    DatabaseMaintenanceService,
   ],
-  exports: [DataArchivalService],
+  exports: [
+    DataArchivalService,
+    SecurityPatchManagementService,
+    DatabaseMaintenanceService,
+  ],
 })
 export class CleanupModule {}

--- a/backend/src/modules/cleanup/database-maintenance.service.spec.ts
+++ b/backend/src/modules/cleanup/database-maintenance.service.spec.ts
@@ -1,0 +1,34 @@
+import { DataSource } from 'typeorm';
+import { DatabaseMaintenanceService } from './database-maintenance.service';
+
+describe('DatabaseMaintenanceService', () => {
+  it('skips vacuum for non-postgres databases', async () => {
+    const dataSource = {
+      options: { type: 'sqlite' },
+      query: jest.fn(),
+    } as unknown as DataSource;
+    const service = new DatabaseMaintenanceService(dataSource);
+
+    const stats = await service.runMaintenance();
+
+    expect(stats.vacuumAnalyzeRan).toBe(false);
+    expect(dataSource.query).not.toHaveBeenCalled();
+  });
+
+  it('runs vacuum analyze for postgres databases', async () => {
+    const dataSource = {
+      options: { type: 'postgres' },
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ tableName: 'users', deadTuples: '1200' }])
+        .mockResolvedValueOnce(undefined),
+    } as unknown as DataSource;
+    const service = new DatabaseMaintenanceService(dataSource);
+
+    const stats = await service.runMaintenance();
+
+    expect(stats.vacuumAnalyzeRan).toBe(true);
+    expect(stats.tablesNeedingVacuum).toBe(1);
+    expect(dataSource.query).toHaveBeenLastCalledWith('VACUUM (ANALYZE)');
+  });
+});

--- a/backend/src/modules/cleanup/database-maintenance.service.ts
+++ b/backend/src/modules/cleanup/database-maintenance.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DataSource } from 'typeorm';
+
+export interface DatabaseMaintenanceStats {
+  checkedAt: string;
+  databaseType: string;
+  vacuumAnalyzeRan: boolean;
+  tablesNeedingVacuum: number;
+}
+
+@Injectable()
+export class DatabaseMaintenanceService {
+  private readonly logger = new Logger(DatabaseMaintenanceService.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async runScheduledMaintenance(): Promise<void> {
+    const stats = await this.runMaintenance();
+    this.logger.log(
+      `Database maintenance completed: vacuum=${stats.vacuumAnalyzeRan}, tablesNeedingVacuum=${stats.tablesNeedingVacuum}`,
+    );
+  }
+
+  async runMaintenance(): Promise<DatabaseMaintenanceStats> {
+    const databaseType = String(this.dataSource.options.type);
+    const stats: DatabaseMaintenanceStats = {
+      checkedAt: new Date().toISOString(),
+      databaseType,
+      vacuumAnalyzeRan: false,
+      tablesNeedingVacuum: 0,
+    };
+
+    if (databaseType !== 'postgres') {
+      this.logger.debug(`Skipping maintenance for ${databaseType} database`);
+      return stats;
+    }
+
+    const tables = await this.getTablesNeedingVacuum();
+    stats.tablesNeedingVacuum = tables.length;
+
+    await this.dataSource.query('VACUUM (ANALYZE)');
+    stats.vacuumAnalyzeRan = true;
+
+    return stats;
+  }
+
+  async getTablesNeedingVacuum(
+    minimumDeadTuples = 1000,
+  ): Promise<Array<{ tableName: string; deadTuples: number }>> {
+    const databaseType = String(this.dataSource.options.type);
+    if (databaseType !== 'postgres') {
+      return [];
+    }
+
+    const rows = (await this.dataSource.query(
+      `
+        SELECT relname AS "tableName", n_dead_tup AS "deadTuples"
+        FROM pg_stat_user_tables
+        WHERE n_dead_tup >= $1
+        ORDER BY n_dead_tup DESC
+      `,
+      [minimumDeadTuples],
+    )) as Array<{ tableName: string; deadTuples: string | number }>;
+
+    return rows.map((row) => ({
+      tableName: row.tableName,
+      deadTuples: Number(row.deadTuples),
+    }));
+  }
+}

--- a/backend/src/modules/cleanup/security-patch-management.service.spec.ts
+++ b/backend/src/modules/cleanup/security-patch-management.service.spec.ts
@@ -1,0 +1,51 @@
+import { SecurityPatchManagementService } from './security-patch-management.service';
+
+type VulnerabilityCounts = {
+  critical: number;
+  high: number;
+  moderate: number;
+  low: number;
+  info: number;
+  total: number;
+};
+
+describe('SecurityPatchManagementService', () => {
+  it('classifies high severity audit results as urgent patches', () => {
+    const service = new SecurityPatchManagementService();
+    const extract = service as unknown as {
+      extractVulnerabilityCounts(auditJson: unknown): VulnerabilityCounts;
+      getRecommendedAction(vulnerabilities: VulnerabilityCounts): string;
+    };
+
+    const counts = extract.extractVulnerabilityCounts({
+      metadata: {
+        vulnerabilities: {
+          critical: 0,
+          high: 1,
+          moderate: 2,
+          low: 0,
+          info: 0,
+          total: 3,
+        },
+      },
+    });
+
+    expect(counts.high).toBe(1);
+    expect(extract.getRecommendedAction(counts)).toBe('urgent_patch');
+  });
+
+  it('classifies clean audit results as no action', () => {
+    const service = new SecurityPatchManagementService();
+    const extract = service as unknown as {
+      extractVulnerabilityCounts(auditJson: unknown): VulnerabilityCounts;
+      getRecommendedAction(vulnerabilities: VulnerabilityCounts): string;
+    };
+
+    const counts = extract.extractVulnerabilityCounts({
+      metadata: { vulnerabilities: { total: 0 } },
+    });
+
+    expect(counts.total).toBe(0);
+    expect(extract.getRecommendedAction(counts)).toBe('none');
+  });
+});

--- a/backend/src/modules/cleanup/security-patch-management.service.ts
+++ b/backend/src/modules/cleanup/security-patch-management.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { execFile } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface SecurityPatchSummary {
+  packageManager: string;
+  checkedAt: string;
+  vulnerabilities: {
+    critical: number;
+    high: number;
+    moderate: number;
+    low: number;
+    info: number;
+    total: number;
+  };
+  recommendedAction: 'none' | 'scheduled_patch' | 'urgent_patch';
+}
+
+@Injectable()
+export class SecurityPatchManagementService {
+  private readonly logger = new Logger(SecurityPatchManagementService.name);
+
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async runScheduledSecurityPatchCheck(): Promise<void> {
+    const summary = await this.checkForSecurityPatches();
+
+    if (summary.recommendedAction === 'urgent_patch') {
+      this.logger.warn(
+        `Security audit found ${summary.vulnerabilities.high + summary.vulnerabilities.critical} high/critical issue(s)`,
+      );
+      return;
+    }
+
+    if (summary.recommendedAction === 'scheduled_patch') {
+      this.logger.warn(
+        `Security audit found ${summary.vulnerabilities.moderate} moderate issue(s)`,
+      );
+      return;
+    }
+
+    this.logger.log('Security audit completed without vulnerable packages');
+  }
+
+  async checkForSecurityPatches(
+    projectRoot = process.cwd(),
+  ): Promise<SecurityPatchSummary> {
+    const packageManager = this.detectPackageManager(projectRoot);
+    const auditJson = await this.runAudit(packageManager, projectRoot);
+    const vulnerabilities = this.extractVulnerabilityCounts(auditJson);
+
+    return {
+      packageManager,
+      checkedAt: new Date().toISOString(),
+      vulnerabilities,
+      recommendedAction: this.getRecommendedAction(vulnerabilities),
+    };
+  }
+
+  private detectPackageManager(projectRoot: string): string {
+    const packageJsonPath = join(projectRoot, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+        packageManager?: string;
+      };
+
+      if (packageJson.packageManager?.startsWith('pnpm')) {
+        return 'pnpm';
+      }
+    }
+
+    if (existsSync(join(projectRoot, 'pnpm-lock.yaml'))) {
+      return 'pnpm';
+    }
+
+    return 'npm';
+  }
+
+  private async runAudit(
+    packageManager: string,
+    projectRoot: string,
+  ): Promise<unknown> {
+    const command = packageManager === 'pnpm' ? 'pnpm' : 'npm';
+    const args =
+      packageManager === 'pnpm'
+        ? ['audit', '--json']
+        : ['audit', '--json', '--audit-level=low'];
+
+    try {
+      const { stdout } = await execFileAsync(command, args, {
+        cwd: projectRoot,
+        shell: process.platform === 'win32',
+        timeout: 120_000,
+      });
+      return JSON.parse(stdout || '{}');
+    } catch (error) {
+      const auditError = error as { stdout?: string; message?: string };
+      if (auditError.stdout) {
+        return JSON.parse(auditError.stdout);
+      }
+
+      throw new Error(
+        `Security audit failed: ${auditError.message ?? String(error)}`,
+      );
+    }
+  }
+
+  private extractVulnerabilityCounts(auditJson: unknown) {
+    const counts = {
+      critical: 0,
+      high: 0,
+      moderate: 0,
+      low: 0,
+      info: 0,
+      total: 0,
+    };
+
+    const metadata = (auditJson as { metadata?: { vulnerabilities?: unknown } })
+      .metadata?.vulnerabilities;
+
+    if (metadata && typeof metadata === 'object') {
+      for (const severity of Object.keys(counts) as Array<
+        keyof typeof counts
+      >) {
+        const value = (metadata as Record<string, unknown>)[severity];
+        counts[severity] = typeof value === 'number' ? value : 0;
+      }
+      counts.total =
+        counts.total ||
+        counts.critical + counts.high + counts.moderate + counts.low;
+      return counts;
+    }
+
+    const advisories = (auditJson as { advisories?: Record<string, unknown> })
+      .advisories;
+    if (advisories) {
+      for (const advisory of Object.values(advisories)) {
+        const severity = (advisory as { severity?: keyof typeof counts })
+          .severity;
+        if (severity && severity in counts) {
+          counts[severity] += 1;
+          counts.total += 1;
+        }
+      }
+    }
+
+    return counts;
+  }
+
+  private getRecommendedAction(
+    vulnerabilities: SecurityPatchSummary['vulnerabilities'],
+  ): SecurityPatchSummary['recommendedAction'] {
+    if (vulnerabilities.critical > 0 || vulnerabilities.high > 0) {
+      return 'urgent_patch';
+    }
+
+    if (vulnerabilities.moderate > 0 || vulnerabilities.low > 0) {
+      return 'scheduled_patch';
+    }
+
+    return 'none';
+  }
+}


### PR DESCRIPTION
Closes #1027
Closes #1028
Closes #1029
Closes #1030

## Changes
- Added scheduled security patch audit automation that detects the package manager, runs JSON audits, classifies vulnerability severity, and logs urgent/scheduled patch actions.
- Added scheduled PostgreSQL database maintenance that checks dead tuple counts and runs `VACUUM (ANALYZE)` while skipping non-PostgreSQL test databases.
- Added hourly cache dependency metadata cleanup and dependency-based cache invalidation helpers.
- Added configurable backend log rotation cleanup through the existing logger module.
- Documented security patch checks and database maintenance operations.
- Added focused unit tests for security patch classification, database maintenance, cache cleanup, dependency invalidation, log cleanup, and scheduled maintenance services.

## Testing
- `git diff --check`
- `backend/node_modules/.bin/jest.CMD src/modules/cleanup/security-patch-management.service.spec.ts src/modules/cleanup/database-maintenance.service.spec.ts --runInBand --forceExit`
- `backend/node_modules/.bin/tsc.CMD --noEmit`