### PR TITLE
feat(resilience): bulkhead, fallback, graceful degradation & incident tracking

### DIFF
--- a/backend/docs/INCIDENT_RESPONSE.md
+++ b/backend/docs/INCIDENT_RESPONSE.md
@@ -35,6 +35,7 @@ This document defines the end-to-end incident response procedures for the Chioma
 - [Comprehensive Monitoring](./COMPREHENSIVE_MONITORING.md) — metrics, alerting, observability
 - [Disaster Recovery Plan](./deployment/DISASTER_RECOVERY_PLAN.md) — full platform outage and DR scenarios
 - [Error Handling](./ERROR_HANDLING.md) — exception filters, error classification
+- [Resilience Patterns](./RESILIENCE.md) — fallback, bulkhead, graceful degradation, and the `IncidentService`
 - [Security Policies](./security/SECURITY_POLICIES_AND_STANDARDS.md) — breach response, encryption
 - [Backup and Recovery](./deployment/BACKUP_AND_RECOVERY.md) — database restore, file recovery
 
@@ -420,6 +421,35 @@ Track these incident metrics to measure response effectiveness:
 | **MTTR** (Mean Time to Resolve)     | ≤4 hours   | Time from alert to full resolution           |
 | **Incident Rate**                   | Decreasing | Number of SEV1/SEV2 incidents per month      |
 | **Repeat Incident Rate**            | <10%       | Incidents with same root cause               |
+
+### Programmatic Incident Tracking
+
+The backend exposes an in-process `IncidentService`
+(`src/common/resilience/incident.service.ts`) that mirrors the record and
+timeline described above. It is intended for in-process coordination and for
+surfacing current incident status — not as the system of record.
+
+- **Identifiers** follow the documented `INC-YYYY-NNN` format.
+- **Lifecycle** transitions map to the documented statuses (`open` →
+  `investigating` → `mitigating` → `monitoring` → `resolved` / `closed`), and
+  `mitigatedAt` / `resolvedAt` are stamped automatically.
+- **Metrics** (`getMetrics`) compute time-to-detect, time-to-mitigate, and
+  time-to-resolve in line with the MTTM / MTTR targets above.
+- **Degradation linkage**: declaring or resolving an incident recomputes the
+  platform degradation level from the highest open severity (SEV1 → `SEVERE`,
+  SEV2 → `PARTIAL`), so non-essential features are shed for the duration of an
+  active incident. See [Resilience Patterns](./RESILIENCE.md).
+
+```ts
+const incident = incidents.declare({
+  title: 'API 503 errors on /api/v1/properties',
+  severity: IncidentSeverity.SEV2,
+  affectedServices: ['API', 'Property Search'],
+});
+incidents.addEvent(incident.id, 'Rollback initiated to v2.4.0');
+incidents.mitigate(incident.id, 'Rollback complete');
+incidents.resolve(incident.id, 'Error rate <0.1% for 15 minutes');
+```
 
 ---
 

--- a/backend/docs/RESILIENCE.md
+++ b/backend/docs/RESILIENCE.md
@@ -1,0 +1,116 @@
+# Resilience Patterns
+
+The backend ships a small set of resilience primitives under
+`src/common/resilience` (the global `ResilienceModule`). They keep the platform
+responsive when a downstream dependency slows down or fails, and they make
+"production readiness" behaviours testable and reusable across feature modules.
+
+| Pattern              | Service                | Purpose                                                       |
+| -------------------- | ---------------------- | ------------------------------------------------------------- |
+| Bulkhead isolation   | `BulkheadService`      | Cap concurrency per dependency so one can't starve the others |
+| Fallback             | `FallbackService`      | Serve a substitute result when the primary call fails         |
+| Graceful degradation | `DegradationService`   | Shed non-essential features as health worsens                 |
+| Incident tracking    | `IncidentService`      | Track incidents and drive degradation (see INCIDENT_RESPONSE) |
+
+All four are provided by a `@Global()` module, so any feature module can inject
+them directly without re-importing.
+
+```ts
+constructor(
+  private readonly bulkhead: BulkheadService,
+  private readonly fallback: FallbackService,
+  private readonly degradation: DegradationService,
+) {}
+```
+
+---
+
+## Bulkhead isolation (`BulkheadService`)
+
+Each named **compartment** has its own concurrency pool (`maxConcurrent`) and a
+bounded waiting queue (`maxQueue`). A misbehaving dependency can only exhaust
+its own compartment, leaving the rest of the system unaffected. When both the
+active slots and the queue are full, further calls are rejected immediately
+with `BulkheadCapacityExceededError` (HTTP 503) instead of piling up.
+
+```ts
+// Configure once (optional — defaults are 10 concurrent / 20 queued).
+this.bulkhead.configure('kyc-provider', { maxConcurrent: 5, maxQueue: 10 });
+
+// Run isolated work.
+const result = await this.bulkhead.execute('kyc-provider', () =>
+  this.kycClient.verify(payload),
+);
+
+// Observe saturation for dashboards / alerts.
+this.bulkhead.getMetrics('kyc-provider'); // { active, queued, totalRejected, ... }
+```
+
+## Fallback (`FallbackService`)
+
+Wrap a primary operation so a failure yields a sensible substitute — a cached
+value, a cheaper source, or a static default — keeping user flows working in a
+reduced form. Pair it with the existing `RetryService`: retry transient
+failures first, then fall back only once retries are exhausted.
+
+```ts
+const rate = await this.fallback.execute(() => this.fx.getLiveRate('USD'), {
+  context: 'fx-rate',
+  fallbackFn: () => this.cache.getLastKnownRate('USD'),
+  // Only fall back on transient/service errors, not on programmer errors.
+  shouldFallback: (err) => err instanceof NetworkError,
+});
+```
+
+On failure the service uses `fallbackFn(error)` if present, otherwise
+`fallbackValue`; if neither is configured the original error is rethrown.
+
+## Graceful degradation (`DegradationService`)
+
+Holds an overall `DegradationLevel` (`NORMAL` → `PARTIAL` → `SEVERE`) and a
+registry of features tagged by `FeaturePriority`:
+
+| Level     | Enabled features                  |
+| --------- | --------------------------------- |
+| `NORMAL`  | essential + standard + optional   |
+| `PARTIAL` | essential + standard              |
+| `SEVERE`  | essential only                    |
+
+```ts
+// At startup, declare what's optional.
+this.degradation.registerFeature('payments', FeaturePriority.ESSENTIAL);
+this.degradation.registerFeature('recommendations', FeaturePriority.OPTIONAL);
+
+// Guard optional work.
+if (this.degradation.isFeatureEnabled('recommendations')) {
+  await this.recommend(user);
+}
+// …or assert and let the global exception filter map it to 503:
+this.degradation.assertFeatureEnabled('recommendations');
+```
+
+The level is normally driven automatically by `IncidentService` (a SEV1
+incident forces `SEVERE`, a SEV2 forces `PARTIAL`), but it can also be set
+manually for planned maintenance or load-shedding.
+
+## Incident tracking (`IncidentService`)
+
+Operationalises [`INCIDENT_RESPONSE.md`](./INCIDENT_RESPONSE.md): declare
+incidents (`INC-YYYY-NNN`), maintain a timeline, transition through the
+documented lifecycle, and compute MTTM/MTTR. Declaring/resolving an incident
+recomputes the degradation level from the highest open severity. See the
+incident-response runbook for the full procedures.
+
+---
+
+## Testing
+
+Every service has a unit spec colocated in `src/common/resilience/*.spec.ts`.
+They instantiate the service directly (no Nest `TestingModule` needed) and run
+under the standard backend test command:
+
+```bash
+cd backend
+pnpm run test            # all unit tests
+pnpm exec jest common/resilience   # just the resilience suite
+```

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -56,6 +56,7 @@ import { InquiriesModule } from './modules/inquiries/inquiries.module';
 import { AnalyticsModule } from './modules/analytics/analytics.module';
 import { LockModule } from './common/lock';
 import { IdempotencyModule } from './common/idempotency';
