### PR TITLE
Fix backend auth/storage/exception filter specs and align expectations with actual behavior

### DIFF
--- a/backend/src/common/filters/all-exceptions.filter.spec.ts
+++ b/backend/src/common/filters/all-exceptions.filter.spec.ts
@@ -1,0 +1,92 @@
+import { BadRequestException, HttpException } from '@nestjs/common';
+import { ArgumentsHost } from '@nestjs/common/interfaces';
+import { AllExceptionsFilter } from './all-exceptions.filter';
+import { ErrorCode } from '../errors/error-codes';
+
+const buildArgumentsHost = (request: any, response: any): ArgumentsHost => ({
+  switchToHttp: () => ({
+    getRequest: () => request,
+    getResponse: () => response,
+  }),
+  getType: () => 'http',
+  switchToRpc: jest.fn(),
+  switchToWs: jest.fn(),
+} as unknown as ArgumentsHost);
+
+describe('AllExceptionsFilter', () => {
+  let filter: AllExceptionsFilter;
+  let response: any;
+  let request: any;
+
+  beforeEach(() => {
+    filter = new AllExceptionsFilter();
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    request = {
+      url: '/api/test',
+      method: 'POST',
+      headers: { 'x-request-id': 'request-id' },
+    };
+  });
+
+  it('formats validation errors consistently for ValidationPipe bad requests', () => {
+    const exception = new BadRequestException([
+      'email must be an email',
+      'password must be longer than or equal to 8 characters',
+    ]);
+
+    filter.catch(exception, buildArgumentsHost(request, response));
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 400,
+        message: [
+          'email must be an email',
+          'password must be longer than or equal to 8 characters',
+        ],
+        error: 'Bad Request',
+        code: ErrorCode.VALIDATION_FAILED,
+        path: '/api/test',
+      }),
+    );
+  });
+
+  it('returns generic internal server error shape for unexpected exceptions', () => {
+    const exception = new Error('Unhandled');
+
+    filter.catch(exception, buildArgumentsHost(request, response));
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 500,
+        message: 'An unexpected error occurred',
+        error: 'Internal Server Error',
+        code: ErrorCode.INTERNAL_SERVER_ERROR,
+        path: '/api/test',
+      }),
+    );
+  });
+
+  it('preserves custom HttpException response bodies', () => {
+    const exception = new HttpException(
+      { message: 'Custom body', extra: 'data' },
+      403,
+    );
+
+    filter.catch(exception, buildArgumentsHost(request, response));
+
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Custom body',
+        extra: 'data',
+        path: '/api/test',
+        requestId: 'request-id',
+      }),
+    );
+  });
+});

--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -24,6 +24,7 @@ import { MfaService } from './services/mfa.service';
 import { PasswordPolicyService } from './services/password-policy.service';
 import { RegisterDto } from './dto/register.dto';
 import { Repository } from 'typeorm';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ReferralService } from '../referral/referral.service';
@@ -284,7 +285,7 @@ describe('AuthService', () => {
 
       mockUserRepository.findOne.mockResolvedValue({
         ...mockUser,
-        status: 'inactive',
+        isActive: false,
       });
 
       await expect(service.login(loginDto)).rejects.toThrow(
@@ -300,13 +301,128 @@ describe('AuthService', () => {
 
       const lockedUser = {
         ...mockUser,
-        accountLocked: true,
-        lockedUntil: new Date(Date.now() + 30 * 60 * 1000),
+        accountLockedUntil: new Date(Date.now() + 30 * 60 * 1000),
       };
 
       mockUserRepository.findOne.mockResolvedValue(lockedUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
 
       await expect(service.login(loginDto)).rejects.toThrow(
+        AuthenticationError,
+      );
+      expect(mockUserRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('generateTokens', () => {
+    it('should sign access and refresh tokens with correct claims', () => {
+      mockJwtService.sign.mockReturnValueOnce('access-token');
+      mockJwtService.sign.mockReturnValueOnce('refresh-token');
+
+      const tokens = service.generateTokens(
+        mockUser.id as string,
+        mockUser.email as string,
+        mockUser.role as string,
+      );
+
+      expect(tokens.accessToken).toBe('access-token');
+      expect(tokens.refreshToken).toBe('refresh-token');
+      expect(mockJwtService.sign).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          sub: mockUser.id,
+          email: mockUser.email,
+          role: mockUser.role,
+          type: 'access',
+        }),
+        expect.objectContaining({
+          secret: 'test-secret',
+          expiresIn: '15m',
+        }),
+      );
+      expect(mockJwtService.sign).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          sub: mockUser.id,
+          email: mockUser.email,
+          role: mockUser.role,
+          type: 'refresh',
+        }),
+        expect.objectContaining({
+          secret: 'test-refresh-secret',
+          expiresIn: '7d',
+        }),
+      );
+    });
+  });
+
+  describe('refreshToken', () => {
+    const refreshTokenDto: RefreshTokenDto = {
+      refreshToken: 'refresh-token',
+    };
+
+    it('should refresh tokens and rotate refresh token', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: mockUser.id,
+        email: mockUser.email,
+        role: mockUser.role,
+        type: 'refresh',
+      });
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: 'hashed-refresh-token',
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      mockJwtService.sign.mockReturnValueOnce('new-access-token');
+      mockJwtService.sign.mockReturnValueOnce('new-refresh-token');
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed-new-refresh' as never);
+
+      const result = await service.refreshToken(refreshTokenDto);
+
+      expect(result.accessToken).toBe('new-access-token');
+      expect(result.refreshToken).toBe('new-refresh-token');
+      expect(mockUserRepository.update).toHaveBeenCalledWith(mockUser.id, {
+        refreshToken: 'hashed-new-refresh',
+      });
+    });
+
+    it('should reject refresh tokens with invalid type', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: mockUser.id,
+        email: mockUser.email,
+        role: mockUser.role,
+        type: 'access',
+      });
+
+      await expect(service.refreshToken(refreshTokenDto)).rejects.toThrow(
+        AuthenticationError,
+      );
+    });
+
+    it('should reject invalid refresh tokens when signature verification fails', async () => {
+      mockJwtService.verify.mockImplementation(() => {
+        throw new Error('invalid token');
+      });
+
+      await expect(service.refreshToken(refreshTokenDto)).rejects.toThrow(
+        AuthenticationError,
+      );
+    });
+
+    it('should reject refresh tokens when stored refresh token does not match', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: mockUser.id,
+        email: mockUser.email,
+        role: mockUser.role,
+        type: 'refresh',
+      });
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: 'hashed-refresh-token',
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await expect(service.refreshToken(refreshTokenDto)).rejects.toThrow(
         AuthenticationError,
       );
     });

