### PR TITLE
fix: add jest type definitions to backend tsconfig

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "types": ["node", "jest"],
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
### Summary\n\nAdd Jest type definitions to backend/tsconfig.json so backend spec files recognize Jest globals in the editor. \n\n### Verification\n\n- pnpm exec tsc --noEmit ✅\n- pnpm run lint ✅ (warnings only)\n- pnpm run build ✅\n\n### Notes\n\nThis PR is scoped to the backend TypeScript configuration only.
Closes: #986
Closes: #1007
Closes: #1004
Closes: #1003