+import { ResilienceModule } from './common/resilience';
 import { FraudModule } from './modules/fraud/fraud.module';
 import { TransactionModule } from './modules/transactions/transaction.module';
 
@@ -70,6 +71,7 @@ const appLogger = new Logger('AppModule');
     LoggerModule,
     LockModule,
     IdempotencyModule,
+    ResilienceModule,
     require('./common/services/encryption.module').EncryptionModule,
     process.env.NODE_ENV === 'test'
       ? CacheModule.register({

--- a/backend/src/common/errors/error-codes.ts
+++ b/backend/src/common/errors/error-codes.ts
@@ -90,6 +90,11 @@ export enum ErrorCode {
   CONFIGURATION_ERROR = 'SYS_11004',
   MAINTENANCE_MODE = 'SYS_11005',
 
+  // Resilience & Degradation (12xxx)
+  BULKHEAD_CAPACITY_EXCEEDED = 'RESIL_12001',
+  SERVICE_DEGRADED = 'RESIL_12002',
+  FEATURE_DISABLED = 'RESIL_12003',
+
   // Unknown
   UNKNOWN_ERROR = 'UNKNOWN',
 }
@@ -194,6 +199,13 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.NOT_IMPLEMENTED]: 'This feature is not yet implemented',
   [ErrorCode.CONFIGURATION_ERROR]: 'System configuration error',
   [ErrorCode.MAINTENANCE_MODE]: 'System is under maintenance',
+
+  // Resilience & Degradation
+  [ErrorCode.BULKHEAD_CAPACITY_EXCEEDED]:
+    'Service is at capacity. Please try again shortly',
+  [ErrorCode.SERVICE_DEGRADED]: 'Service is currently running in a degraded state',
+  [ErrorCode.FEATURE_DISABLED]:
+    'This feature is temporarily unavailable due to degraded service',
 
   // Unknown
   [ErrorCode.UNKNOWN_ERROR]: 'An unknown error occurred',

--- a/backend/src/common/resilience/bulkhead.service.spec.ts
+++ b/backend/src/common/resilience/bulkhead.service.spec.ts
@@ -1,0 +1,155 @@
+import { BulkheadService } from './bulkhead.service';
+import { BulkheadCapacityExceededError } from './resilience.errors';
+
+/** Creates a promise plus its resolver so a test can hold a call "in flight". */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('BulkheadService', () => {
+  let service: BulkheadService;
+
+  beforeEach(() => {
+    service = new BulkheadService();
+  });
+
+  describe('execute', () => {
+    it('runs a call immediately when a slot is free', async () => {
+      service.configure('svc', { maxConcurrent: 2, maxQueue: 2 });
+      const result = await service.execute('svc', async () => 'ok');
+      expect(result).toBe('ok');
+
+      const metrics = service.getMetrics('svc');
+      expect(metrics?.active).toBe(0);
+      expect(metrics?.totalExecuted).toBe(1);
+    });
+
+    it('limits concurrency to maxConcurrent', async () => {
+      service.configure('svc', { maxConcurrent: 2, maxQueue: 5 });
+
+      const d1 = deferred<string>();
+      const d2 = deferred<string>();
+      const d3 = deferred<string>();
+
+      const p1 = service.execute('svc', () => d1.promise);
+      const p2 = service.execute('svc', () => d2.promise);
+      const p3 = service.execute('svc', () => d3.promise);
+
+      // Let the synchronous scheduling settle.
+      await Promise.resolve();
+
+      const metrics = service.getMetrics('svc');
+      expect(metrics?.active).toBe(2);
+      expect(metrics?.queued).toBe(1);
+
+      // Free a slot; the queued call should now run.
+      d1.resolve('a');
+      await p1;
+      await Promise.resolve();
+      expect(service.getMetrics('svc')?.active).toBe(2);
+      expect(service.getMetrics('svc')?.queued).toBe(0);
+
+      d2.resolve('b');
+      d3.resolve('c');
+      await Promise.all([p2, p3]);
+      expect(service.getMetrics('svc')?.active).toBe(0);
+    });
+
+    it('rejects with BulkheadCapacityExceededError when active and queue are full', async () => {
+      service.configure('svc', { maxConcurrent: 1, maxQueue: 1 });
+
+      const d1 = deferred<string>();
+      const d2 = deferred<string>();
+
+      const p1 = service.execute('svc', () => d1.promise); // active
+      const p2 = service.execute('svc', () => d2.promise); // queued
+      await Promise.resolve();
+
+      await expect(
+        service.execute('svc', async () => 'overflow'),
+      ).rejects.toBeInstanceOf(BulkheadCapacityExceededError);
+
+      expect(service.getMetrics('svc')?.totalRejected).toBe(1);
+
+      // Drain in-flight calls so the test ends cleanly.
+      d1.resolve('a');
+      await p1;
+      d2.resolve('b');
+      await p2;
+    });
+
+    it('releases a slot even when the call throws', async () => {
+      service.configure('svc', { maxConcurrent: 1, maxQueue: 0 });
+
+      await expect(
+        service.execute('svc', async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      const metrics = service.getMetrics('svc');
+      expect(metrics?.active).toBe(0);
+      expect(metrics?.totalExecuted).toBe(1);
+    });
+
+    it('lazily creates an unconfigured compartment with defaults', async () => {
+      const result = await service.execute('lazy', async () => 42);
+      expect(result).toBe(42);
+
+      const metrics = service.getMetrics('lazy');
+      expect(metrics?.maxConcurrent).toBe(10);
+      expect(metrics?.maxQueue).toBe(20);
+    });
+
+    it('isolates compartments from each other', async () => {
+      service.configure('a', { maxConcurrent: 1, maxQueue: 0 });
+      service.configure('b', { maxConcurrent: 1, maxQueue: 0 });
+
+      const dA = deferred<string>();
+      const pA = service.execute('a', () => dA.promise); // saturates "a"
+      await Promise.resolve();
+
+      // "b" still has a free slot despite "a" being full.
+      await expect(service.execute('b', async () => 'b-ok')).resolves.toBe(
+        'b-ok',
+      );
+
+      dA.resolve('a-ok');
+      await pA;
+    });
+  });
+
+  describe('configure', () => {
+    it('rejects invalid concurrency limits', () => {
+      expect(() => service.configure('svc', { maxConcurrent: 0 })).toThrow();
+      expect(() => service.configure('svc', { maxQueue: -1 })).toThrow();
+    });
+
+    it('updates limits for an existing compartment', () => {
+      service.configure('svc', { maxConcurrent: 2, maxQueue: 2 });
+      service.configure('svc', { maxConcurrent: 5, maxQueue: 1 });
+      const metrics = service.getMetrics('svc');
+      expect(metrics?.maxConcurrent).toBe(5);
+      expect(metrics?.maxQueue).toBe(1);
+    });
+  });
+
+  describe('metrics', () => {
+    it('returns undefined for an unknown compartment', () => {
+      expect(service.getMetrics('nope')).toBeUndefined();
+    });
+
+    it('reports metrics for all compartments', async () => {
+      await service.execute('a', async () => 1);
+      await service.execute('b', async () => 2);
+      const all = service.getAllMetrics();
+      expect(all.map((m) => m.name).sort()).toEqual(['a', 'b']);
+    });
+  });
+});

--- a/backend/src/common/resilience/bulkhead.service.ts
+++ b/backend/src/common/resilience/bulkhead.service.ts
@@ -1,0 +1,151 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  BulkheadMetrics,
+  BulkheadOptions,
+  DEFAULT_BULKHEAD_OPTIONS,
+} from './resilience.types';
+import { BulkheadCapacityExceededError } from './resilience.errors';
+
+interface Waiter {
+  resolve: () => void;
+}
+
+interface Compartment {
+  options: BulkheadOptions;
+  active: number;
+  queue: Waiter[];
+  totalExecuted: number;
+  totalRejected: number;
+}
+
+/**
+ * Bulkhead pattern for service isolation.
+ *
+ * Each named "compartment" gets an isolated pool of concurrency. A slow or
+ * failing dependency can only saturate its own compartment, so it cannot
+ * exhaust the resources other parts of the system depend on. When a
+ * compartment is fully busy and its waiting queue is full, further calls are
+ * rejected immediately with {@link BulkheadCapacityExceededError} rather than
+ * piling up unbounded work.
+ */
+@Injectable()
+export class BulkheadService {
+  private readonly logger = new Logger(BulkheadService.name);
+  private readonly compartments = new Map<string, Compartment>();
+
+  /**
+   * Define (or redefine) the limits for a compartment. Calling this is
+   * optional — an unconfigured compartment is created lazily with
+   * {@link DEFAULT_BULKHEAD_OPTIONS}.
+   */
+  configure(name: string, options: Partial<BulkheadOptions> = {}): void {
+    const merged: BulkheadOptions = { ...DEFAULT_BULKHEAD_OPTIONS, ...options };
+    if (merged.maxConcurrent < 1) {
+      throw new Error('Bulkhead maxConcurrent must be at least 1');
+    }
+    if (merged.maxQueue < 0) {
+      throw new Error('Bulkhead maxQueue cannot be negative');
+    }
+
+    const existing = this.compartments.get(name);
+    if (existing) {
+      existing.options = merged;
+    } else {
+      this.compartments.set(name, {
+        options: merged,
+        active: 0,
+        queue: [],
+        totalExecuted: 0,
+        totalRejected: 0,
+      });
+    }
+  }
+
+  /**
+   * Run `fn` inside the named compartment, respecting its concurrency limit.
+   *
+   * - If a slot is free, the call runs immediately.
+   * - If the compartment is full but the queue has room, the call waits for a
+   *   slot to free up.
+   * - If both the active slots and the queue are full, the call is rejected
+   *   with {@link BulkheadCapacityExceededError}.
+   */
+  async execute<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const compartment = this.getOrCreate(name);
+
+    // The capacity check and the synchronous `active++` below run without an
+    // intervening await, so they are atomic with respect to other callers.
+    if (compartment.active >= compartment.options.maxConcurrent) {
+      if (compartment.queue.length >= compartment.options.maxQueue) {
+        compartment.totalRejected++;
+        this.logger.warn(
+          `[${name}] Bulkhead rejected: ${compartment.active} active, ${compartment.queue.length} queued`,
+        );
+        throw new BulkheadCapacityExceededError(
+          name,
+          compartment.options.maxConcurrent,
+          compartment.options.maxQueue,
+        );
+      }
+
+      await new Promise<void>((resolve) => {
+        compartment.queue.push({ resolve });
+      });
+    }
+
+    compartment.active++;
+    try {
+      return await fn();
+    } finally {
+      compartment.active--;
+      compartment.totalExecuted++;
+      const next = compartment.queue.shift();
+      if (next) {
+        next.resolve();
+      }
+    }
+  }
+
+  /** Returns a snapshot of the named compartment, or `undefined` if unknown. */
+  getMetrics(name: string): BulkheadMetrics | undefined {
+    const compartment = this.compartments.get(name);
+    if (!compartment) {
+      return undefined;
+    }
+    return this.toMetrics(name, compartment);
+  }
+
+  /** Returns a snapshot of every known compartment. */
+  getAllMetrics(): BulkheadMetrics[] {
+    return Array.from(this.compartments.entries()).map(([name, compartment]) =>
+      this.toMetrics(name, compartment),
+    );
+  }
+
+  private getOrCreate(name: string): Compartment {
+    let compartment = this.compartments.get(name);
+    if (!compartment) {
+      compartment = {
+        options: { ...DEFAULT_BULKHEAD_OPTIONS },
+        active: 0,
+        queue: [],
+        totalExecuted: 0,
+        totalRejected: 0,
+      };
+      this.compartments.set(name, compartment);
+    }
+    return compartment;
+  }
+
+  private toMetrics(name: string, compartment: Compartment): BulkheadMetrics {
+    return {
+      name,
+      active: compartment.active,
+      queued: compartment.queue.length,
+      maxConcurrent: compartment.options.maxConcurrent,
+      maxQueue: compartment.options.maxQueue,
+      totalExecuted: compartment.totalExecuted,
+      totalRejected: compartment.totalRejected,
+    };
+  }
+}

--- a/backend/src/common/resilience/degradation.service.spec.ts
+++ b/backend/src/common/resilience/degradation.service.spec.ts
@@ -1,0 +1,92 @@
+import { DegradationService } from './degradation.service';
+import { DegradationLevel, FeaturePriority } from './resilience.types';
+import { FeatureDisabledError } from './resilience.errors';
+
+describe('DegradationService', () => {
+  let service: DegradationService;
+
+  beforeEach(() => {
+    service = new DegradationService();
+  });
+
+  it('starts in the NORMAL level', () => {
+    expect(service.getLevel()).toBe(DegradationLevel.NORMAL);
+    expect(service.isDegraded()).toBe(false);
+  });
+
+  describe('feature gating', () => {
+    beforeEach(() => {
+      service.registerFeature('payments', FeaturePriority.ESSENTIAL);
+      service.registerFeature('search', FeaturePriority.STANDARD);
+      service.registerFeature('recommendations', FeaturePriority.OPTIONAL);
+    });
+
+    it('enables every feature when NORMAL', () => {
+      expect(service.isFeatureEnabled('payments')).toBe(true);
+      expect(service.isFeatureEnabled('search')).toBe(true);
+      expect(service.isFeatureEnabled('recommendations')).toBe(true);
+    });
+
+    it('sheds only OPTIONAL features when PARTIAL', () => {
+      service.setLevel(DegradationLevel.PARTIAL, 'high latency');
+      expect(service.isFeatureEnabled('payments')).toBe(true);
+      expect(service.isFeatureEnabled('search')).toBe(true);
+      expect(service.isFeatureEnabled('recommendations')).toBe(false);
+    });
+
+    it('keeps only ESSENTIAL features when SEVERE', () => {
+      service.setLevel(DegradationLevel.SEVERE, 'db outage');
+      expect(service.isFeatureEnabled('payments')).toBe(true);
+      expect(service.isFeatureEnabled('search')).toBe(false);
+      expect(service.isFeatureEnabled('recommendations')).toBe(false);
+    });
+
+    it('treats unregistered features as STANDARD priority', () => {
+      expect(service.isFeatureEnabled('unknown')).toBe(true);
+      service.setLevel(DegradationLevel.SEVERE);
+      expect(service.isFeatureEnabled('unknown')).toBe(false);
+    });
+
+    it('assertFeatureEnabled throws FeatureDisabledError when shed', () => {
+      service.setLevel(DegradationLevel.PARTIAL);
+      expect(() => service.assertFeatureEnabled('payments')).not.toThrow();
+      expect(() => service.assertFeatureEnabled('recommendations')).toThrow(
+        FeatureDisabledError,
+      );
+    });
+  });
+
+  describe('setLevel', () => {
+    it('updates the level, reason, and since timestamp on change', () => {
+      const before = service.getStatus().since;
+      service.setLevel(DegradationLevel.PARTIAL, 'queue backlog');
+
+      const status = service.getStatus();
+      expect(status.level).toBe(DegradationLevel.PARTIAL);
+      expect(status.reason).toBe('queue backlog');
+      expect(status.since.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+
+    it('is a no-op when the level is unchanged', () => {
+      service.setLevel(DegradationLevel.PARTIAL, 'first');
+      const since = service.getStatus().since;
+      service.setLevel(DegradationLevel.PARTIAL, 'second');
+      // since must not be reset when the level does not actually change
+      expect(service.getStatus().since).toBe(since);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('reports each registered feature with its computed enabled flag', () => {
+      service.registerFeature('payments', FeaturePriority.ESSENTIAL);
+      service.registerFeature('recommendations', FeaturePriority.OPTIONAL);
+      service.setLevel(DegradationLevel.PARTIAL);
+
+      const status = service.getStatus();
+      const byName = Object.fromEntries(
+        status.features.map((f) => [f.name, f.enabled]),
+      );
+      expect(byName).toEqual({ payments: true, recommendations: false });
+    });
+  });
+});

--- a/backend/src/common/resilience/degradation.service.ts
+++ b/backend/src/common/resilience/degradation.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  DegradationLevel,
+  DegradationStatus,
+  FeaturePriority,
+  FeatureStatus,
+} from './resilience.types';
+import { FeatureDisabledError } from './resilience.errors';
+
+/** Higher rank = more important; never shed before lower ranks. */
+const PRIORITY_RANK: Record<FeaturePriority, number> = {
+  [FeaturePriority.OPTIONAL]: 1,
+  [FeaturePriority.STANDARD]: 2,
+  [FeaturePriority.ESSENTIAL]: 3,
+};
+
+/**
+ * Minimum priority rank that stays enabled at each degradation level.
+ * NORMAL keeps everything; PARTIAL sheds OPTIONAL; SEVERE keeps only ESSENTIAL.
+ */
+const LEVEL_THRESHOLD: Record<DegradationLevel, number> = {
+  [DegradationLevel.NORMAL]: PRIORITY_RANK[FeaturePriority.OPTIONAL],
+  [DegradationLevel.PARTIAL]: PRIORITY_RANK[FeaturePriority.STANDARD],
+  [DegradationLevel.SEVERE]: PRIORITY_RANK[FeaturePriority.ESSENTIAL],
+};
+
+/**
+ * Graceful degradation strategies.
+ *
+ * Tracks an overall degradation level and a registry of features tagged by
+ * priority. As the level rises, lower-priority features are automatically
+ * shed so that scarce capacity is reserved for the essential ones (auth,
+ * payments, core reads). Call sites guard optional work with
+ * {@link isFeatureEnabled} or {@link assertFeatureEnabled}.
+ */
+@Injectable()
+export class DegradationService {
+  private readonly logger = new Logger(DegradationService.name);
+
+  private level: DegradationLevel = DegradationLevel.NORMAL;
+  private reason?: string;
+  private since = new Date();
+
+  /** feature name -> priority */
+  private readonly features = new Map<string, FeaturePriority>();
+
+  /**
+   * Register a feature so it can be gated by degradation level. Unregistered
+   * features are treated as {@link FeaturePriority.STANDARD} when queried.
+   */
+  registerFeature(
+    name: string,
+    priority: FeaturePriority = FeaturePriority.STANDARD,
+  ): void {
+    this.features.set(name, priority);
+  }
+
+  /** Set the current degradation level. No-op if the level is unchanged. */
+  setLevel(level: DegradationLevel, reason?: string): void {
+    if (level === this.level) {
+      this.reason = reason ?? this.reason;
+      return;
+    }
+
+    const previous = this.level;
+    this.level = level;
+    this.reason = reason;
+    this.since = new Date();
+
+    const message = `Degradation level changed: ${previous} -> ${level}${
+      reason ? ` (${reason})` : ''
+    }`;
+    if (level === DegradationLevel.NORMAL) {
+      this.logger.log(message);
+    } else {
+      this.logger.warn(message);
+    }
+  }
+
+  getLevel(): DegradationLevel {
+    return this.level;
+  }
+
+  /** Whether the system is in any non-normal state. */
+  isDegraded(): boolean {
+    return this.level !== DegradationLevel.NORMAL;
+  }
+
+  /**
+   * Whether a feature should currently run. A feature is enabled when its
+   * priority rank meets or exceeds the threshold for the current level.
+   */
+  isFeatureEnabled(name: string): boolean {
+    const priority = this.features.get(name) ?? FeaturePriority.STANDARD;
+    return PRIORITY_RANK[priority] >= LEVEL_THRESHOLD[this.level];
+  }
+
+  /**
+   * Throws {@link FeatureDisabledError} when the feature is currently shed.
+   * Useful as a guard at the top of an optional code path.
+   */
+  assertFeatureEnabled(name: string): void {
+    if (!this.isFeatureEnabled(name)) {
+      throw new FeatureDisabledError(name, this.level);
+    }
+  }
+
+  /** Full status snapshot for health endpoints / dashboards. */
+  getStatus(): DegradationStatus {
+    const features: FeatureStatus[] = Array.from(this.features.entries()).map(
+      ([name, priority]) => ({
+        name,
+        priority,
+        enabled: this.isFeatureEnabled(name),
+      }),
+    );
+
+    return {
+      level: this.level,
+      reason: this.reason,
+      since: this.since,
+      features,
+    };
+  }
+}

--- a/backend/src/common/resilience/fallback.service.spec.ts
+++ b/backend/src/common/resilience/fallback.service.spec.ts
@@ -1,0 +1,122 @@
+import { FallbackService } from './fallback.service';
+
+describe('FallbackService', () => {
+  let service: FallbackService;
+
+  beforeEach(() => {
+    service = new FallbackService();
+    service.resetStats();
+  });
+
+  describe('execute', () => {
+    it('returns the primary result when it succeeds', async () => {
+      const primary = jest.fn().mockResolvedValue('live');
+      const result = await service.execute(primary, {
+        fallbackValue: 'cached',
+      });
+      expect(result).toBe('live');
+      expect(service.getStats().totalFallbacks).toBe(0);
+    });
+
+    it('returns the static fallback value when the primary fails', async () => {
+      const primary = jest.fn().mockRejectedValue(new Error('down'));
+      const result = await service.execute(primary, {
+        fallbackValue: 'cached',
+      });
+      expect(result).toBe('cached');
+      expect(service.getStats().totalFallbacks).toBe(1);
+    });
+
+    it('invokes the fallback function with the original error', async () => {
+      const error = new Error('boom');
+      const primary = jest.fn().mockRejectedValue(error);
+      const fallbackFn = jest.fn().mockResolvedValue('computed');
+
+      const result = await service.execute(primary, { fallbackFn });
+      expect(result).toBe('computed');
+      expect(fallbackFn).toHaveBeenCalledWith(error);
+    });
+
+    it('prefers fallbackFn over fallbackValue when both are present', async () => {
+      const primary = jest.fn().mockRejectedValue(new Error('x'));
+      const result = await service.execute(primary, {
+        fallbackFn: () => 'fn',
+        fallbackValue: 'value',
+      });
+      expect(result).toBe('fn');
+    });
+
+    it('rethrows the original error when shouldFallback returns false', async () => {
+      const primary = jest.fn().mockRejectedValue(new Error('fatal'));
+      await expect(
+        service.execute(primary, {
+          fallbackValue: 'cached',
+          shouldFallback: () => false,
+        }),
+      ).rejects.toThrow('fatal');
+      expect(service.getStats().totalFallbacks).toBe(0);
+    });
+
+    it('rethrows when no fallback is configured', async () => {
+      const primary = jest.fn().mockRejectedValue(new Error('nope'));
+      await expect(service.execute(primary, {})).rejects.toThrow('nope');
+    });
+
+    it('treats an explicit undefined fallbackValue as a valid fallback', async () => {
+      const primary = jest.fn().mockRejectedValue(new Error('down'));
+      const result = await service.execute<string | undefined>(primary, {
+        fallbackValue: undefined,
+      });
+      expect(result).toBeUndefined();
+      expect(service.getStats().totalFallbacks).toBe(1);
+    });
+
+    it('propagates errors thrown by the fallback function', async () => {
+      const primary = jest.fn().mockRejectedValue(new Error('primary'));
+      const fallbackFn = jest.fn().mockRejectedValue(new Error('fallback-too'));
+      await expect(service.execute(primary, { fallbackFn })).rejects.toThrow(
+        'fallback-too',
+      );
+    });
+
+    it('calls onFallback when the fallback path is taken', async () => {
+      const onFallback = jest.fn();
+      const primary = jest.fn().mockRejectedValue(new Error('down'));
+      await service.execute(primary, { fallbackValue: 'cached', onFallback });
+      expect(onFallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('wrap', () => {
+    it('produces a fallback-protected function', async () => {
+      const flaky = jest.fn().mockImplementation(async (n: number) => {
+        if (n < 0) throw new Error('negative');
+        return n * 2;
+      });
+      const safe = service.wrap(flaky, { fallbackValue: -1 });
+
+      await expect(safe(5)).resolves.toBe(10);
+      await expect(safe(-5)).resolves.toBe(-1);
+    });
+  });
+
+  describe('stats', () => {
+    it('tracks call and fallback counts and resets them', async () => {
+      await service.execute(jest.fn().mockResolvedValue('ok'), {
+        fallbackValue: 'x',
+      });
+      await service.execute(jest.fn().mockRejectedValue(new Error('e')), {
+        fallbackValue: 'x',
+      });
+
+      let stats = service.getStats();
+      expect(stats.totalCalls).toBe(2);
+      expect(stats.totalFallbacks).toBe(1);
+
+      service.resetStats();
+      stats = service.getStats();
+      expect(stats.totalCalls).toBe(0);
+      expect(stats.totalFallbacks).toBe(0);
+    });
+  });
+});

--- a/backend/src/common/resilience/fallback.service.ts
+++ b/backend/src/common/resilience/fallback.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { FallbackOptions, FallbackStats } from './resilience.types';
+
+/**
+ * Fallback mechanisms for degraded services.
+ *
+ * Wraps a primary operation so that, when it fails, the caller receives a
+ * sensible substitute instead of an error — a cached/last-known value, a
+ * cheaper alternative source, or a static default. This keeps user-facing
+ * flows working (in a reduced form) when a downstream dependency is degraded.
+ *
+ * Pairs naturally with {@link RetryService}: retry transient failures first,
+ * then fall back only once retries are exhausted.
+ */
+@Injectable()
+export class FallbackService {
+  private readonly logger = new Logger(FallbackService.name);
+
+  private stats: FallbackStats = { totalCalls: 0, totalFallbacks: 0 };
+
+  /**
+   * Execute `primary`; if it rejects (and `shouldFallback` allows it), resolve
+   * with the configured fallback instead.
+   *
+   * Resolution order on failure:
+   * 1. `fallbackFn(error)` if provided,
+   * 2. otherwise `fallbackValue` if provided,
+   * 3. otherwise the original error is rethrown.
+   *
+   * If the fallback itself throws, that error propagates to the caller.
+   */
+  async execute<T>(
+    primary: () => Promise<T>,
+    options: FallbackOptions<T>,
+  ): Promise<T> {
+    const context = options.context ?? 'FallbackService';
+    this.stats.totalCalls++;
+
+    try {
+      return await primary();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.stats.lastError = error;
+
+      const shouldFallback = options.shouldFallback
+        ? options.shouldFallback(error)
+        : true;
+
+      if (!shouldFallback) {
+        throw error;
+      }
+
+      const hasFallback =
+        typeof options.fallbackFn === 'function' || 'fallbackValue' in options;
+      if (!hasFallback) {
+        // Nothing to fall back to — preserve the original failure.
+        throw error;
+      }
+
+      this.stats.totalFallbacks++;
+      this.logger.warn(
+        `[${context}] Primary failed (${error.message}); serving fallback`,
+        { error: error.message },
+      );
+
+      if (options.onFallback) {
+        options.onFallback(error);
+      }
+
+      if (typeof options.fallbackFn === 'function') {
+        return await options.fallbackFn(error);
+      }
+      return options.fallbackValue as T;
+    }
+  }
+
+  /**
+   * Convenience wrapper that produces a fallback-protected version of an
+   * existing async function.
+   */
+  wrap<TArgs extends unknown[], T>(
+    primary: (...args: TArgs) => Promise<T>,
+    options: FallbackOptions<T>,
+  ): (...args: TArgs) => Promise<T> {
+    return (...args: TArgs) => this.execute(() => primary(...args), options);
+  }
+
+  /** Returns a snapshot of aggregate fallback statistics. */
+  getStats(): Readonly<FallbackStats> {
+    return { ...this.stats };
+  }
+
+  /** Reset aggregate statistics. */
+  resetStats(): void {
+    this.stats = { totalCalls: 0, totalFallbacks: 0 };
+  }
+}

--- a/backend/src/common/resilience/incident.service.spec.ts
+++ b/backend/src/common/resilience/incident.service.spec.ts
@@ -1,0 +1,155 @@
+import { DegradationService } from './degradation.service';
+import { IncidentService } from './incident.service';
+import {
+  DegradationLevel,
+  IncidentSeverity,
+  IncidentStatus,
+} from './resilience.types';
+
+describe('IncidentService', () => {
+  let degradation: DegradationService;
+  let service: IncidentService;
+
+  beforeEach(() => {
+    degradation = new DegradationService();
+    service = new IncidentService(degradation);
+  });
+
+  describe('declare', () => {
+    it('creates an incident with an INC-YYYY-NNN id and an opening timeline entry', () => {
+      const incident = service.declare({
+        title: 'API 503 errors',
+        severity: IncidentSeverity.SEV2,
+      });
+
+      expect(incident.id).toMatch(/^INC-\d{4}-\d{3}$/);
+      expect(incident.status).toBe(IncidentStatus.OPEN);
+      expect(incident.timeline).toHaveLength(1);
+      expect(incident.timeline[0].message).toContain('SEV2 declared');
+    });
+
+    it('issues sequential ids within the same year', () => {
+      const a = service.declare({
+        title: 'one',
+        severity: IncidentSeverity.SEV3,
+      });
+      const b = service.declare({
+        title: 'two',
+        severity: IncidentSeverity.SEV3,
+      });
+      const year = new Date().getFullYear();
+      expect(a.id).toBe(`INC-${year}-001`);
+      expect(b.id).toBe(`INC-${year}-002`);
+    });
+  });
+
+  describe('degradation linkage', () => {
+    it('raises degradation to SEVERE for a SEV1 incident', () => {
+      service.declare({
+        title: 'total outage',
+        severity: IncidentSeverity.SEV1,
+      });
+      expect(degradation.getLevel()).toBe(DegradationLevel.SEVERE);
+    });
+
+    it('raises degradation to PARTIAL for a SEV2 incident', () => {
+      service.declare({ title: 'slow', severity: IncidentSeverity.SEV2 });
+      expect(degradation.getLevel()).toBe(DegradationLevel.PARTIAL);
+    });
+
+    it('leaves the system NORMAL for a SEV3 incident', () => {
+      service.declare({ title: 'minor', severity: IncidentSeverity.SEV3 });
+      expect(degradation.getLevel()).toBe(DegradationLevel.NORMAL);
+    });
+
+    it('uses the highest open severity when several incidents overlap', () => {
+      service.declare({ title: 'a', severity: IncidentSeverity.SEV2 });
+      const sev1 = service.declare({
+        title: 'b',
+        severity: IncidentSeverity.SEV1,
+      });
+      expect(degradation.getLevel()).toBe(DegradationLevel.SEVERE);
+
+      // Resolving the SEV1 drops back to the level implied by the SEV2.
+      service.resolve(sev1.id);
+      expect(degradation.getLevel()).toBe(DegradationLevel.PARTIAL);
+    });
+
+    it('returns to NORMAL once all incidents are resolved', () => {
+      const inc = service.declare({
+        title: 'outage',
+        severity: IncidentSeverity.SEV1,
+      });
+      service.resolve(inc.id);
+      expect(degradation.getLevel()).toBe(DegradationLevel.NORMAL);
+      expect(service.listOpen()).toHaveLength(0);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('records mitigatedAt and resolvedAt as it transitions', () => {
+      const inc = service.declare({
+        title: 'x',
+        severity: IncidentSeverity.SEV2,
+      });
+      service.mitigate(inc.id, 'rolled back');
+      expect(service.get(inc.id)?.status).toBe(IncidentStatus.MITIGATING);
+      expect(service.get(inc.id)?.mitigatedAt).toBeInstanceOf(Date);
+
+      service.resolve(inc.id, 'fully restored');
+      expect(service.get(inc.id)?.status).toBe(IncidentStatus.RESOLVED);
+      expect(service.get(inc.id)?.resolvedAt).toBeInstanceOf(Date);
+    });
+
+    it('appends free-form timeline events', () => {
+      const inc = service.declare({
+        title: 'x',
+        severity: IncidentSeverity.SEV3,
+      });
+      service.addEvent(inc.id, 'paged on-call');
+      const timeline = service.get(inc.id)?.timeline ?? [];
+      expect(timeline.map((e) => e.message)).toContain('paged on-call');
+    });
+
+    it('throws for an unknown incident id', () => {
+      expect(() => service.addEvent('INC-9999-999', 'noop')).toThrow(
+        /Unknown incident/,
+      );
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('computes mitigate/resolve durations relative to detection', () => {
+      const started = new Date('2026-04-24T10:30:00Z');
+      const detected = new Date('2026-04-24T10:30:02Z');
+
+      jest.useFakeTimers().setSystemTime(detected);
+      const inc = service.declare({
+        title: 'x',
+        severity: IncidentSeverity.SEV2,
+        startedAt: started,
+      });
+
+      jest.setSystemTime(new Date('2026-04-24T10:55:02Z')); // +25m from detect
+      service.mitigate(inc.id);
+      jest.setSystemTime(new Date('2026-04-24T11:20:02Z')); // +50m from detect
+      service.resolve(inc.id);
+      jest.useRealTimers();
+
+      const metrics = service.getMetrics(inc.id);
+      expect(metrics.timeToDetectMs).toBe(2000);
+      expect(metrics.timeToMitigateMs).toBe(25 * 60 * 1000);
+      expect(metrics.timeToResolveMs).toBe(50 * 60 * 1000);
+    });
+
+    it('leaves mitigate/resolve metrics undefined before those milestones', () => {
+      const inc = service.declare({
+        title: 'open',
+        severity: IncidentSeverity.SEV3,
+      });
+      const metrics = service.getMetrics(inc.id);
+      expect(metrics.timeToMitigateMs).toBeUndefined();
+      expect(metrics.timeToResolveMs).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/common/resilience/incident.service.ts
+++ b/backend/src/common/resilience/incident.service.ts
@@ -1,0 +1,203 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DegradationService } from './degradation.service';
+import {
+  DeclareIncidentInput,
+  DegradationLevel,
+  Incident,
+  IncidentMetrics,
+  IncidentSeverity,
+  IncidentStatus,
+} from './resilience.types';
+
+const OPEN_STATUSES = new Set<IncidentStatus>([
+  IncidentStatus.OPEN,
+  IncidentStatus.INVESTIGATING,
+  IncidentStatus.MITIGATING,
+  IncidentStatus.MONITORING,
+]);
+
+/**
+ * Degradation level implied by an open incident of a given severity.
+ * SEV3/SEV4 do not change the system posture on their own.
+ */
+const SEVERITY_TO_LEVEL: Record<IncidentSeverity, DegradationLevel> = {
+  [IncidentSeverity.SEV1]: DegradationLevel.SEVERE,
+  [IncidentSeverity.SEV2]: DegradationLevel.PARTIAL,
+  [IncidentSeverity.SEV3]: DegradationLevel.NORMAL,
+  [IncidentSeverity.SEV4]: DegradationLevel.NORMAL,
+};
+
+const LEVEL_ORDER: Record<DegradationLevel, number> = {
+  [DegradationLevel.NORMAL]: 0,
+  [DegradationLevel.PARTIAL]: 1,
+  [DegradationLevel.SEVERE]: 2,
+};
+
+/**
+ * Incident response procedures, in code.
+ *
+ * Operationalises docs/INCIDENT_RESPONSE.md: declaring incidents, maintaining
+ * a timeline, transitioning through the documented lifecycle, and computing
+ * the response metrics (MTTM/MTTR). Declaring or resolving an incident also
+ * drives the {@link DegradationService} so the system automatically sheds
+ * non-essential features for the duration of a SEV1/SEV2 incident.
+ *
+ * State is held in memory; it is intended for in-process coordination and for
+ * surfacing current incident status, not as the system of record.
+ */
+@Injectable()
+export class IncidentService {
+  private readonly logger = new Logger(IncidentService.name);
+
+  private readonly incidents = new Map<string, Incident>();
+  /** Per-year monotonic counter used to build INC-YYYY-NNN identifiers. */
+  private readonly yearCounters = new Map<number, number>();
+
+  constructor(private readonly degradation: DegradationService) {}
+
+  /** Declare a new incident. Returns the created record. */
+  declare(input: DeclareIncidentInput): Incident {
+    const now = new Date();
+    const startedAt = input.startedAt ?? now;
+    const incident: Incident = {
+      id: this.nextId(now),
+      title: input.title,
+      severity: input.severity,
+      status: IncidentStatus.OPEN,
+      description: input.description,
+      category: input.category,
+      reportedBy: input.reportedBy,
+      affectedServices: input.affectedServices ?? [],
+      startedAt,
+      detectedAt: now,
+      updatedAt: now,
+      timeline: [
+        { at: now, message: `${input.severity} declared: ${input.title}` },
+      ],
+    };
+
+    this.incidents.set(incident.id, incident);
+    this.logger.warn(
+      `Incident declared: ${incident.id} (${incident.severity})`,
+    );
+    this.applyDegradation();
+    return incident;
+  }
+
+  /** Append a free-form entry to an incident timeline. */
+  addEvent(id: string, message: string): Incident {
+    const incident = this.require(id);
+    const at = new Date();
+    incident.timeline.push({ at, message });
+    incident.updatedAt = at;
+    return incident;
+  }
+
+  /** Transition an incident to a new status, recording it on the timeline. */
+  updateStatus(id: string, status: IncidentStatus, note?: string): Incident {
+    const incident = this.require(id);
+    const at = new Date();
+
+    incident.status = status;
+    incident.updatedAt = at;
+    if (status === IncidentStatus.MITIGATING && !incident.mitigatedAt) {
+      incident.mitigatedAt = at;
+    }
+    if (
+      (status === IncidentStatus.RESOLVED ||
+        status === IncidentStatus.CLOSED) &&
+      !incident.resolvedAt
+    ) {
+      incident.resolvedAt = at;
+    }
+    incident.timeline.push({
+      at,
+      message: note ? `Status -> ${status}: ${note}` : `Status -> ${status}`,
+    });
+
+    this.applyDegradation();
+    return incident;
+  }
+
+  /** Convenience transition: mark mitigation applied. */
+  mitigate(id: string, note?: string): Incident {
+    return this.updateStatus(id, IncidentStatus.MITIGATING, note);
+  }
+
+  /** Convenience transition: mark the incident resolved. */
+  resolve(id: string, note?: string): Incident {
+    return this.updateStatus(id, IncidentStatus.RESOLVED, note);
+  }
+
+  get(id: string): Incident | undefined {
+    return this.incidents.get(id);
+  }
+
+  /** Incidents that are not yet resolved or closed. */
+  listOpen(): Incident[] {
+    return Array.from(this.incidents.values()).filter((i) =>
+      OPEN_STATUSES.has(i.status),
+    );
+  }
+
+  listAll(): Incident[] {
+    return Array.from(this.incidents.values());
+  }
+
+  /**
+   * Response metrics for a single incident (milliseconds). `timeToMitigateMs`
+   * and `timeToResolveMs` are only present once the milestone is reached.
+   */
+  getMetrics(id: string): IncidentMetrics {
+    const incident = this.require(id);
+    return {
+      id,
+      timeToDetectMs:
+        incident.detectedAt.getTime() - incident.startedAt.getTime(),
+      timeToMitigateMs: incident.mitigatedAt
+        ? incident.mitigatedAt.getTime() - incident.detectedAt.getTime()
+        : undefined,
+      timeToResolveMs: incident.resolvedAt
+        ? incident.resolvedAt.getTime() - incident.detectedAt.getTime()
+        : undefined,
+    };
+  }
+
+  /**
+   * Recompute the degradation level from the highest-severity open incident.
+   * Falls back to NORMAL when nothing is open.
+   */
+  private applyDegradation(): void {
+    const open = this.listOpen();
+    let target = DegradationLevel.NORMAL;
+    let driver: Incident | undefined;
+
+    for (const incident of open) {
+      const level = SEVERITY_TO_LEVEL[incident.severity];
+      if (LEVEL_ORDER[level] > LEVEL_ORDER[target]) {
+        target = level;
+        driver = incident;
+      }
+    }
+
+    const reason = driver
+      ? `${driver.id} (${driver.severity}): ${driver.title}`
+      : 'all incidents resolved';
+    this.degradation.setLevel(target, reason);
+  }
+
+  private nextId(now: Date): string {
+    const year = now.getFullYear();
+    const next = (this.yearCounters.get(year) ?? 0) + 1;
+    this.yearCounters.set(year, next);
+    return `INC-${year}-${String(next).padStart(3, '0')}`;
+  }
+
+  private require(id: string): Incident {
+    const incident = this.incidents.get(id);
+    if (!incident) {
+      throw new Error(`Unknown incident: ${id}`);
+    }
+    return incident;
+  }
+}

--- a/backend/src/common/resilience/index.ts
+++ b/backend/src/common/resilience/index.ts
@@ -1,0 +1,26 @@
+export { ResilienceModule } from './resilience.module';
+export { BulkheadService } from './bulkhead.service';
+export { FallbackService } from './fallback.service';
+export { DegradationService } from './degradation.service';
+export { IncidentService } from './incident.service';
+export {
+  BulkheadCapacityExceededError,
+  FeatureDisabledError,
+} from './resilience.errors';
+export {
+  BulkheadOptions,
+  BulkheadMetrics,
+  DEFAULT_BULKHEAD_OPTIONS,
+  FallbackOptions,
+  FallbackStats,
+  DegradationLevel,
+  DegradationStatus,
+  FeaturePriority,
+  FeatureStatus,
+  Incident,
+  IncidentMetrics,
+  IncidentSeverity,
+  IncidentStatus,
+  IncidentTimelineEntry,
+  DeclareIncidentInput,
+} from './resilience.types';

--- a/backend/src/common/resilience/resilience.errors.ts
+++ b/backend/src/common/resilience/resilience.errors.ts
@@ -1,0 +1,41 @@
+import { HttpStatus } from '@nestjs/common';
+import { BaseAppError } from '../errors/base.error';
+import { ErrorCode } from '../errors/error-codes';
+
+/**
+ * Thrown when a bulkhead compartment has no free execution slot and its
+ * waiting queue is full. Surfaced as HTTP 503 so callers/clients can back off.
+ */
+export class BulkheadCapacityExceededError extends BaseAppError {
+  public readonly compartment: string;
+
+  constructor(compartment: string, maxConcurrent: number, maxQueue: number) {
+    super(
+      ErrorCode.BULKHEAD_CAPACITY_EXCEEDED,
+      HttpStatus.SERVICE_UNAVAILABLE,
+      `Bulkhead "${compartment}" is at capacity (max ${maxConcurrent} concurrent, ${maxQueue} queued)`,
+      true,
+      { compartment, maxConcurrent, maxQueue },
+    );
+    this.compartment = compartment;
+  }
+}
+
+/**
+ * Thrown when a feature is requested while the system has shed it as part of
+ * graceful degradation.
+ */
+export class FeatureDisabledError extends BaseAppError {
+  public readonly feature: string;
+
+  constructor(feature: string, level: string) {
+    super(
+      ErrorCode.FEATURE_DISABLED,
+      HttpStatus.SERVICE_UNAVAILABLE,
+      `Feature "${feature}" is disabled while the system is degraded (level: ${level})`,
+      true,
+      { feature, level },
+    );
+    this.feature = feature;
+  }
+}

--- a/backend/src/common/resilience/resilience.module.ts
+++ b/backend/src/common/resilience/resilience.module.ts
@@ -1,0 +1,28 @@
+import { Global, Module } from '@nestjs/common';
+import { BulkheadService } from './bulkhead.service';
+import { FallbackService } from './fallback.service';
+import { DegradationService } from './degradation.service';
+import { IncidentService } from './incident.service';
+
+/**
+ * Groups the platform resilience patterns (bulkhead isolation, fallback
+ * execution, graceful degradation, and incident tracking) into a single
+ * globally-available module so any feature module can inject them without
+ * re-importing.
+ */
+@Global()
+@Module({
+  providers: [
+    BulkheadService,
+    FallbackService,
+    DegradationService,
+    IncidentService,
+  ],
+  exports: [
+    BulkheadService,
+    FallbackService,
+    DegradationService,
+    IncidentService,
+  ],
+})
+export class ResilienceModule {}

--- a/backend/src/common/resilience/resilience.types.ts
+++ b/backend/src/common/resilience/resilience.types.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared types for the resilience module.
+ *
+ * The resilience module groups together the production-readiness patterns that
+ * keep the platform responsive when downstream dependencies misbehave:
+ *
+ * - Bulkhead isolation ({@link BulkheadOptions})
+ * - Fallback execution ({@link FallbackOptions})
+ * - Graceful degradation ({@link DegradationLevel}, {@link FeaturePriority})
+ * - Incident tracking ({@link IncidentSeverity}, {@link IncidentStatus})
+ */
+
+// ── Bulkhead ────────────────────────────────────────────────────────────────
+
+/** Configuration for an isolated bulkhead compartment. */
+export interface BulkheadOptions {
+  /** Maximum number of calls allowed to run concurrently. */
+  maxConcurrent: number;
+  /** Maximum number of calls allowed to wait for a free slot. */
+  maxQueue: number;
+}
+
+export const DEFAULT_BULKHEAD_OPTIONS: BulkheadOptions = {
+  maxConcurrent: 10,
+  maxQueue: 20,
+};
+
+/** Point-in-time view of a bulkhead compartment. */
+export interface BulkheadMetrics {
+  name: string;
+  /** Calls currently executing. */
+  active: number;
+  /** Calls currently waiting for a free slot. */
+  queued: number;
+  maxConcurrent: number;
+  maxQueue: number;
+  /** Calls that have completed (successfully or not). */
+  totalExecuted: number;
+  /** Calls rejected because the compartment was saturated. */
+  totalRejected: number;
+}
+
+// ── Fallback ──────────────────────────────────────────────────────────────
+
+/**
+ * Options describing how to recover when the primary operation fails.
+ * Exactly one of `fallbackFn` or `fallbackValue` should be supplied; when both
+ * are present `fallbackFn` takes precedence.
+ */
+export interface FallbackOptions<T> {
+  /** Produces a fallback result from the primary error. */
+  fallbackFn?: (error: Error) => Promise<T> | T;
+  /** Static value returned when the primary operation fails. */
+  fallbackValue?: T;
+  /**
+   * Predicate deciding whether a given error should trigger the fallback.
+   * Defaults to falling back on every error.
+   */
+  shouldFallback?: (error: Error) => boolean;
+  /** Label used in logs. */
+  context?: string;
+  /** Invoked when the fallback path is taken. */
+  onFallback?: (error: Error) => void;
+}
+
+export interface FallbackStats {
+  totalCalls: number;
+  totalFallbacks: number;
+  lastError?: Error;
+}
+
+// ── Graceful degradation ──────────────────────────────────────────────────
+
+/** Overall health posture used to gate non-essential functionality. */
+export enum DegradationLevel {
+  /** Everything is healthy; all features enabled. */
+  NORMAL = 'normal',
+  /** Reduced capacity; optional features disabled. */
+  PARTIAL = 'partial',
+  /** Major outage; only essential features remain. */
+  SEVERE = 'severe',
+}
+
+/** How important a feature is, used to decide what to shed under load. */
+export enum FeaturePriority {
+  /** Must always remain available (auth, payments, core reads). */
+  ESSENTIAL = 'essential',
+  /** Normal functionality; disabled only under a severe outage. */
+  STANDARD = 'standard',
+  /** Nice-to-have; first to be disabled when degraded. */
+  OPTIONAL = 'optional',
+}
+
+export interface FeatureStatus {
+  name: string;
+  priority: FeaturePriority;
+  enabled: boolean;
+}
+
+export interface DegradationStatus {
+  level: DegradationLevel;
+  reason?: string;
+  since: Date;
+  features: FeatureStatus[];
+}
+
+// ── Incident tracking ──────────────────────────────────────────────────────
+
+/** Severity levels mirrored from docs/INCIDENT_RESPONSE.md. */
+export enum IncidentSeverity {
+  /** Critical: complete outage or data loss. */
+  SEV1 = 'SEV1',
+  /** Major: significant degradation affecting many users. */
+  SEV2 = 'SEV2',
+  /** Minor: limited impact or workaround available. */
+  SEV3 = 'SEV3',
+  /** Low: cosmetic or negligible impact. */
+  SEV4 = 'SEV4',
+}
+
+/** Lifecycle states mirrored from docs/INCIDENT_RESPONSE.md. */
+export enum IncidentStatus {
+  OPEN = 'open',
+  INVESTIGATING = 'investigating',
+  MITIGATING = 'mitigating',
+  MONITORING = 'monitoring',
+  RESOLVED = 'resolved',
+  CLOSED = 'closed',
+}
+
+export interface IncidentTimelineEntry {
+  at: Date;
+  message: string;
+}
+
+export interface DeclareIncidentInput {
+  title: string;
+  severity: IncidentSeverity;
+  description?: string;
+  category?: string;
+  reportedBy?: string;
+  affectedServices?: string[];
+  /** When the incident actually began (defaults to now). */
+  startedAt?: Date;
+}
+
+export interface Incident {
+  /** Human-readable identifier in the form INC-YYYY-NNN. */
+  id: string;
+  title: string;
+  severity: IncidentSeverity;
+  status: IncidentStatus;
+  description?: string;
+  category?: string;
+  reportedBy?: string;
+  affectedServices: string[];
+  startedAt: Date;
+  detectedAt: Date;
+  mitigatedAt?: Date;
+  resolvedAt?: Date;
+  updatedAt: Date;
+  timeline: IncidentTimelineEntry[];
+}
+
+/**
+ * Response-effectiveness metrics for a single incident, in milliseconds.
+ * Mirrors the MTTM / MTTR definitions in docs/INCIDENT_RESPONSE.md.
+ * Values are `undefined` until the relevant milestone is reached.
+ */
+export interface IncidentMetrics {
+  id: string;
+  /** Detection latency: detectedAt - startedAt. */
+  timeToDetectMs: number;
+  /** Mean Time To Mitigate: mitigatedAt - detectedAt. */
+  timeToMitigateMs?: number;
+  /** Mean Time To Resolve: resolvedAt - detectedAt. */
+  timeToResolveMs?: number;
+}


### PR DESCRIPTION
## Summary

Adds a cohesive **`ResilienceModule`** (`backend/src/common/resilience`, registered globally in `app.module`) covering the four backend production-readiness patterns these issues request. Each is an injectable NestJS service with colocated unit tests, following the conventions of the existing `RetryService`/`LockModule`.

## What's implemented

- **#1009 — Fallback mechanisms for degraded services** — `FallbackService` runs a primary operation and, on failure, serves a substitute (`fallbackFn` or `fallbackValue`, gated by an optional `shouldFallback` predicate), keeping user flows working in a reduced form. Designed to pair with the existing `RetryService` (retry first, then fall back). Tracks call/fallback stats; `wrap()` produces a protected function.
- **#1010 — Bulkhead pattern for service isolation** — `BulkheadService` gives each named compartment its own concurrency pool + bounded queue. A saturated compartment rejects fast with `BulkheadCapacityExceededError` (HTTP 503) so one slow dependency can't exhaust the rest. Exposes per-compartment metrics.
- **#1014 — Graceful degradation strategies** — `DegradationService` holds a `NORMAL → PARTIAL → SEVERE` level and a registry of priority-tagged features (`essential`/`standard`/`optional`), automatically shedding lower-priority features as the level rises. Guards via `isFeatureEnabled` / `assertFeatureEnabled`.
- **#1015 — Incident response procedures** — the runbook (`docs/INCIDENT_RESPONSE.md`) already existed; this adds a **code-backed, tested** `IncidentService` that operationalises it: `INC-YYYY-NNN` ids, the documented lifecycle + timeline, MTTM/MTTR metrics, and degradation linkage (a SEV1 forces `SEVERE`, SEV2 forces `PARTIAL`; resolving recomputes from the highest open severity).

Also adds `RESIL_12xxx` error codes/messages, documents the runtime patterns in **`docs/RESILIENCE.md`**, and links them from the incident runbook.

## Test plan
- [x] `pnpm run build` (nest build) — passes
- [x] `pnpm exec eslint src/common/resilience/**/*.ts` — clean
- [x] `pnpm exec jest common/resilience` — **42 tests / 4 suites pass** (happy path + failure modes for each service)

## Notes
- In-memory incident state is intended for in-process coordination and surfacing current status, not as the system of record (documented in the runbook section and `RESILIENCE.md`).

Closes #1009
Closes #1010
Closes #1014
Closes #1015