### PR TITLE
feat(monitoring): DB query performance stats + public status page

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { PropertiesModule } from './modules/properties/properties.module';
 import { StellarModule } from './modules/stellar/stellar.module';
 import { DisputesModule } from './modules/disputes/disputes.module';
 import { MonitoringModule } from './modules/monitoring/monitoring.module';
+import { StatusModule } from './modules/status/status.module';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { PaymentModule } from './modules/payments/payment.module';
@@ -212,6 +213,7 @@ const appLogger = new Logger('AppModule');
     StellarModule,
     DisputesModule,
     MonitoringModule,
+    StatusModule,
     // Load HealthModule only when not generating OpenAPI (avoids loading broken @nestjs/terminus in script)
     ...(process.env.OPENAPI_GENERATE !== 'true'
       ? [require('./health/health.module').HealthModule]

--- a/backend/src/modules/monitoring/performance-monitor.service.spec.ts
+++ b/backend/src/modules/monitoring/performance-monitor.service.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PerformanceMonitorService } from './performance-monitor.service';
+import { MetricsService } from './metrics.service';
+import { AlertService } from './alert.service';
+
+describe('PerformanceMonitorService - database query monitoring', () => {
+  let service: PerformanceMonitorService;
+  let metricsService: { recordDatabaseQuery: jest.Mock };
+
+  beforeEach(async () => {
+    metricsService = { recordDatabaseQuery: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PerformanceMonitorService,
+        { provide: MetricsService, useValue: metricsService },
+        { provide: AlertService, useValue: { handleAlert: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<PerformanceMonitorService>(PerformanceMonitorService);
+  });
+
+  it('records query durations and forwards them to the metrics service', () => {
+    service.recordDatabaseQuery('findUser', 20);
+    service.recordDatabaseQuery('findUser', 40);
+
+    const stats = service.getDatabaseStats();
+    const op = stats.operations.find((o) => o.operation === 'findUser');
+
+    expect(op).toBeDefined();
+    expect(op!.count).toBe(2);
+    expect(op!.avgDuration).toBe(30);
+    expect(stats.totalQueries).toBe(2);
+    expect(metricsService.recordDatabaseQuery).toHaveBeenCalledWith(
+      'findUser',
+      20,
+    );
+  });
+
+  it('tracks slow queries past the threshold', () => {
+    service.recordDatabaseQuery('reportQuery', 750);
+
+    const stats = service.getDatabaseStats();
+    const op = stats.operations.find((o) => o.operation === 'reportQuery');
+
+    expect(op!.slowCount).toBe(1);
+    expect(stats.recentSlowQueries).toHaveLength(1);
+    expect(stats.recentSlowQueries[0]).toMatchObject({
+      operation: 'reportQuery',
+      duration: 750,
+    });
+  });
+
+  it('ranks the slowest operations for bottleneck detection', () => {
+    service.recordDatabaseQuery('fast', 10);
+    service.recordDatabaseQuery('slow', 900);
+
+    const stats = service.getDatabaseStats();
+    expect(stats.slowestOperations[0].operation).toBe('slow');
+  });
+
+  it('reports no queries before any are recorded', () => {
+    const stats = service.getDatabaseStats();
+    expect(stats.totalQueries).toBe(0);
+    expect(stats.operations).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/monitoring/performance-monitor.service.ts
+++ b/backend/src/modules/monitoring/performance-monitor.service.ts
@@ -73,6 +73,16 @@ export class PerformanceMonitorService {
   private memoryUsageHistory: NodeJS.MemoryUsage[] = [];
   private readonly MAX_HISTORY_SIZE = 1000;
 
+  // Database query performance tracking (per operation)
+  private readonly databaseQueryData: Map<string, number[]> = new Map();
+  private readonly slowQueries: Array<{
+    operation: string;
+    duration: number;
+    timestamp: Date;
+  }> = [];
+  private readonly SLOW_QUERY_THRESHOLD_MS = 500;
+  private readonly MAX_SLOW_QUERY_HISTORY = 100;
+
   constructor(
     private readonly metricsService: MetricsService,
     private readonly alertService: AlertService,
@@ -113,6 +123,86 @@ export class PerformanceMonitorService {
 
     // Check thresholds immediately for critical issues
     this.checkPerformanceThresholds(key, metrics);
+  }
+
+  /**
+   * Record the duration of a database query for an operation (e.g. a repository
+   * method). Wired from the `DatabasePerformanceTrack` decorator. Durations are
+   * forwarded to the metrics service and slow queries are tracked for
+   * bottleneck detection.
+   */
+  recordDatabaseQuery(operation: string, duration: number): void {
+    const durations = this.databaseQueryData.get(operation) ?? [];
+    durations.push(duration);
+    if (durations.length > this.MAX_HISTORY_SIZE) {
+      durations.shift();
+    }
+    this.databaseQueryData.set(operation, durations);
+
+    this.metricsService.recordDatabaseQuery(operation, duration);
+
+    if (duration >= this.SLOW_QUERY_THRESHOLD_MS) {
+      this.slowQueries.push({ operation, duration, timestamp: new Date() });
+      if (this.slowQueries.length > this.MAX_SLOW_QUERY_HISTORY) {
+        this.slowQueries.shift();
+      }
+      this.logger.warn(
+        `Slow database query: ${operation} took ${duration}ms (threshold: ${this.SLOW_QUERY_THRESHOLD_MS}ms)`,
+      );
+    }
+  }
+
+  /**
+   * Aggregated database query statistics, including the slowest operations
+   * (bottleneck detection) and recent slow queries.
+   */
+  getDatabaseStats(): {
+    timestamp: Date;
+    totalQueries: number;
+    slowQueryThresholdMs: number;
+    operations: Array<{
+      operation: string;
+      count: number;
+      avgDuration: number;
+      minDuration: number;
+      maxDuration: number;
+      p95Duration: number;
+      slowCount: number;
+    }>;
+    slowestOperations: Array<{ operation: string; avgDuration: number }>;
+    recentSlowQueries: Array<{
+      operation: string;
+      duration: number;
+      timestamp: Date;
+    }>;
+  } {
+    const operations = Array.from(this.databaseQueryData.entries()).map(
+      ([operation, durations]) => ({
+        operation,
+        count: durations.length,
+        avgDuration: this.calculateAverage(durations),
+        minDuration: Math.min(...durations),
+        maxDuration: Math.max(...durations),
+        p95Duration: this.calculatePercentile(durations, 95),
+        slowCount: durations.filter((d) => d >= this.SLOW_QUERY_THRESHOLD_MS)
+          .length,
+      }),
+    );
+
+    const totalQueries = operations.reduce((sum, op) => sum + op.count, 0);
+    const slowestOperations = [...operations]
+      .sort((a, b) => b.avgDuration - a.avgDuration)
+      .slice(0, 5)
+      .map(({ operation, avgDuration }) => ({ operation, avgDuration }));
+
+    return {
+      timestamp: new Date(),
+      totalQueries,
+      slowQueryThresholdMs: this.SLOW_QUERY_THRESHOLD_MS,
+      operations,
+      slowestOperations,
+      recentSlowQueries: this.slowQueries.slice(-20),
+    };
   }
 
   /**

--- a/backend/src/modules/monitoring/performance.controller.ts
+++ b/backend/src/modules/monitoring/performance.controller.ts
@@ -46,6 +46,25 @@ export class PerformanceController {
     };
   }
 
+  @Get('database')
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({
+    summary: 'Get database query performance statistics',
+    description:
+      'Per-operation query timings (avg/p95), the slowest operations, and recent slow queries.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Database query performance statistics retrieved successfully',
+  })
+  @HttpCode(HttpStatus.OK)
+  async getDatabaseStats() {
+    return {
+      timestamp: new Date().toISOString(),
+      database: this.performanceMonitor.getDatabaseStats(),
+    };
+  }
+
   @Get('endpoints')
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Get performance statistics for all endpoints' })

--- a/backend/src/modules/status/status.controller.ts
+++ b/backend/src/modules/status/status.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { StatusService } from './status.service';
+
+@ApiTags('Status')
+@Controller('status')
+export class StatusController {
+  constructor(private readonly statusService: StatusService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Public status page',
+    description:
+      'Overall service status, per-component health, and uptime — for status-page integrations and uptime monitors.',
+  })
+  @ApiResponse({ status: 200, description: 'Current service status' })
+  getStatus() {
+    return this.statusService.getStatusPage();
+  }
+
+  @Get('uptime')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Service uptime' })
+  @ApiResponse({ status: 200, description: 'Uptime since service start' })
+  getUptime() {
+    return this.statusService.getUptime();
+  }
+}

--- a/backend/src/modules/status/status.module.ts
+++ b/backend/src/modules/status/status.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StatusController } from './status.controller';
+import { StatusService } from './status.service';
+
+@Module({
+  controllers: [StatusController],
+  providers: [StatusService],
+  exports: [StatusService],
+})
+export class StatusModule {}

--- a/backend/src/modules/status/status.service.spec.ts
+++ b/backend/src/modules/status/status.service.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { StatusService } from './status.service';
+
+describe('StatusService', () => {
+  let service: StatusService;
+  let dataSource: { query: jest.Mock };
+
+  async function build() {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StatusService, { provide: DataSource, useValue: dataSource }],
+    }).compile();
+    return module.get<StatusService>(StatusService);
+  }
+
+  beforeEach(async () => {
+    dataSource = { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    service = await build();
+  });
+
+  it('reports operational status when the database responds', async () => {
+    const page = await service.getStatusPage();
+
+    expect(page.status).toBe('operational');
+    expect(page.components.find((c) => c.name === 'database')?.status).toBe(
+      'operational',
+    );
+    expect(page.components.find((c) => c.name === 'api')?.status).toBe(
+      'operational',
+    );
+    expect(dataSource.query).toHaveBeenCalledWith('SELECT 1');
+  });
+
+  it('reports a major outage when the database check fails', async () => {
+    dataSource.query.mockRejectedValueOnce(new Error('connection refused'));
+
+    const page = await service.getStatusPage();
+
+    expect(page.status).toBe('major_outage');
+    expect(page.components.find((c) => c.name === 'database')?.status).toBe(
+      'major_outage',
+    );
+  });
+
+  it('reports uptime since service start', () => {
+    const uptime = service.getUptime();
+    expect(uptime.seconds).toBeGreaterThanOrEqual(0);
+    expect(typeof uptime.since).toBe('string');
+    expect(uptime.processSeconds).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/backend/src/modules/status/status.service.ts
+++ b/backend/src/modules/status/status.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+export type ComponentState = 'operational' | 'degraded' | 'major_outage';
+
+export interface ComponentStatus {
+  name: string;
+  status: ComponentState;
+  responseTimeMs?: number;
+}
+
+export interface UptimeInfo {
+  /** Seconds since this service instance started. */
+  seconds: number;
+  since: string;
+  /** Node process uptime in seconds. */
+  processSeconds: number;
+}
+
+export interface StatusPage {
+  status: ComponentState;
+  description: string;
+  components: ComponentStatus[];
+  uptime: UptimeInfo;
+  timestamp: string;
+}
+
+const STATUS_DESCRIPTIONS: Record<ComponentState, string> = {
+  operational: 'All systems operational',
+  degraded: 'Degraded performance',
+  major_outage: 'Major service outage',
+};
+
+/**
+ * Aggregates component health and uptime into a public status-page payload
+ * suitable for status-page integrations and uptime monitors.
+ */
+@Injectable()
+export class StatusService {
+  private readonly logger = new Logger(StatusService.name);
+  private readonly startedAt = new Date();
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  async getStatusPage(): Promise<StatusPage> {
+    const components: ComponentStatus[] = [
+      { name: 'api', status: 'operational' },
+      await this.checkDatabase(),
+    ];
+
+    const status = this.deriveOverallStatus(components);
+
+    return {
+      status,
+      description: STATUS_DESCRIPTIONS[status],
+      components,
+      uptime: this.getUptime(),
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  getUptime(): UptimeInfo {
+    const seconds = Math.floor((Date.now() - this.startedAt.getTime()) / 1000);
+    return {
+      seconds,
+      since: this.startedAt.toISOString(),
+      processSeconds: Math.floor(process.uptime()),
+    };
+  }
+
+  private async checkDatabase(): Promise<ComponentStatus> {
+    const start = Date.now();
+    try {
+      await this.dataSource.query('SELECT 1');
+      return {
+        name: 'database',
+        status: 'operational',
+        responseTimeMs: Date.now() - start,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Database status check failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return {
+        name: 'database',
+        status: 'major_outage',
+        responseTimeMs: Date.now() - start,
+      };
+    }
+  }
+
+  private deriveOverallStatus(components: ComponentStatus[]): ComponentState {
+    if (components.some((c) => c.status === 'major_outage')) {
+      return 'major_outage';
+    }
+    if (components.some((c) => c.status === 'degraded')) {
+      return 'degraded';
+    }
+    return 'operational';
+  }
+}


### PR DESCRIPTION
## Summary

Operational/observability work across the backend monitoring surface. Two issues were already implemented on `main` and are verified; two had real gaps that are addressed here.

### #951 — Performance monitoring & bottleneck detection — Closes #951
**Already implemented on `main`** (verified): `PerformanceMonitorService` records per-endpoint latency (p50/p95/p99), error rate and throughput, checks thresholds and fires alerts, runs periodic system health checks, and `generatePerformanceReport()` surfaces `slowestEndpoints` + recommendations (bottleneck detection). Exposed via `GET /api/performance/*`. No change required.

### #953 — Database query performance monitoring — Closes #953
The `DatabasePerformanceTrack` decorator already called `performanceMonitor.recordDatabaseQuery?.(...)`, but that method **did not exist** (silent no-op). Implemented it:
- `PerformanceMonitorService.recordDatabaseQuery(operation, duration)` — aggregates per-operation query timings, forwards to `MetricsService`, and tracks slow queries (≥500ms) with a bounded history.
- `getDatabaseStats()` — per-operation count/avg/min/max/p95, slow-query counts, the **slowest operations** (DB bottleneck detection), and recent slow queries.
- New admin endpoint **`GET /api/performance/database`**.

### #955 — Uptime monitoring & status page integration — Closes #955
New **`StatusModule`** with a **public** status page:
- `GET /status` — overall status (`operational`/`degraded`/`major_outage`), per-component health (api + a live DB ping with response time), and uptime.
- `GET /status/uptime` — service + process uptime.
Suitable for external status-page integrations and uptime monitors (no auth required, unlike the admin `/health/detailed`).

### #958 — Data retention & archival policies — Closes #958
**Already implemented on `main`** (verified): `DataArchivalService` defines per-entity retention policies (`retentionDays`, archive table, soft/hard delete), runs a daily archival cron, supports manual archival, and reports stats; complemented by `AuditRetentionService` and the cleanup module. No change required.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean (no errors in changed files).
- [x] `pnpm test` — full unit suite: **1189 passed, 0 failed** (53 skipped); no existing tests broken.
- [x] New specs: `performance-monitor.service.spec.ts` and `status/status.service.spec.ts` (7 tests) pass.
- [x] `prettier --check` and `eslint` clean on changed files (0 errors).

## Notes / out of scope
- `eslint` reports **41 pre-existing warnings on `main`** (0 errors); the lint script does not enforce `--max-warnings 0`, so CI lint passes. This change introduces 0 errors and no new warnings.
- #951 and #958 were already implemented; they're included here per the single-PR request and closed as verified-resolved, with the real new work being #953 and #955.

Closes #951
Closes #953
Closes #955
Closes #958