--- a/backend/src/modules/storage/storage.service.spec.ts
+++ b/backend/src/modules/storage/storage.service.spec.ts
@@ -15,6 +15,10 @@ jest.mock('@aws-sdk/client-s3', () => {
   };
 });
 
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn(async () => 'https://signed-url.example.com'),
+}));
+
 const mockRepo = () => ({
   save: jest.fn(),
   findOne: jest.fn(),
@@ -70,6 +74,107 @@ describe('StorageService', () => {
         60 * 1024 * 1024,
       ),
     ).rejects.toThrow('File too large');
+  });
+
+  it('should generate and store a signed upload URL for valid files', async () => {
+    const result = await service.getUploadUrl(
+      'docs/owner/file.pdf',
+      'application/pdf',
+      'owner',
+      'file.pdf',
+      1024,
+    );
+
+    expect(result).toContain('https://');
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'file.pdf',
+        fileSize: 1024,
+        fileType: 'application/pdf',
+        s3Key: 'docs/owner/file.pdf',
+        ownerId: 'owner',
+      }),
+    );
+  });
+
+  it('should upload a generic document buffer and save metadata', async () => {
+    const sendSpy = jest.spyOn(service['s3'], 'send');
+
+    const result = await service.uploadBuffer(
+      Buffer.from('test content'),
+      'docs/owner/file.pdf',
+      'application/pdf',
+      'owner',
+      'file.pdf',
+    );
+
+    expect(sendSpy).toHaveBeenCalled();
+    expect(result.url).toContain('https://');
+    expect(result.variants).toEqual({});
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'file.pdf',
+        fileSize: 12,
+        fileType: 'application/pdf',
+        s3Key: 'docs/owner/file.pdf',
+        ownerId: 'owner',
+      }),
+    );
+  });
+
+  it('should upload original file when image processing fails', async () => {
+    jest
+      .spyOn(service['imageProcessing'] as any, 'processImage')
+      .mockRejectedValue(new Error('processing failed'));
+    const sendSpy = jest.spyOn(service['s3'], 'send');
+
+    const result = await service.uploadBuffer(
+      Buffer.from('image data'),
+      'images/owner/file.png',
+      'image/png',
+      'owner',
+      'file.png',
+    );
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(result.url).toContain('https://');
+    expect(result.variants).toEqual({});
+  });
+
+  it('should return CDN download URL when CDN is configured', async () => {
+    service['cdnBaseUrl'] = 'https://cdn.example.com';
+    repo.findOne.mockResolvedValue({
+      s3Key: 'docs/owner/file.pdf',
+      ownerId: 'owner',
+    });
+
+    const result = await service.getDownloadUrl('docs/owner/file.pdf', 'owner');
+
+    expect(result).toBe('https://cdn.example.com/docs/owner/file.pdf');
+  });
+
+  it('should delete a file and remove metadata when found', async () => {
+    repo.findOne.mockResolvedValue({
+      s3Key: 'docs/owner/file.pdf',
+      ownerId: 'owner',
+    });
+    jest.spyOn(service['s3'], 'send');
+
+    await service.deleteFile('docs/owner/file.pdf', 'owner');
+
+    expect(service['s3'].send).toHaveBeenCalled();
+    expect(repo.delete).toHaveBeenCalledWith({
+      s3Key: 'docs/owner/file.pdf',
+      ownerId: 'owner',
+    });
+  });
+
+  it('should throw when deleting a missing file', async () => {
+    repo.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.deleteFile('docs/owner/file.pdf', 'owner'),
+    ).rejects.toThrow('File not found or access denied');
   });
 
   it('should throw if download file not found', async () => {


### PR DESCRIPTION
## Summary
This change updates backend test coverage by fixing failing Jest spec expectations and aligning test behavior with the actual implementation of the auth, storage, and exception handling logic.

## Files Changed
- `backend/src/modules/auth/auth.service.spec.ts`
- `backend/src/modules/storage/storage.service.spec.ts`
- `backend/src/common/filters/all-exceptions.filter.spec.ts`

## What Changed
- Adjusted authentication lockout test expectations to reflect that locked accounts fail before save is called.
- Fixed mocked `imageProcessing.processImage` behavior in storage tests using the correct Jest spy/cast.
- Updated exception filter spec expectations to preserve the actual `HttpException` response body shape.
- Added a new backend exception filter spec file.

## Tests Run
- `cd backend && pnpm exec jest --runInBand src/modules/auth/auth.service.spec.ts src/modules/storage/storage.service.spec.ts src/common/filters/all-exceptions.filter.spec.ts`

## Result
- All targeted backend specs passed successfully.

Close #1116
Close #1118
Close #1114
Close #1112