### PR TITLE
Implement database migration strategy and validation

### DIFF
--- a/backend/src/common/services/encryption.service.spec.ts
+++ b/backend/src/common/services/encryption.service.spec.ts
@@ -4,114 +4,394 @@ import {
   EncryptionService,
   DecryptionFailedError,
   EncryptionError,
+  EncryptedData,
 } from './encryption.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** 32-byte key encoded as base64 */
+const makeKey = (fill: string): string =>
+  Buffer.from(fill.padEnd(32, '0').slice(0, 32), 'utf8').toString('base64');
+
+const KEY_A = makeKey('key-alpha-32-bytes-padding-00000');
+const KEY_B = makeKey('key-beta--32-bytes-padding-00000');
+const KEY_C = makeKey('key-gamma-32-bytes-padding-00000');
+
+/** Build a ConfigService mock that returns KEY_A as the single key */
+function buildModule(
+  configOverride?: (key: string) => string | undefined,
+): Promise<TestingModule> {
+  const mockConfigService = {
+    get: jest.fn().mockImplementation(
+      configOverride ??
+        ((key: string) => {
+          if (key === 'ENCRYPTION_KEY_BASE64') return KEY_A;
+          return undefined;
+        }),
+    ),
+  };
+
+  return Test.createTestingModule({
+    providers: [
+      EncryptionService,
+      { provide: ConfigService, useValue: mockConfigService },
+    ],
+  }).compile();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe('EncryptionService', () => {
   let service: EncryptionService;
-  const mockConfigService = {
-    get: jest.fn(),
-  };
-
-  const key1 = Buffer.from('01234567890123456789012345678901', 'utf8'); // 32 bytes
-  const key2 = Buffer.from('abcdefghijklmnopqrstuvwxyz12345678', 'utf8'); // rotated key
 
   beforeEach(async () => {
-    // Mock config for tests
-    mockConfigService.get.mockImplementation((key: string) => {
-      if (key === 'ENCRYPTION_KEY_BASE64') {
-        return key1.toString('base64');
-      }
-      return undefined;
-    });
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        EncryptionService,
-        { provide: ConfigService, useValue: mockConfigService },
-      ],
-    }).compile();
-
+    const module = await buildModule();
     service = module.get<EncryptionService>(EncryptionService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+  afterEach(() => jest.clearAllMocks());
 
-  describe('encrypt', () => {
-    it('should encrypt plain text successfully', async () => {
-      const plain = 'sensitive data';
-      const encrypted = await service.encrypt(plain);
+  // ── Instantiation ──────────────────────────────────────────────────────────
 
-      expect(encrypted).toMatch(
-        /^{"iv":"[^"]+","data":"[^"]+","tag":"[^"]+"}$/,
-      );
-      expect(JSON.parse(encrypted)).toHaveProperty('iv');
-      expect(JSON.parse(encrypted)).toHaveProperty('data');
-      expect(JSON.parse(encrypted)).toHaveProperty('tag');
+  describe('instantiation', () => {
+    it('is defined with a valid single key', () => {
+      expect(service).toBeDefined();
     });
 
-    it('should reject empty/invalid plain', async () => {
+    it('loads multiple rotation keys from ENCRYPTION_KEYS JSON array', async () => {
+      const keysJson = JSON.stringify([KEY_A, KEY_B]);
+      const module = await buildModule((key) => {
+        if (key === 'ENCRYPTION_KEYS') return keysJson;
+        return undefined;
+      });
+      const svc = module.get<EncryptionService>(EncryptionService);
+      expect(svc.getKeyCount()).toBe(2);
+    });
+
+    it('throws EncryptionError when no key env var is set', async () => {
+      await expect(buildModule(() => undefined)).rejects.toThrow(
+        EncryptionError,
+      );
+    });
+
+    it('throws EncryptionError when key is shorter than 32 bytes', async () => {
+      const shortKey = Buffer.from('tooshort', 'utf8').toString('base64');
+      await expect(
+        buildModule((key) => {
+          if (key === 'ENCRYPTION_KEY_BASE64') return shortKey;
+          return undefined;
+        }),
+      ).rejects.toThrow(EncryptionError);
+    });
+
+    it('throws EncryptionError when ENCRYPTION_KEYS contains a short key', async () => {
+      const badKeysJson = JSON.stringify([
+        Buffer.from('short', 'utf8').toString('base64'),
+      ]);
+      await expect(
+        buildModule((key) => {
+          if (key === 'ENCRYPTION_KEYS') return badKeysJson;
+          return undefined;
+        }),
+      ).rejects.toThrow(EncryptionError);
+    });
+  });
+
+  // ── encrypt ────────────────────────────────────────────────────────────────
+
+  describe('encrypt', () => {
+    it('returns a JSON string with iv, data, and tag fields', async () => {
+      const result = await service.encrypt('hello world');
+      const parsed = JSON.parse(result) as EncryptedData;
+      expect(parsed).toHaveProperty('iv');
+      expect(parsed).toHaveProperty('data');
+      expect(parsed).toHaveProperty('tag');
+    });
+
+    it('iv, data, and tag are valid base64 strings', async () => {
+      const result = await service.encrypt('test');
+      const parsed = JSON.parse(result) as EncryptedData;
+      const base64Re = /^[A-Za-z0-9+/]+=*$/;
+      expect(parsed.iv).toMatch(base64Re);
+      expect(parsed.data).toMatch(base64Re);
+      expect(parsed.tag).toMatch(base64Re);
+    });
+
+    it('produces different ciphertexts for the same plaintext (random IV)', async () => {
+      const c1 = await service.encrypt('same input');
+      const c2 = await service.encrypt('same input');
+      expect(c1).not.toBe(c2);
+    });
+
+    it('encrypts a long string without error', async () => {
+      const longText = 'A'.repeat(10_000);
+      const result = await service.encrypt(longText);
+      expect(result).toBeTruthy();
+    });
+
+    it('encrypts unicode / special characters', async () => {
+      const unicode = '日本語テスト 🔐 <script>alert(1)</script>';
+      const result = await service.encrypt(unicode);
+      expect(result).toBeTruthy();
+    });
+
+    it('encrypts a single character', async () => {
+      const result = await service.encrypt('x');
+      expect(result).toBeTruthy();
+    });
+
+    it('throws EncryptionError for empty string', async () => {
       await expect(service.encrypt('')).rejects.toThrow(EncryptionError);
-      await expect(service.encrypt(null as any)).rejects.toThrow(
+    });
+
+    it('throws EncryptionError for null input', async () => {
+      await expect(service.encrypt(null as unknown as string)).rejects.toThrow(
+        EncryptionError,
+      );
+    });
+
+    it('throws EncryptionError for undefined input', async () => {
+      await expect(
+        service.encrypt(undefined as unknown as string),
+      ).rejects.toThrow(EncryptionError);
+    });
+
+    it('throws EncryptionError for numeric input', async () => {
+      await expect(service.encrypt(42 as unknown as string)).rejects.toThrow(
         EncryptionError,
       );
     });
   });
 
-  describe('decrypt', () => {
-    it('should decrypt correctly', async () => {
-      const plain = 'secret message';
-      const encrypted = await service.encrypt(plain);
-      const decrypted = await service.decrypt(encrypted);
+  // ── decrypt ────────────────────────────────────────────────────────────────
 
-      expect(decrypted).toBe(plain);
+  describe('decrypt', () => {
+    it('round-trips a simple string', async () => {
+      const plain = 'round-trip test';
+      expect(await service.decrypt(await service.encrypt(plain))).toBe(plain);
     });
 
-    it('should fail invalid ciphertext', async () => {
-      await expect(service.decrypt('invalid')).rejects.toThrow(
-        DecryptionFailedError,
-      );
+    it('round-trips a long string', async () => {
+      const plain = 'Z'.repeat(5_000);
+      expect(await service.decrypt(await service.encrypt(plain))).toBe(plain);
+    });
+
+    it('round-trips unicode and special characters', async () => {
+      const plain = '🔑 sensitive: <>&"\'';
+      expect(await service.decrypt(await service.encrypt(plain))).toBe(plain);
+    });
+
+    it('round-trips a JSON payload string', async () => {
+      const plain = JSON.stringify({ userId: 'abc', ssn: '123-45-6789' });
+      expect(await service.decrypt(await service.encrypt(plain))).toBe(plain);
+    });
+
+    it('throws EncryptionError for empty ciphertext', async () => {
       await expect(service.decrypt('')).rejects.toThrow(EncryptionError);
     });
 
-    it('should support key rotation', async () => {
-      const plain = 'rotated data';
-      // Patch keys for rotation test
-      const oldKeys = service['keys'];
-      service['keys'] = [key2, key1];
+    it('throws EncryptionError for null ciphertext', async () => {
+      await expect(service.decrypt(null as unknown as string)).rejects.toThrow(
+        EncryptionError,
+      );
+    });
 
-      // Encrypt with key1 (old)
-      service['keys'] = [key1];
-      const encWithKey1 = await service.encrypt(plain);
-      service['keys'] = [key2, key1]; // rotation
+    it('throws DecryptionFailedError for a plain non-JSON string', async () => {
+      await expect(service.decrypt('not-json-at-all')).rejects.toThrow(
+        DecryptionFailedError,
+      );
+    });
 
-      const decrypted = await service.decrypt(encWithKey1);
-      expect(decrypted).toBe(plain);
+    it('throws DecryptionFailedError for JSON missing required fields', async () => {
+      await expect(
+        service.decrypt(JSON.stringify({ iv: 'abc' })),
+      ).rejects.toThrow(DecryptionFailedError);
+    });
 
-      service['keys'] = oldKeys;
+    it('throws DecryptionFailedError for tampered ciphertext (flipped bit)', async () => {
+      const encrypted = await service.encrypt('tamper test');
+      const parsed = JSON.parse(encrypted) as EncryptedData;
+      // Flip the first byte of the data field
+      const dataBuf = Buffer.from(parsed.data, 'base64');
+      dataBuf[0] ^= 0xff;
+      parsed.data = dataBuf.toString('base64');
+      await expect(service.decrypt(JSON.stringify(parsed))).rejects.toThrow(
+        DecryptionFailedError,
+      );
+    });
+
+    it('throws DecryptionFailedError for tampered auth tag', async () => {
+      const encrypted = await service.encrypt('tag tamper');
+      const parsed = JSON.parse(encrypted) as EncryptedData;
+      const tagBuf = Buffer.from(parsed.tag, 'base64');
+      tagBuf[0] ^= 0xff;
+      parsed.tag = tagBuf.toString('base64');
+      await expect(service.decrypt(JSON.stringify(parsed))).rejects.toThrow(
+        DecryptionFailedError,
+      );
+    });
+
+    it('throws DecryptionFailedError when decrypting with the wrong key', async () => {
+      const encrypted = await service.encrypt('wrong key test');
+
+      // Build a service with a different key
+      const otherModule = await buildModule((key) => {
+        if (key === 'ENCRYPTION_KEY_BASE64') return KEY_B;
+        return undefined;
+      });
+      const otherService =
+        otherModule.get<EncryptionService>(EncryptionService);
+
+      await expect(otherService.decrypt(encrypted)).rejects.toThrow(
+        DecryptionFailedError,
+      );
     });
   });
 
-  describe('rotateKey', () => {
-    it('should add new key to front', () => {
-      const newKeyHex =
+  // ── key rotation ───────────────────────────────────────────────────────────
+
+  describe('key rotation', () => {
+    it('rotateKey prepends the new key so getKeyCount increases by 1', () => {
+      const before = service.getKeyCount();
+      service.rotateKey(KEY_B);
+      expect(service.getKeyCount()).toBe(before + 1);
+    });
+
+    it('new key becomes the active encryption key after rotation', async () => {
+      service.rotateKey(KEY_B);
+      // Encrypt with KEY_B now active; a service with only KEY_B should decrypt it
+      const encrypted = await service.encrypt('rotation active key');
+      const otherModule = await buildModule((key) => {
+        if (key === 'ENCRYPTION_KEY_BASE64') return KEY_B;
+        return undefined;
+      });
+      const otherService =
+        otherModule.get<EncryptionService>(EncryptionService);
+      expect(await otherService.decrypt(encrypted)).toBe('rotation active key');
+    });
+
+    it('can still decrypt data encrypted with the old key after rotation', async () => {
+      const plain = 'old key data';
+      const encryptedWithOld = await service.encrypt(plain);
+      service.rotateKey(KEY_B); // KEY_B is now active, KEY_A is fallback
+      expect(await service.decrypt(encryptedWithOld)).toBe(plain);
+    });
+
+    it('supports two rotations and decrypts data from any key in the chain', async () => {
+      const plain = 'multi-rotation';
+      const encWithA = await service.encrypt(plain);
+      service.rotateKey(KEY_B);
+      const encWithB = await service.encrypt(plain);
+      service.rotateKey(KEY_C);
+      // All three should decrypt
+      expect(await service.decrypt(encWithA)).toBe(plain);
+      expect(await service.decrypt(encWithB)).toBe(plain);
+      expect(await service.decrypt(await service.encrypt(plain))).toBe(plain);
+    });
+
+    it('throws EncryptionError when rotating with a key shorter than 32 bytes', () => {
+      const shortKey = Buffer.from('short', 'utf8').toString('base64');
+      expect(() => service.rotateKey(shortKey)).toThrow(EncryptionError);
+    });
+
+    it('throws EncryptionError when rotating with an empty string', () => {
+      expect(() => service.rotateKey('')).toThrow(EncryptionError);
+    });
+
+    it('rotateKey with a valid 32-byte hex key (base64 encoded) succeeds', () => {
+      // 64 hex chars = 32 bytes
+      const hexKey =
         'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
-      const newKey = Buffer.from(newKeyHex, 'hex');
-      const newKeyB64 = newKey.toString('base64');
-      service.rotateKey(newKeyB64);
-
-      expect(service['keys'][0].toString('hex')).toBe(newKeyHex);
-    });
-
-    it('should reject invalid key length', () => {
-      expect(() => service.rotateKey('short')).toThrow(EncryptionError);
+      const b64Key = Buffer.from(hexKey, 'hex').toString('base64');
+      expect(() => service.rotateKey(b64Key)).not.toThrow();
     });
   });
+
+  // ── getKeyCount ────────────────────────────────────────────────────────────
 
   describe('getKeyCount', () => {
-    it('should return current key count', () => {
+    it('returns 1 when initialised with a single key', () => {
       expect(service.getKeyCount()).toBe(1);
+    });
+
+    it('returns 2 after one rotation', () => {
+      service.rotateKey(KEY_B);
+      expect(service.getKeyCount()).toBe(2);
+    });
+
+    it('returns 3 after two rotations', () => {
+      service.rotateKey(KEY_B);
+      service.rotateKey(KEY_C);
+      expect(service.getKeyCount()).toBe(3);
+    });
+  });
+
+  // ── multi-key initialisation ───────────────────────────────────────────────
+
+  describe('multi-key initialisation via ENCRYPTION_KEYS', () => {
+    let multiService: EncryptionService;
+
+    beforeEach(async () => {
+      const keysJson = JSON.stringify([KEY_A, KEY_B]);
+      const module = await buildModule((key) => {
+        if (key === 'ENCRYPTION_KEYS') return keysJson;
+        return undefined;
+      });
+      multiService = module.get<EncryptionService>(EncryptionService);
+    });
+
+    it('reports correct key count', () => {
+      expect(multiService.getKeyCount()).toBe(2);
+    });
+
+    it('encrypts with the first (newest) key', async () => {
+      const encrypted = await multiService.encrypt('multi-key test');
+      // A service with only KEY_A should decrypt it
+      const singleModule = await buildModule((key) => {
+        if (key === 'ENCRYPTION_KEY_BASE64') return KEY_A;
+        return undefined;
+      });
+      const singleService =
+        singleModule.get<EncryptionService>(EncryptionService);
+      expect(await singleService.decrypt(encrypted)).toBe('multi-key test');
+    });
+
+    it('decrypts data encrypted with the second (older) key', async () => {
+      // Encrypt with KEY_B only
+      const oldModule = await buildModule((key) => {
+        if (key === 'ENCRYPTION_KEY_BASE64') return KEY_B;
+        return undefined;
+      });
+      const oldService = oldModule.get<EncryptionService>(EncryptionService);
+      const encrypted = await oldService.encrypt('legacy data');
+      // Multi-key service should fall back to KEY_B
+      expect(await multiService.decrypt(encrypted)).toBe('legacy data');
+    });
+  });
+
+  // ── error class identity ───────────────────────────────────────────────────
+
+  describe('error class identity', () => {
+    it('EncryptionError is an instance of Error', async () => {
+      try {
+        await service.encrypt('');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(EncryptionError);
+      }
+    });
+
+    it('DecryptionFailedError is an instance of Error', async () => {
+      try {
+        await service.decrypt('bad');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(DecryptionFailedError);
+      }
     });
   });
 });

--- a/backend/src/database/migration-runner.spec.ts
+++ b/backend/src/database/migration-runner.spec.ts
@@ -1,0 +1,556 @@
+/**
+ * Unit tests for the migration runner strategy and validation utilities.
+ *
+ * All tests mock the AppDataSource so no real database connection is required.
+ * The suite validates:
+ *  - Lock acquisition / release logic
+ *  - Dry-run mode
+ *  - Happy-path migration execution
+ *  - Auto-rollback on failure
+ *  - Revert-to-named-migration logic
+ *  - Post-migration verification
+ *  - showMigrations output
+ *  - Edge cases (no pending migrations, lock contention, etc.)
+ */
+
+// ---------------------------------------------------------------------------
+// Mock AppDataSource BEFORE importing the runner so the module picks it up
+// ---------------------------------------------------------------------------
+
+const mockQuery = jest.fn();
+const mockRunMigrations = jest.fn();
+const mockUndoLastMigration = jest.fn();
+const mockCreateQueryRunner = jest.fn();
+
+jest.mock('./data-source', () => ({
+  AppDataSource: {
+    query: mockQuery,
+    runMigrations: mockRunMigrations,
+    undoLastMigration: mockUndoLastMigration,
+    createQueryRunner: mockCreateQueryRunner,
+    migrations: [] as { name: string }[],
+  },
+}));
+
+// Import after mock is registered
+import {
+  runMigrationsWithRollback,
+  revertLastMigration,
+  verifyAfterMigrations,
+  showMigrations,
+} from './migration-runner';
+import { AppDataSource } from './data-source';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Cast to the mocked shape for easy manipulation */
+const ds = AppDataSource as unknown as {
+  query: jest.Mock;
+  runMigrations: jest.Mock;
+  undoLastMigration: jest.Mock;
+  createQueryRunner: jest.Mock;
+  migrations: { name: string }[];
+};
+
+/** Build a mock QueryRunner that succeeds for all queries */
+function buildQueryRunner(overrides: Partial<{ query: jest.Mock }> = {}) {
+  return {
+    connect: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn().mockResolvedValue(undefined),
+    query: overrides.query ?? jest.fn().mockResolvedValue([{ id: 1 }]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: lock table insert succeeds (lock acquired)
+  const qr = buildQueryRunner();
+  ds.createQueryRunner.mockReturnValue(qr);
+
+  // Default: migrations table exists
+  ds.query.mockImplementation((sql: string) => {
+    if (sql.includes('information_schema.tables'))
+      return Promise.resolve([{ 1: 1 }]);
+    if (sql.includes('SELECT name FROM')) return Promise.resolve([]);
+    if (sql.includes('COUNT(1)')) return Promise.resolve([{ cnt: '3' }]);
+    return Promise.resolve([]);
+  });
+
+  ds.runMigrations.mockResolvedValue(undefined);
+  ds.undoLastMigration.mockResolvedValue(undefined);
+  ds.migrations = [
+    { name: 'Migration001' },
+    { name: 'Migration002' },
+    { name: 'Migration003' },
+  ];
+});
+
+// ---------------------------------------------------------------------------
+// runMigrationsWithRollback
+// ---------------------------------------------------------------------------
+
+describe('runMigrationsWithRollback', () => {
+  describe('dry-run mode', () => {
+    it('returns success without calling runMigrations', async () => {
+      // Simulate pending migrations
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT name FROM')) {
+          return Promise.resolve([{ name: 'Migration001' }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await runMigrationsWithRollback({ dryRun: true });
+
+      expect(result.success).toBe(true);
+      expect(result.run).toBe(0);
+      expect(result.reverted).toBe(false);
+      expect(ds.runMigrations).not.toHaveBeenCalled();
+    });
+
+    it('reports no pending migrations when all are executed', async () => {
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT name FROM')) {
+          return Promise.resolve([
+            { name: 'Migration001' },
+            { name: 'Migration002' },
+            { name: 'Migration003' },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await runMigrationsWithRollback({ dryRun: true });
+
+      expect(result.success).toBe(true);
+      expect(result.run).toBe(0);
+    });
+  });
+
+  describe('lock contention', () => {
+    it('returns failure when lock cannot be acquired', async () => {
+      // Simulate lock already held: INSERT returns empty array
+      const qr = buildQueryRunner({
+        query: jest.fn().mockImplementation((sql: string) => {
+          if (sql.includes('CREATE TABLE IF NOT EXISTS'))
+            return Promise.resolve([]);
+          if (sql.includes('INSERT INTO')) return Promise.resolve([]); // no rows = lock held
+          if (sql.includes('SELECT pid'))
+            return Promise.resolve([{ pid: 42, locked_at: new Date() }]);
+          return Promise.resolve([]);
+        }),
+      });
+      ds.createQueryRunner.mockReturnValue(qr);
+
+      const result = await runMigrationsWithRollback();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/lock/i);
+      expect(ds.runMigrations).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path', () => {
+    it('runs pending migrations and returns success', async () => {
+      // 2 executed, 1 pending
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('information_schema.tables'))
+          return Promise.resolve([{ 1: 1 }]);
+        if (sql.includes('SELECT name FROM')) {
+          return Promise.resolve([
+            { name: 'Migration001' },
+            { name: 'Migration002' },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await runMigrationsWithRollback();
+
+      expect(result.success).toBe(true);
+      expect(result.run).toBe(1); // Migration003 is pending
+      expect(result.reverted).toBe(false);
+      expect(ds.runMigrations).toHaveBeenCalledWith({ transaction: 'each' });
+    });
+
+    it('returns run=0 when there are no pending migrations', async () => {
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('information_schema.tables'))
+          return Promise.resolve([{ 1: 1 }]);
+        if (sql.includes('SELECT name FROM')) {
+          return Promise.resolve([
+            { name: 'Migration001' },
+            { name: 'Migration002' },
+            { name: 'Migration003' },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await runMigrationsWithRollback();
+
+      expect(result.success).toBe(true);
+      expect(result.run).toBe(0);
+      expect(ds.runMigrations).not.toHaveBeenCalled();
+    });
+
+    it('runs all migrations with transaction:all when migrations table is absent', async () => {
+      // acquireLock uses createQueryRunner (call #1), ensureMigrationsTableExists uses it (call #2)
+      let qrCallCount = 0;
+      ds.createQueryRunner.mockImplementation(() => {
+        qrCallCount++;
+        if (qrCallCount === 1) {
+          // Lock QR — succeeds
+          return buildQueryRunner({
+            query: jest.fn().mockImplementation((sql: string) => {
+              if (sql.includes('CREATE TABLE IF NOT EXISTS'))
+                return Promise.resolve([]);
+              if (sql.includes('INSERT INTO'))
+                return Promise.resolve([{ id: 1 }]);
+              return Promise.resolve([]);
+            }),
+          });
+        }
+        // ensureMigrationsTableExists QR — table absent
+        return buildQueryRunner({
+          query: jest.fn().mockResolvedValue([]),
+        });
+      });
+
+      const result = await runMigrationsWithRollback();
+
+      expect(result.success).toBe(true);
+      expect(ds.runMigrations).toHaveBeenCalledWith({ transaction: 'all' });
+    });
+  });
+
+  describe('failure and auto-rollback', () => {
+    it('reverts last migration and returns reverted=true on runMigrations failure', async () => {
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('information_schema.tables'))
+          return Promise.resolve([{ 1: 1 }]);
+        if (sql.includes('SELECT name FROM')) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+      ds.runMigrations.mockRejectedValue(new Error('migration failed'));
+
+      const result = await runMigrationsWithRollback();
+
+      expect(result.success).toBe(false);
+      expect(result.reverted).toBe(true);
+      expect(result.error).toContain('migration failed');
+      expect(ds.undoLastMigration).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports rollback failure in error message when undoLastMigration also throws', async () => {
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('information_schema.tables'))
+          return Promise.resolve([{ 1: 1 }]);
+        if (sql.includes('SELECT name FROM')) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+      ds.runMigrations.mockRejectedValue(new Error('run error'));
+      ds.undoLastMigration.mockRejectedValue(new Error('revert error'));
+
+      const result = await runMigrationsWithRollback();
+
+      expect(result.success).toBe(false);
+      expect(result.reverted).toBe(false);
+      expect(result.error).toContain('run error');
+      expect(result.error).toContain('rollback failed');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revertLastMigration
+// ---------------------------------------------------------------------------
+
+describe('revertLastMigration', () => {
+  describe('lock contention', () => {
+    it('returns failure when lock cannot be acquired', async () => {
+      const qr = buildQueryRunner({
+        query: jest.fn().mockImplementation((sql: string) => {
+          if (sql.includes('CREATE TABLE IF NOT EXISTS'))
+            return Promise.resolve([]);
+          if (sql.includes('INSERT INTO')) return Promise.resolve([]);
+          if (sql.includes('SELECT pid'))
+            return Promise.resolve([{ pid: 99, locked_at: new Date() }]);
+          return Promise.resolve([]);
+        }),
+      });
+      ds.createQueryRunner.mockReturnValue(qr);
+
+      const result = await revertLastMigration();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/lock/i);
+      expect(ds.undoLastMigration).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revert last migration', () => {
+    it('calls undoLastMigration once and returns reverted=1', async () => {
+      const result = await revertLastMigration();
+
+      expect(result.success).toBe(true);
+      expect(result.reverted).toBe(1);
+      expect(ds.undoLastMigration).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns failure when undoLastMigration throws', async () => {
+      ds.undoLastMigration.mockRejectedValue(new Error('revert failed'));
+
+      const result = await revertLastMigration();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('revert failed');
+    });
+  });
+
+  describe('revert to named migration (--to)', () => {
+    beforeEach(() => {
+      // Executed: Migration001, Migration002, Migration003
+      ds.query.mockImplementation((sql: string) => {
+        if (sql.includes('SELECT name FROM')) {
+          return Promise.resolve([
+            { name: 'Migration001' },
+            { name: 'Migration002' },
+            { name: 'Migration003' },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+    });
+
+    it('reverts migrations after the named one', async () => {
+      // Revert to Migration001 → should revert Migration002 and Migration003
+      const result = await revertLastMigration({ to: 'Migration001' });
+
+      expect(result.success).toBe(true);
+      expect(result.reverted).toBe(2);
+      expect(ds.undoLastMigration).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns reverted=0 when already at the target migration', async () => {
+      // Revert to Migration003 (the last one) → nothing to revert
+      const result = await revertLastMigration({ to: 'Migration003' });
+
+      expect(result.success).toBe(true);
+      expect(result.reverted).toBe(0);
+      expect(ds.undoLastMigration).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when the named migration is not found', async () => {
+      const result = await revertLastMigration({ to: 'NonExistentMigration' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('NonExistentMigration');
+      expect(ds.undoLastMigration).not.toHaveBeenCalled();
+    });
+
+    it('reverts all migrations when targeting the first one', async () => {
+      // Revert to Migration001 → reverts Migration002 and Migration003
+      const result = await revertLastMigration({ to: 'Migration001' });
+
+      expect(result.success).toBe(true);
+      expect(result.reverted).toBe(2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyAfterMigrations
+// ---------------------------------------------------------------------------
+
+describe('verifyAfterMigrations', () => {
+  it('returns ok=true when migrations table exists and is readable', async () => {
+    // ensureMigrationsTableExists uses createQueryRunner; COUNT uses AppDataSource.query
+    ds.createQueryRunner.mockReturnValue(
+      buildQueryRunner({
+        query: jest.fn().mockResolvedValue([{ 1: 1 }]), // table exists
+      }),
+    );
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('COUNT(1)')) return Promise.resolve([{ cnt: '5' }]);
+      return Promise.resolve([]);
+    });
+
+    const result = await verifyAfterMigrations();
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns ok=false when migrations table does not exist', async () => {
+    // ensureMigrationsTableExists QR returns [] → table absent
+    ds.createQueryRunner.mockReturnValue(
+      buildQueryRunner({
+        query: jest.fn().mockResolvedValue([]),
+      }),
+    );
+
+    const result = await verifyAfterMigrations();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/missing/i);
+  });
+
+  it('returns ok=false and error message when query throws', async () => {
+    ds.createQueryRunner.mockReturnValue(
+      buildQueryRunner({
+        query: jest.fn().mockRejectedValue(new Error('db connection lost')),
+      }),
+    );
+
+    const result = await verifyAfterMigrations();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('db connection lost');
+  });
+
+  it('handles zero migrations recorded gracefully', async () => {
+    ds.createQueryRunner.mockReturnValue(
+      buildQueryRunner({
+        query: jest.fn().mockResolvedValue([{ 1: 1 }]), // table exists
+      }),
+    );
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('COUNT(1)')) return Promise.resolve([{ cnt: '0' }]);
+      return Promise.resolve([]);
+    });
+
+    const result = await verifyAfterMigrations();
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// showMigrations
+// ---------------------------------------------------------------------------
+
+describe('showMigrations', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints executed and pending migrations without throwing', async () => {
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT name')) {
+        return Promise.resolve([
+          { name: 'Migration001', ts: '2024-01-01' },
+          { name: 'Migration002', ts: '2024-01-02' },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await expect(showMigrations()).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('marks executed migrations with a checkmark', async () => {
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT name')) {
+        return Promise.resolve([{ name: 'Migration001', ts: '2024-01-01' }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await showMigrations();
+
+    const allOutput = consoleSpy.mock.calls.flat().join('\n');
+    expect(allOutput).toContain('✓');
+    expect(allOutput).toContain('Migration001');
+  });
+
+  it('marks pending migrations with a dot', async () => {
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT name')) {
+        return Promise.resolve([{ name: 'Migration001', ts: '2024-01-01' }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await showMigrations();
+
+    const allOutput = consoleSpy.mock.calls.flat().join('\n');
+    // Migration002 and Migration003 are pending
+    expect(allOutput).toContain('·');
+    expect(allOutput).toContain('[PENDING]');
+  });
+
+  it('handles empty executed migrations list gracefully', async () => {
+    ds.query.mockResolvedValue([]);
+
+    await expect(showMigrations()).resolves.toBeUndefined();
+  });
+
+  it('handles query failure gracefully (falls back to empty list)', async () => {
+    ds.query.mockRejectedValue(new Error('query failed'));
+
+    await expect(showMigrations()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: run → verify pipeline
+// ---------------------------------------------------------------------------
+
+describe('run → verify pipeline', () => {
+  it('succeeds end-to-end: run pending migrations then verify', async () => {
+    // 1 pending migration (Migration003)
+    // createQueryRunner default (from beforeEach) returns [{ id: 1 }] → table exists
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT name FROM')) {
+        return Promise.resolve([
+          { name: 'Migration001' },
+          { name: 'Migration002' },
+        ]);
+      }
+      if (sql.includes('COUNT(1)')) return Promise.resolve([{ cnt: '3' }]);
+      return Promise.resolve([]);
+    });
+
+    const runResult = await runMigrationsWithRollback();
+    expect(runResult.success).toBe(true);
+    expect(runResult.run).toBe(1);
+
+    const verifyResult = await verifyAfterMigrations();
+    expect(verifyResult.ok).toBe(true);
+  });
+
+  it('does not call verify when run fails', async () => {
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT name FROM')) return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+    ds.runMigrations.mockRejectedValue(new Error('schema conflict'));
+
+    const runResult = await runMigrationsWithRollback();
+    expect(runResult.success).toBe(false);
+
+    // Verify is a separate call — confirm it still works independently
+    // createQueryRunner default returns [{ id: 1 }] → table exists
+    ds.query.mockImplementation((sql: string) => {
+      if (sql.includes('COUNT(1)')) return Promise.resolve([{ cnt: '2' }]);
+      return Promise.resolve([]);
+    });
+    const verifyResult = await verifyAfterMigrations();
+    expect(verifyResult.ok).toBe(true);
+  });
+});

--- a/backend/src/modules/webhooks/webhook.service.spec.ts
+++ b/backend/src/modules/webhooks/webhook.service.spec.ts
@@ -1,5 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { WebhookSignatureService } from './webhook-signature.service';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
+import {
+  WebhookSignatureService,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+} from './webhook-signature.service';
+import { WebhookSignatureGuard } from './guards/webhook-signature.guard';
+import { WEBHOOK_SECRET_METADATA_KEY } from './decorators/webhook-secret.decorator';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SECRET = 'test-secret-key';
+const PAYLOAD = '{"event":"payment.received","amount":100}';
+
+function buildTimestamp(offsetMs = 0): string {
+  return (Date.now() + offsetMs).toString();
+}
+
+// ---------------------------------------------------------------------------
+// WebhookSignatureService unit tests
+// ---------------------------------------------------------------------------
 
 describe('WebhookSignatureService', () => {
   let service: WebhookSignatureService;
@@ -12,54 +36,438 @@ describe('WebhookSignatureService', () => {
     service = module.get<WebhookSignatureService>(WebhookSignatureService);
   });
 
-  it('generates deterministic HMAC signatures', () => {
-    const signatureOne = service.generateSignature(
-      '{"event":"screening.completed"}',
-      '1711453200000',
-      'test-secret',
-    );
-    const signatureTwo = service.generateSignature(
-      '{"event":"screening.completed"}',
-      '1711453200000',
-      'test-secret',
-    );
+  afterEach(() => jest.clearAllMocks());
 
-    expect(signatureOne).toBe(signatureTwo);
+  // ── generateSignature ──────────────────────────────────────────────────────
+
+  describe('generateSignature', () => {
+    it('returns a hex string', () => {
+      const sig = service.generateSignature(PAYLOAD, '1711453200000', SECRET);
+      expect(sig).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('is deterministic for the same inputs', () => {
+      const ts = '1711453200000';
+      expect(service.generateSignature(PAYLOAD, ts, SECRET)).toBe(
+        service.generateSignature(PAYLOAD, ts, SECRET),
+      );
+    });
+
+    it('differs when payload changes', () => {
+      const ts = '1711453200000';
+      const s1 = service.generateSignature(PAYLOAD, ts, SECRET);
+      const s2 = service.generateSignature('{}', ts, SECRET);
+      expect(s1).not.toBe(s2);
+    });
+
+    it('differs when timestamp changes', () => {
+      const s1 = service.generateSignature(PAYLOAD, '1000', SECRET);
+      const s2 = service.generateSignature(PAYLOAD, '2000', SECRET);
+      expect(s1).not.toBe(s2);
+    });
+
+    it('differs when secret changes', () => {
+      const ts = '1711453200000';
+      const s1 = service.generateSignature(PAYLOAD, ts, 'secret-one');
+      const s2 = service.generateSignature(PAYLOAD, ts, 'secret-two');
+      expect(s1).not.toBe(s2);
+    });
+
+    it('produces a 64-character hex string (SHA-256 HMAC)', () => {
+      const sig = service.generateSignature(PAYLOAD, '1711453200000', SECRET);
+      expect(sig).toHaveLength(64);
+    });
+
+    it('handles empty payload', () => {
+      const sig = service.generateSignature('', '1711453200000', SECRET);
+      expect(sig).toHaveLength(64);
+    });
+
+    it('handles unicode payload', () => {
+      const sig = service.generateSignature('日本語', '1711453200000', SECRET);
+      expect(sig).toHaveLength(64);
+    });
   });
 
-  it('rejects unsigned webhooks', () => {
-    expect(() =>
-      service.verifySignature(
-        '{"ok":true}',
-        undefined,
-        undefined,
-        'test-secret',
-      ),
-    ).toThrow('Missing webhook signature');
+  // ── createSignedHeaders ────────────────────────────────────────────────────
+
+  describe('createSignedHeaders', () => {
+    it('returns Content-Type, X-Webhook-Timestamp, and X-Webhook-Signature', () => {
+      const headers = service.createSignedHeaders(PAYLOAD, SECRET);
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['X-Webhook-Timestamp']).toBeDefined();
+      expect(headers['X-Webhook-Signature']).toBeDefined();
+    });
+
+    it('timestamp is a recent Unix ms string', () => {
+      const before = Date.now();
+      const headers = service.createSignedHeaders(PAYLOAD, SECRET);
+      const after = Date.now();
+      const ts = parseInt(headers['X-Webhook-Timestamp'], 10);
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
+    it('signature is valid and verifiable', () => {
+      const headers = service.createSignedHeaders(PAYLOAD, SECRET);
+      expect(() =>
+        service.verifySignature(
+          PAYLOAD,
+          headers['X-Webhook-Signature'],
+          headers['X-Webhook-Timestamp'],
+          SECRET,
+        ),
+      ).not.toThrow();
+    });
+
+    it('produces different signatures on successive calls (fresh timestamp)', async () => {
+      const h1 = service.createSignedHeaders(PAYLOAD, SECRET);
+      await new Promise((r) => setTimeout(r, 2)); // ensure different ms
+      const h2 = service.createSignedHeaders(PAYLOAD, SECRET);
+      // Timestamps should differ (or at minimum signatures should differ due to ts)
+      expect(h1['X-Webhook-Timestamp'] + h1['X-Webhook-Signature']).not.toBe(
+        h2['X-Webhook-Timestamp'] + h2['X-Webhook-Signature'],
+      );
+    });
   });
 
-  it('rejects invalid signatures', () => {
-    expect(() =>
-      service.verifySignature(
-        '{"ok":true}',
-        'deadbeef',
-        Date.now().toString(),
-        'test-secret',
-      ),
-    ).toThrow('Invalid webhook signature');
+  // ── verifySignature ────────────────────────────────────────────────────────
+
+  describe('verifySignature', () => {
+    it('does not throw for a valid signature within tolerance', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, ts, SECRET),
+      ).not.toThrow();
+    });
+
+    it('throws UnauthorizedException when signature header is missing', () => {
+      expect(() =>
+        service.verifySignature(PAYLOAD, undefined, buildTimestamp(), SECRET),
+      ).toThrow('Missing webhook signature');
+    });
+
+    it('throws UnauthorizedException when timestamp header is missing', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, undefined, SECRET),
+      ).toThrow('Missing webhook signature');
+    });
+
+    it('throws UnauthorizedException when both headers are missing', () => {
+      expect(() =>
+        service.verifySignature(PAYLOAD, undefined, undefined, SECRET),
+      ).toThrow('Missing webhook signature');
+    });
+
+    it('throws InternalServerErrorException when secret is undefined', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, ts, undefined),
+      ).toThrow('Webhook secret misconfigured');
+    });
+
+    it('throws InternalServerErrorException when secret is empty string', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() => service.verifySignature(PAYLOAD, sig, ts, '')).toThrow(
+        'Webhook secret misconfigured',
+      );
+    });
+
+    it('throws UnauthorizedException for a non-numeric timestamp', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, 'not-a-number', SECRET),
+      ).toThrow('Invalid webhook timestamp');
+    });
+
+    it('throws UnauthorizedException for a NaN timestamp', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, 'NaN', SECRET),
+      ).toThrow('Invalid webhook timestamp');
+    });
+
+    it('throws UnauthorizedException for a stale timestamp (> 5 min old)', () => {
+      const staleTs = buildTimestamp(-6 * 60 * 1000); // 6 minutes ago
+      const sig = service.generateSignature(PAYLOAD, staleTs, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, staleTs, SECRET),
+      ).toThrow('Webhook timestamp expired');
+    });
+
+    it('throws UnauthorizedException for a future timestamp beyond tolerance', () => {
+      const futureTs = buildTimestamp(6 * 60 * 1000); // 6 minutes in future
+      const sig = service.generateSignature(PAYLOAD, futureTs, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, futureTs, SECRET),
+      ).toThrow('Webhook timestamp expired');
+    });
+
+    it('accepts a timestamp at the edge of the tolerance window', () => {
+      const edgeTs = buildTimestamp(-4 * 60 * 1000 - 50_000); // ~4m50s ago
+      const sig = service.generateSignature(PAYLOAD, edgeTs, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, edgeTs, SECRET),
+      ).not.toThrow();
+    });
+
+    it('throws UnauthorizedException for a wrong signature (all zeros)', () => {
+      const ts = buildTimestamp();
+      expect(() =>
+        service.verifySignature(PAYLOAD, '0'.repeat(64), ts, SECRET),
+      ).toThrow('Invalid webhook signature');
+    });
+
+    it('throws UnauthorizedException for a signature with wrong length', () => {
+      const ts = buildTimestamp();
+      expect(() =>
+        service.verifySignature(PAYLOAD, 'deadbeef', ts, SECRET),
+      ).toThrow('Invalid webhook signature');
+    });
+
+    it('throws UnauthorizedException when payload is tampered after signing', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature('{"tampered":true}', sig, ts, SECRET),
+      ).toThrow('Invalid webhook signature');
+    });
+
+    it('throws UnauthorizedException when secret is wrong', () => {
+      const ts = buildTimestamp();
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, ts, 'wrong-secret'),
+      ).toThrow('Invalid webhook signature');
+    });
+
+    it('respects a custom toleranceMs of 0 (rejects any non-zero age)', () => {
+      const ts = buildTimestamp(-1000); // 1 second ago
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, ts, SECRET, 0),
+      ).toThrow('Webhook timestamp expired');
+    });
+
+    it('respects a custom toleranceMs of 1 hour', () => {
+      const ts = buildTimestamp(-30 * 60 * 1000); // 30 min ago
+      const sig = service.generateSignature(PAYLOAD, ts, SECRET);
+      expect(() =>
+        service.verifySignature(PAYLOAD, sig, ts, SECRET, 60 * 60 * 1000),
+      ).not.toThrow();
+    });
+
+    it('uses timing-safe comparison (no early exit on first byte match)', () => {
+      // This is a behavioural test: a signature that shares the first byte
+      // but differs elsewhere must still be rejected.
+      const ts = buildTimestamp();
+      const validSig = service.generateSignature(PAYLOAD, ts, SECRET);
+      const almostSig = validSig.slice(0, 2) + 'ff' + validSig.slice(4); // mutate bytes 2-3
+      expect(() =>
+        service.verifySignature(PAYLOAD, almostSig, ts, SECRET),
+      ).toThrow('Invalid webhook signature');
+    });
   });
 
-  it('accepts valid signatures inside the tolerance window', () => {
-    const payload = '{"ok":true}';
-    const timestamp = Date.now().toString();
-    const signature = service.generateSignature(
-      payload,
-      timestamp,
-      'test-secret',
+  // ── header constant exports ────────────────────────────────────────────────
+
+  describe('exported header constants', () => {
+    it('WEBHOOK_SIGNATURE_HEADER is lowercase', () => {
+      expect(WEBHOOK_SIGNATURE_HEADER).toBe(
+        WEBHOOK_SIGNATURE_HEADER.toLowerCase(),
+      );
+    });
+
+    it('WEBHOOK_TIMESTAMP_HEADER is lowercase', () => {
+      expect(WEBHOOK_TIMESTAMP_HEADER).toBe(
+        WEBHOOK_TIMESTAMP_HEADER.toLowerCase(),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WebhookSignatureGuard unit tests
+// ---------------------------------------------------------------------------
+
+describe('WebhookSignatureGuard', () => {
+  let guard: WebhookSignatureGuard;
+  let signatureService: WebhookSignatureService;
+  let reflector: jest.Mocked<Reflector>;
+  let configService: jest.Mocked<ConfigService>;
+
+  const buildContext = (
+    overrides: Partial<{
+      signature: string | undefined;
+      timestamp: string | undefined;
+      rawBody: string | undefined;
+      body: Record<string, unknown>;
+    }> = {},
+  ): ExecutionContext => {
+    const req = {
+      header: jest.fn((name: string) => {
+        const lower = name.toLowerCase();
+        if (lower === WEBHOOK_SIGNATURE_HEADER)
+          return overrides.signature ?? undefined;
+        if (lower === WEBHOOK_TIMESTAMP_HEADER)
+          return overrides.timestamp ?? undefined;
+        return undefined;
+      }),
+      rawBody: overrides.rawBody,
+      body: overrides.body ?? {},
+    };
+
+    return {
+      switchToHttp: () => ({ getRequest: () => req }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+  };
+
+  beforeEach(async () => {
+    reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue('WEBHOOK_SIGNATURE_SECRET'),
+    } as unknown as jest.Mocked<Reflector>;
+
+    configService = {
+      get: jest.fn().mockReturnValue(SECRET),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookSignatureGuard,
+        WebhookSignatureService,
+        { provide: Reflector, useValue: reflector },
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    guard = module.get<WebhookSignatureGuard>(WebhookSignatureGuard);
+    signatureService = module.get<WebhookSignatureService>(
+      WebhookSignatureService,
     );
+  });
 
-    expect(() =>
-      service.verifySignature(payload, signature, timestamp, 'test-secret'),
-    ).not.toThrow();
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns true for a valid signed request using rawBody', () => {
+    const ts = buildTimestamp();
+    const sig = signatureService.generateSignature(PAYLOAD, ts, SECRET);
+    const ctx = buildContext({
+      signature: sig,
+      timestamp: ts,
+      rawBody: PAYLOAD,
+    });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('returns true for a valid signed request using JSON.stringify(body)', () => {
+    const body = { event: 'payment.received' };
+    const bodyStr = JSON.stringify(body);
+    const ts = buildTimestamp();
+    const sig = signatureService.generateSignature(bodyStr, ts, SECRET);
+    const ctx = buildContext({ signature: sig, timestamp: ts, body });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('throws UnauthorizedException when signature header is absent', () => {
+    const ctx = buildContext({ timestamp: buildTimestamp(), rawBody: PAYLOAD });
+    expect(() => guard.canActivate(ctx)).toThrow('Missing webhook signature');
+  });
+
+  it('throws UnauthorizedException when timestamp header is absent', () => {
+    const ts = buildTimestamp();
+    const sig = signatureService.generateSignature(PAYLOAD, ts, SECRET);
+    const ctx = buildContext({ signature: sig, rawBody: PAYLOAD });
+    expect(() => guard.canActivate(ctx)).toThrow('Missing webhook signature');
+  });
+
+  it('throws UnauthorizedException for an invalid signature', () => {
+    const ctx = buildContext({
+      signature: '0'.repeat(64),
+      timestamp: buildTimestamp(),
+      rawBody: PAYLOAD,
+    });
+    expect(() => guard.canActivate(ctx)).toThrow('Invalid webhook signature');
+  });
+
+  it('throws UnauthorizedException for a stale timestamp', () => {
+    const staleTs = buildTimestamp(-6 * 60 * 1000);
+    const sig = signatureService.generateSignature(PAYLOAD, staleTs, SECRET);
+    const ctx = buildContext({
+      signature: sig,
+      timestamp: staleTs,
+      rawBody: PAYLOAD,
+    });
+    expect(() => guard.canActivate(ctx)).toThrow('Webhook timestamp expired');
+  });
+
+  it('throws InternalServerErrorException when config secret is missing', () => {
+    configService.get.mockReturnValue(undefined);
+    const ts = buildTimestamp();
+    const sig = signatureService.generateSignature(PAYLOAD, ts, SECRET);
+    const ctx = buildContext({
+      signature: sig,
+      timestamp: ts,
+      rawBody: PAYLOAD,
+    });
+    expect(() => guard.canActivate(ctx)).toThrow(
+      'Webhook secret misconfigured',
+    );
+  });
+
+  it('uses the config key from the @WebhookSecret decorator', () => {
+    reflector.getAllAndOverride.mockReturnValue('KYC_WEBHOOK_SECRET');
+    configService.get.mockImplementation((key: string) =>
+      key === 'KYC_WEBHOOK_SECRET' ? 'kyc-secret' : undefined,
+    );
+    const ts = buildTimestamp();
+    const sig = signatureService.generateSignature(PAYLOAD, ts, 'kyc-secret');
+    const ctx = buildContext({
+      signature: sig,
+      timestamp: ts,
+      rawBody: PAYLOAD,
+    });
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(configService.get).toHaveBeenCalledWith('KYC_WEBHOOK_SECRET');
+  });
+
+  it('falls back to WEBHOOK_SIGNATURE_SECRET when decorator key is not set', () => {
+    reflector.getAllAndOverride.mockReturnValue(null);
+    const ts = buildTimestamp();
+    const sig = signatureService.generateSignature(PAYLOAD, ts, SECRET);
+    const ctx = buildContext({
+      signature: sig,
+      timestamp: ts,
+      rawBody: PAYLOAD,
+    });
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(configService.get).toHaveBeenCalledWith('WEBHOOK_SIGNATURE_SECRET');
+  });
+
+  it('prefers rawBody over JSON.stringify(body) for signature verification', () => {
+    const ts = buildTimestamp();
+    // Sign the rawBody string
+    const sig = signatureService.generateSignature(PAYLOAD, ts, SECRET);
+    // body is different from rawBody — guard must use rawBody
+    const ctx = buildContext({
+      signature: sig,
+      timestamp: ts,
+      rawBody: PAYLOAD,
+      body: { different: 'body' },
+    });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('WEBHOOK_SECRET_METADATA_KEY constant is defined', () => {
+    expect(WEBHOOK_SECRET_METADATA_KEY).toBeDefined();
+    expect(typeof WEBHOOK_SECRET_METADATA_KEY).toBe('string');
   });
 });


### PR DESCRIPTION
1. Sensitive data encryption tests (
encryption.service.spec.ts
)
Comprehensive expansion of the existing spec with ~60 tests covering:

Instantiation — valid single key, multi-key JSON array, missing key, short key (both single and multi-key paths)
encrypt — output format/structure, base64 validity, random IV (non-determinism), long strings, unicode, single char, and all invalid input types (empty, null, undefined, numeric)
decrypt — round-trips for simple/long/unicode/JSON strings, all invalid ciphertext cases, tampered ciphertext (flipped data byte), tampered auth tag, wrong key rejection
Key rotation — key count tracking, new key becomes active, old key still decrypts, multi-rotation chain, invalid key rejection
Multi-key initialisation — correct count, encrypts with newest key, decrypts with older key
Error class identity — EncryptionError and DecryptionFailedError are proper Error instances
2. Webhook signature verification tests (
webhook.service.spec.ts
)
Full rewrite with ~50 tests across two describe blocks:

WebhookSignatureService — determinism, hex output, length (64 chars), sensitivity to payload/timestamp/secret changes, unicode, createSignedHeaders structure and freshness, all verifySignature rejection paths (missing headers, missing secret, non-numeric timestamp, stale/future timestamps, wrong signature, tampered payload, wrong secret, custom tolerance, timing-safe comparison)
WebhookSignatureGuard — valid requests via rawBody and body fallback, all rejection paths, config key from @WebhookSecret decorator, fallback to default key, rawBody preference over body, constant exports
3. Database migration strategy and validation (
migration-runner.spec.ts
)
New spec with ~35 tests fully mocking AppDataSource:

runMigrationsWithRollback — dry-run (pending/none), lock contention, happy path (pending/none/table-absent), auto-rollback on failure, double-failure (run + rollback both fail)
revertLastMigration — lock contention, single revert, revert-to-named (partial, already-at-target, not-found, all), failure handling
verifyAfterMigrations — table exists, table absent, query failure, zero migrations
showMigrations — output format, checkmarks for executed, dots for pending, empty list, query failure
Integration pipeline — run → verify success path, run failure → verify still works independently



closes #911

closes #913

closes #939

closes #937