### PR TITLE
feat(backend): production readiness for env validation, shutdown, and…

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -49,10 +49,15 @@ format-check: ## Check code formatting without modifying files
 	npx prettier --check "src/**/*.ts" "test/**/*.ts"
 	@echo "$(GREEN)✓ Format check passed$(NC)"
 
-verify-backup: ## Verify the latest database backup
+verify-backup: ## Verify the latest database backup (set BACKUP_VERIFY_METADATA_ONLY=true for lightweight check)
 	@echo "$(BLUE)Verifying database backup...$(NC)"
 	bash ./scripts/verify-backup.sh
 	@echo "$(GREEN)✓ Backup verification passed$(NC)"
+
+verify-backup-metadata: ## Verify backup file exists and gzip integrity only (no PostgreSQL restore)
+	@echo "$(BLUE)Verifying backup metadata...$(NC)"
+	BACKUP_VERIFY_METADATA_ONLY=true bash ./scripts/verify-backup.sh
+	@echo "$(GREEN)✓ Backup metadata verification passed$(NC)"
 
 typecheck: ## Run TypeScript type checking
 	@echo "$(BLUE)Running TypeScript type checking...$(NC)"

--- a/backend/docs/CONFIGURATION_MANAGEMENT.md
+++ b/backend/docs/CONFIGURATION_MANAGEMENT.md
@@ -176,31 +176,16 @@ Variables are accessed via `ConfigService.get<T>('VARIABLE_NAME')` or directly v
 
 ### Startup Validation
 
-`AppModule` validates rate-limit variables at construction time. If any are missing the application throws and refuses to start:
+`ConfigModule` uses `validateEnvironment` from `src/config/env.validation.ts` at boot time. The application refuses to start when required variables are missing or unsafe for the current `NODE_ENV`.
 
-```typescript
-private validateRateLimitConfig(): void {
-  const required = [
-    'RATE_LIMIT_TTL',
-    'RATE_LIMIT_MAX',
-    'RATE_LIMIT_AUTH_TTL',
-    'RATE_LIMIT_AUTH_MAX',
-    'RATE_LIMIT_STRICT_TTL',
-    'RATE_LIMIT_STRICT_MAX',
-  ];
+- **All environments (except relaxed test):** rate limits, JWT secrets (development+)
+- **Staging / production:** database URL or `DB_*` set, Redis (Upstash or host/port), encryption keys, non-placeholder secrets
 
-  const missing = required.filter((key) => !process.env[key]);
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing required environment variables: ${missing.join(', ')}`,
-    );
-  }
-}
-```
+See [deployment/PRODUCTION_READINESS.md](./deployment/PRODUCTION_READINESS.md) for the operational checklist.
 
 ### Adding Validation for New Variables
 
-To add startup validation for a new required variable, extend the `required` array in `validateRateLimitConfig` or create a dedicated validation method in `AppModule`. For complex validation (type checking, range checks), use a Joi or `class-validator` schema loaded via `ConfigModule.forRoot({ validationSchema })`.
+Extend `validateEnvironment` in `src/config/env.validation.ts` and add cases to `src/config/env.validation.spec.ts`.
 
 Example using Joi:
 

--- a/backend/docs/deployment/BACKUP_VERIFICATION.md
+++ b/backend/docs/deployment/BACKUP_VERIFICATION.md
@@ -1,0 +1,42 @@
+# Backup Verification
+
+Automated verification for PostgreSQL backups used in production readiness (#994).
+
+## Script
+
+`backend/scripts/verify-backup.sh`
+
+| Mode | Command | Requires PostgreSQL |
+| ---- | ------- | ------------------- |
+| Metadata only | `BACKUP_VERIFY_METADATA_ONLY=true make verify-backup` | No |
+| Full restore drill | `make verify-backup` | Yes |
+
+### Metadata-only checks
+
+- Latest `backup_*.sql.gz` exists under `BACKUP_DIR` (default `/var/backups/chioma`)
+- File is readable and passes `gunzip -t`
+- File size is at least 1 KB
+
+### Full verification
+
+1. Creates temporary database `chioma_verify_<timestamp>`
+2. Restores the latest gzip SQL dump
+3. Queries `SELECT COUNT(*) FROM "user"`
+4. Drops the temporary database on exit
+
+## Environment variables
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `BACKUP_DIR` | `/var/backups/chioma` | Directory containing backup files |
+| `BACKUP_VERIFY_METADATA_ONLY` | `false` | Skip restore when `true` |
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_USERNAME` | `postgres` | PostgreSQL user |
+| `DB_PASSWORD` | — | PostgreSQL password |
+
+## Scheduling
+
+Run metadata verification daily in CI or cron. Run full restore verification weekly in staging.
+
+See [BACKUP_AND_RECOVERY.md](./BACKUP_AND_RECOVERY.md) for backup creation and retention policies.

--- a/backend/docs/deployment/PRODUCTION_READINESS.md
+++ b/backend/docs/deployment/PRODUCTION_READINESS.md
@@ -1,0 +1,106 @@
+# Backend Production Readiness
+
+Operational checklist for backend infrastructure issues aimed at production deployment.
+Use this guide when working on production-readiness GitHub issues (for example #957, #988, #991, #994).
+
+## Issue mapping
+
+| Issue | Focus | Implementation |
+| ----- | ----- | -------------- |
+| #957 | Startup safety | `src/config/env.validation.ts` — fails fast on missing/weak config in staging/production |
+| #988 | Graceful shutdown | `src/config/graceful-shutdown.ts` — SIGTERM/SIGINT for Kubernetes rollouts |
+| #994 | Backup verification | `scripts/verify-backup.sh` + `make verify-backup` |
+| #991 | This runbook | Pre-deploy checklist, CI commands, staging/production verification |
+
+## Pre-PR checklist (contributors)
+
+1. Copy and configure environment: `cp .env.example .env` (local) or set platform secrets (staging/production).
+2. Run full CI from `backend/`:
+   ```bash
+   make ci
+   ```
+3. For security-sensitive changes:
+   ```bash
+   make security-ci
+   ```
+4. Add or update tests for new behaviour.
+5. Update documentation (this file and linked guides).
+6. Open a PR with `Closes #<issue>` in the description.
+
+## Pre-deploy checklist (staging / production)
+
+### Configuration (#957)
+
+- [ ] `NODE_ENV` is `staging` or `production`
+- [ ] `JWT_SECRET` and `JWT_REFRESH_SECRET` are unique, ≥32 characters, not example values
+- [ ] `DATABASE_URL` includes `sslmode=require` (or `DB_SSL=true` with individual `DB_*` vars)
+- [ ] Redis: `REDIS_URL` + `REDIS_TOKEN` (Upstash) or `REDIS_HOST` + `REDIS_PORT`
+- [ ] `ENCRYPTION_KEY_BASE64` or `ENCRYPTION_KEYS` configured
+- [ ] `SECURITY_ENCRYPTION_KEY` is 64 hex characters
+- [ ] Application starts without `Config validation failed` in logs
+
+### Process lifecycle (#988)
+
+- [ ] Kubernetes deployment uses `preStop` sleep (recommended) and sends SIGTERM on rollout
+- [ ] Liveness: `GET /health`
+- [ ] Readiness: `GET /health/detailed`
+- [ ] Rollout completes with zero failed pods; no connection reset spikes in logs
+
+### Backups (#994)
+
+- [ ] Automated backups run on schedule (see [BACKUP_AND_RECOVERY.md](./BACKUP_AND_RECOVERY.md))
+- [ ] Metadata check (no DB required):
+  ```bash
+  BACKUP_VERIFY_METADATA_ONLY=true make verify-backup
+  ```
+- [ ] Full restore drill (requires PostgreSQL):
+  ```bash
+  make verify-backup
+  ```
+
+### Observability
+
+- [ ] `SENTRY_DSN` set for production error tracking
+- [ ] Log level `info` or `warn` in production (`LOG_LEVEL`)
+- [ ] Health endpoints reachable from load balancer / ingress
+
+## Verification commands
+
+```bash
+cd backend
+
+# Full contributor CI
+make ci
+
+# Pre-commit subset
+make pre-commit
+
+# Backup metadata only
+BACKUP_VERIFY_METADATA_ONLY=true make verify-backup
+
+# Build production artefact
+make build
+```
+
+## Staging verification
+
+1. Deploy branch to staging.
+2. Confirm `/health` returns `ok` and `/health/detailed` shows database + dependencies.
+3. Trigger a rolling restart; confirm graceful shutdown log lines and no 5xx spike.
+4. Run metadata backup verification against staging backup volume.
+
+## Production verification
+
+1. Repeat staging checks on production URLs.
+2. Confirm secrets differ from staging (JWT, encryption keys, DB credentials).
+3. Record backup verification timestamp in your ops log.
+4. Monitor Sentry and application logs for 15–30 minutes post-deploy.
+
+## Related documentation
+
+- [CONFIGURATION_MANAGEMENT.md](../CONFIGURATION_MANAGEMENT.md)
+- [CONFIGURATION_OPTIONS.md](../CONFIGURATION_OPTIONS.md)
+- [PRODUCTION_SETUP.md](./PRODUCTION_SETUP.md)
+- [BACKUP_AND_RECOVERY.md](./BACKUP_AND_RECOVERY.md)
+- [RESILIENCE.md](../RESILIENCE.md)
+- [INCIDENT_RESPONSE.md](../INCIDENT_RESPONSE.md)

--- a/backend/scripts/verify-backup.sh
+++ b/backend/scripts/verify-backup.sh
@@ -1,44 +1,95 @@
 #!/bin/bash
 # Backup Verification Script
-# This script finds the latest backup file, restores it to a temporary database,
-# and performs a basic validation query to ensure the backup is valid.
+# Finds the latest backup, optionally restores to a temporary database,
+# and validates schema integrity.
+#
+# Usage:
+#   ./scripts/verify-backup.sh              # Full restore + validation
+#   BACKUP_VERIFY_METADATA_ONLY=true ./scripts/verify-backup.sh
+#
+# Environment:
+#   BACKUP_DIR                  Backup directory (default: /var/backups/chioma)
+#   BACKUP_VERIFY_METADATA_ONLY When "true", only checks file presence and gzip integrity
+#   DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD  PostgreSQL connection
 
-set -e
+set -euo pipefail
 
 BACKUP_DIR="${BACKUP_DIR:-/var/backups/chioma}"
 DB_HOST="${DB_HOST:-localhost}"
 DB_PORT="${DB_PORT:-5432}"
 DB_USERNAME="${DB_USERNAME:-postgres}"
-TEMP_DB="chioma_verify_$(date +%s)"
+METADATA_ONLY="${BACKUP_VERIFY_METADATA_ONLY:-false}"
 
-echo "Starting automated backup verification..."
+usage() {
+  cat <<'EOF'
+Chioma backup verification
 
-# 1. Find the latest backup file
-LATEST_BACKUP=$(ls -t "$BACKUP_DIR"/backup_*.sql.gz 2>/dev/null | head -n 1)
+  ./scripts/verify-backup.sh
+      Full verification: restore latest backup to a temp DB and query schema.
 
-if [ -z "$LATEST_BACKUP" ]; then
+  BACKUP_VERIFY_METADATA_ONLY=true ./scripts/verify-backup.sh
+      Lightweight check: confirm latest backup exists and gzip is valid.
+
+Environment:
+  BACKUP_DIR, DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD
+  BACKUP_VERIFY_METADATA_ONLY=true|false
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+echo "Starting backup verification (metadata_only=${METADATA_ONLY})..."
+
+LATEST_BACKUP=$(ls -t "$BACKUP_DIR"/backup_*.sql.gz 2>/dev/null | head -n 1 || true)
+
+if [[ -z "$LATEST_BACKUP" ]]; then
   echo "Error: No backup files found in $BACKUP_DIR"
   exit 1
 fi
 
 echo "Found latest backup: $LATEST_BACKUP"
 
-# Export password if needed
-if [ -n "$DB_PASSWORD" ]; then
+if [[ ! -r "$LATEST_BACKUP" ]]; then
+  echo "Error: Backup file is not readable: $LATEST_BACKUP"
+  exit 1
+fi
+
+echo "Checking gzip integrity..."
+if ! gunzip -t "$LATEST_BACKUP"; then
+  echo "Error: Backup file failed gzip integrity check"
+  exit 1
+fi
+
+BACKUP_SIZE=$(stat -c%s "$LATEST_BACKUP" 2>/dev/null || stat -f%z "$LATEST_BACKUP")
+if [[ "$BACKUP_SIZE" -lt 1024 ]]; then
+  echo "Error: Backup file is suspiciously small (${BACKUP_SIZE} bytes)"
+  exit 1
+fi
+
+echo "Backup metadata OK (size=${BACKUP_SIZE} bytes)"
+
+if [[ "$METADATA_ONLY" == "true" ]]; then
+  echo "✓ Metadata-only backup verification completed successfully"
+  exit 0
+fi
+
+TEMP_DB="chioma_verify_$(date +%s)"
+
+if [[ -n "${DB_PASSWORD:-}" ]]; then
   export PGPASSWORD="${DB_PASSWORD}"
 fi
 
-# 2. Check if postgres is reachable
 if ! pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" > /dev/null 2>&1; then
   echo "Error: PostgreSQL is not reachable at $DB_HOST:$DB_PORT"
   exit 1
 fi
 
-# 3. Create a temporary database
 echo "Creating temporary database: $TEMP_DB"
 createdb -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" "$TEMP_DB"
 
-# Ensure cleanup on exit
 cleanup() {
   echo "Cleaning up..."
   dropdb -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" "$TEMP_DB" > /dev/null 2>&1 || true
@@ -46,23 +97,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# 4. Restore the backup
 echo "Restoring backup to temporary database..."
 gunzip -c "$LATEST_BACKUP" | psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$TEMP_DB" -v ON_ERROR_STOP=1 -q
 
-# 5. Run a validation query
 echo "Running validation queries..."
-# Try to query the users table (we wrap in single quotes to handle potential schema names or uppercase)
-USER_COUNT=$(psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$TEMP_DB" -t -c "SELECT COUNT(*) FROM \"user\"" 2>/dev/null || echo "ERROR")
+USER_COUNT=$(psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$TEMP_DB" -t -c 'SELECT COUNT(*) FROM "user"' 2>/dev/null || echo "ERROR")
 
-if [ "$USER_COUNT" = "ERROR" ]; then
-  echo "Validation failed: Could not query the 'user' table. Schema might be corrupted or missing."
+if [[ "$USER_COUNT" == "ERROR" ]]; then
+  echo "Error: Could not query the user table. Schema may be corrupted or missing."
   exit 1
 fi
 
-USER_COUNT=$(echo "$USER_COUNT" | xargs) # trim whitespace
-
-echo "Validation successful. Found $USER_COUNT users in the backup."
-echo "✓ Backup verification completed successfully"
+USER_COUNT=$(echo "$USER_COUNT" | xargs)
+echo "Validation successful. Found ${USER_COUNT} users in the backup."
+echo "✓ Full backup verification completed successfully"
 
 exit 0

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { validateEnvironment } from './config/env.validation';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD, APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
@@ -70,6 +71,7 @@ const appLogger = new Logger('AppModule');
     ...(process.env.NODE_ENV === 'test' ? [] : [SentryModule.forRoot()]),
     ConfigModule.forRoot({
       isGlobal: true,
+      validate: validateEnvironment,
     }),
     LoggerModule,
     LockModule,
@@ -286,30 +288,6 @@ const appLogger = new Logger('AppModule');
   ],
 })
 export class AppModule implements NestModule {
-  constructor() {
-    appLogger.log('Validating rate limit config');
-    this.validateRateLimitConfig();
-    appLogger.log('Rate limit config validation passed');
-  }
-
-  private validateRateLimitConfig(): void {
-    const required = [
-      'RATE_LIMIT_TTL',
-      'RATE_LIMIT_MAX',
-      'RATE_LIMIT_AUTH_TTL',
-      'RATE_LIMIT_AUTH_MAX',
-      'RATE_LIMIT_STRICT_TTL',
-      'RATE_LIMIT_STRICT_MAX',
-    ];
-
-    const missing = required.filter((key) => !process.env[key]);
-    if (missing.length > 0) {
-      throw new Error(
-        `Missing required environment variables: ${missing.join(', ')}`,
-      );
-    }
-  }
-
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(LocalizationMiddleware).forRoutes('*');
 

--- a/backend/src/config/env.validation.spec.ts
+++ b/backend/src/config/env.validation.spec.ts
@@ -1,0 +1,99 @@
+import { validateEnvironment } from './env.validation';
+
+const baseRateLimits = {
+  RATE_LIMIT_TTL: '60000',
+  RATE_LIMIT_MAX: '100',
+  RATE_LIMIT_AUTH_TTL: '60000',
+  RATE_LIMIT_AUTH_MAX: '5',
+  RATE_LIMIT_STRICT_TTL: '60000',
+  RATE_LIMIT_STRICT_MAX: '10',
+};
+
+const validJwt = {
+  JWT_SECRET: 'a'.repeat(32),
+  JWT_REFRESH_SECRET: 'b'.repeat(32),
+};
+
+const validProduction = {
+  NODE_ENV: 'production',
+  ...baseRateLimits,
+  ...validJwt,
+  DATABASE_URL: 'postgresql://user:pass@host/db?sslmode=require',
+  REDIS_URL: 'https://example.upstash.io',
+  REDIS_TOKEN: 'token',
+  ENCRYPTION_KEY_BASE64: Buffer.alloc(32, 1).toString('base64'),
+  SECURITY_ENCRYPTION_KEY: 'a'.repeat(64),
+  PAYMENT_METADATA_SECRET: 'prod-payment-metadata-secret-value',
+};
+
+describe('validateEnvironment', () => {
+  it('passes for test environment with rate limits only', () => {
+    expect(() =>
+      validateEnvironment({
+        NODE_ENV: 'test',
+        ...baseRateLimits,
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects missing rate limit variables', () => {
+    expect(() =>
+      validateEnvironment({
+        NODE_ENV: 'test',
+        RATE_LIMIT_TTL: '60000',
+      }),
+    ).toThrow(/RATE_LIMIT_MAX/);
+  });
+
+  it('rejects production config with placeholder JWT secrets', () => {
+    expect(() =>
+      validateEnvironment({
+        ...validProduction,
+        JWT_SECRET: 'your-super-secret-key-minimum-32-characters-long',
+      }),
+    ).toThrow(/placeholder/i);
+  });
+
+  it('rejects production config without database settings', () => {
+    expect(() =>
+      validateEnvironment({
+        ...validProduction,
+        DATABASE_URL: undefined,
+        DB_HOST: undefined,
+      }),
+    ).toThrow(/Database config required/);
+  });
+
+  it('rejects production config without redis settings', () => {
+    expect(() =>
+      validateEnvironment({
+        ...validProduction,
+        REDIS_URL: undefined,
+        REDIS_TOKEN: undefined,
+        REDIS_HOST: undefined,
+      }),
+    ).toThrow(/Redis config required/);
+  });
+
+  it('accepts valid production configuration', () => {
+    expect(() => validateEnvironment(validProduction)).not.toThrow();
+  });
+
+  it('accepts staging with classic redis host', () => {
+    expect(() =>
+      validateEnvironment({
+        NODE_ENV: 'staging',
+        ...baseRateLimits,
+        ...validJwt,
+        DB_HOST: 'localhost',
+        DB_USERNAME: 'postgres',
+        DB_PASSWORD: 'secret',
+        DB_NAME: 'chioma',
+        REDIS_HOST: 'localhost',
+        REDIS_PORT: '6379',
+        ENCRYPTION_KEY_BASE64: Buffer.alloc(32, 2).toString('base64'),
+        SECURITY_ENCRYPTION_KEY: 'c'.repeat(64),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -1,0 +1,239 @@
+/**
+ * Startup environment validation for production readiness.
+ * Wired into ConfigModule.forRoot({ validate }) so misconfiguration fails fast.
+ */
+
+const PLACEHOLDER_SECRETS = [
+  'your-super-secret-key-minimum-32-characters-long',
+  'your-super-refresh-secret-key-minimum-32-characters',
+  'default-encryption-key-change-in-production',
+  'change_me',
+  'password',
+];
+
+const INSECURE_JWT_PREFIXES = ['test-jwt', 'e2e-jwt'];
+
+export type NodeEnv = 'development' | 'staging' | 'production' | 'test';
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isPlaceholderSecret(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return PLACEHOLDER_SECRETS.some(
+    (p) =>
+      normalized === p.toLowerCase() || normalized.includes(p.toLowerCase()),
+  );
+}
+
+function validateJwtSecret(
+  name: string,
+  value: unknown,
+  errors: string[],
+): void {
+  if (!isNonEmpty(value)) {
+    errors.push(`${name} is required`);
+    return;
+  }
+  if (value.length < 32) {
+    errors.push(`${name} must be at least 32 characters`);
+  }
+}
+
+function validateSecurityEncryptionKey(
+  value: unknown,
+  errors: string[],
+  strict: boolean,
+): void {
+  if (!isNonEmpty(value)) {
+    if (strict) {
+      errors.push('SECURITY_ENCRYPTION_KEY is required in staging/production');
+    }
+    return;
+  }
+  if (!/^[0-9a-f]{64}$/i.test(value)) {
+    errors.push('SECURITY_ENCRYPTION_KEY must be 64 hexadecimal characters');
+  }
+  if (strict && isPlaceholderSecret(value)) {
+    errors.push('SECURITY_ENCRYPTION_KEY must not use a placeholder value');
+  }
+}
+
+function validateDatabase(
+  config: Record<string, unknown>,
+  errors: string[],
+): void {
+  const hasUrl = isNonEmpty(config.DATABASE_URL);
+  const hasParts =
+    isNonEmpty(config.DB_HOST) &&
+    isNonEmpty(config.DB_USERNAME) &&
+    isNonEmpty(config.DB_PASSWORD) &&
+    isNonEmpty(config.DB_NAME);
+
+  if (!hasUrl && !hasParts) {
+    errors.push(
+      'Database config required: set DATABASE_URL or DB_HOST, DB_USERNAME, DB_PASSWORD, and DB_NAME',
+    );
+  }
+
+  if (hasUrl && !String(config.DATABASE_URL).includes('sslmode=')) {
+    errors.push(
+      'DATABASE_URL should include sslmode=require for managed PostgreSQL',
+    );
+  }
+}
+
+function validateRedis(
+  config: Record<string, unknown>,
+  errors: string[],
+): void {
+  const hasUpstash =
+    isNonEmpty(config.REDIS_URL) && isNonEmpty(config.REDIS_TOKEN);
+  const hasClassic =
+    isNonEmpty(config.REDIS_HOST) && isNonEmpty(config.REDIS_PORT);
+
+  if (!hasUpstash && !hasClassic) {
+    errors.push(
+      'Redis config required: set REDIS_URL + REDIS_TOKEN (Upstash) or REDIS_HOST + REDIS_PORT',
+    );
+  }
+}
+
+function validateEncryptionKeys(
+  config: Record<string, unknown>,
+  errors: string[],
+): void {
+  const keysJson = config.ENCRYPTION_KEYS;
+  const keyB64 = config.ENCRYPTION_KEY_BASE64;
+
+  if (isNonEmpty(keysJson)) {
+    try {
+      const parsed = JSON.parse(keysJson) as unknown;
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        errors.push(
+          'ENCRYPTION_KEYS must be a non-empty JSON array of base64 keys',
+        );
+      }
+    } catch {
+      errors.push('ENCRYPTION_KEYS must be valid JSON');
+    }
+    return;
+  }
+
+  if (!isNonEmpty(keyB64)) {
+    errors.push('ENCRYPTION_KEY_BASE64 or ENCRYPTION_KEYS is required');
+    return;
+  }
+
+  try {
+    const buf = Buffer.from(keyB64, 'base64');
+    if (buf.length !== 32) {
+      errors.push('ENCRYPTION_KEY_BASE64 must decode to exactly 32 bytes');
+    }
+  } catch {
+    errors.push('ENCRYPTION_KEY_BASE64 must be valid base64');
+  }
+}
+
+function validateProductionSecrets(
+  config: Record<string, unknown>,
+  errors: string[],
+): void {
+  if (
+    isNonEmpty(config.JWT_SECRET) &&
+    isNonEmpty(config.JWT_REFRESH_SECRET) &&
+    config.JWT_SECRET === config.JWT_REFRESH_SECRET
+  ) {
+    errors.push('JWT_REFRESH_SECRET must differ from JWT_SECRET');
+  }
+
+  for (const key of ['JWT_SECRET', 'JWT_REFRESH_SECRET'] as const) {
+    const value = config[key];
+    if (!isNonEmpty(value)) {
+      continue;
+    }
+    if (isPlaceholderSecret(value)) {
+      errors.push(`${key} must not use a placeholder or example value`);
+    }
+    const lower = value.toLowerCase();
+    if (INSECURE_JWT_PREFIXES.some((p) => lower.startsWith(p))) {
+      errors.push(`${key} must not use test-only values in staging/production`);
+    }
+  }
+
+  const paymentMeta = config.PAYMENT_METADATA_SECRET;
+  if (isNonEmpty(paymentMeta) && isPlaceholderSecret(paymentMeta)) {
+    errors.push('PAYMENT_METADATA_SECRET must not use a placeholder value');
+  }
+}
+
+/**
+ * Validates environment variables before the NestJS application boots.
+ * @throws Error when validation fails
+ */
+export function validateEnvironment(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const nodeEnv = (config.NODE_ENV ??
+    process.env.NODE_ENV ??
+    'development') as NodeEnv;
+  const errors: string[] = [];
+
+  const rateLimitKeys = [
+    'RATE_LIMIT_TTL',
+    'RATE_LIMIT_MAX',
+    'RATE_LIMIT_AUTH_TTL',
+    'RATE_LIMIT_AUTH_MAX',
+    'RATE_LIMIT_STRICT_TTL',
+    'RATE_LIMIT_STRICT_MAX',
+  ];
+
+  for (const key of rateLimitKeys) {
+    if (!isNonEmpty(config[key])) {
+      errors.push(`${key} is required`);
+    }
+  }
+
+  if (nodeEnv === 'test') {
+    if (errors.length > 0) {
+      throw new Error(`Config validation failed:\n${errors.join('\n')}`);
+    }
+    return config;
+  }
+
+  validateJwtSecret('JWT_SECRET', config.JWT_SECRET, errors);
+  validateJwtSecret('JWT_REFRESH_SECRET', config.JWT_REFRESH_SECRET, errors);
+
+  const isDeployed = nodeEnv === 'production' || nodeEnv === 'staging';
+
+  if (isDeployed) {
+    validateProductionSecrets(config, errors);
+    validateDatabase(config, errors);
+    validateRedis(config, errors);
+    validateEncryptionKeys(config, errors);
+    validateSecurityEncryptionKey(config.SECURITY_ENCRYPTION_KEY, errors, true);
+
+    if (
+      nodeEnv === 'production' &&
+      config.DB_SSL !== 'true' &&
+      !isNonEmpty(config.DATABASE_URL)
+    ) {
+      errors.push(
+        'DB_SSL=true is required in production when not using DATABASE_URL',
+      );
+    }
+  } else {
+    validateSecurityEncryptionKey(
+      config.SECURITY_ENCRYPTION_KEY,
+      errors,
+      false,
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Config validation failed:\n${errors.join('\n')}`);
+  }
+
+  return config;
+}

--- a/backend/src/config/graceful-shutdown.spec.ts
+++ b/backend/src/config/graceful-shutdown.spec.ts
@@ -1,0 +1,47 @@
+import { INestApplication, Logger } from '@nestjs/common';
+import { registerGracefulShutdown } from './graceful-shutdown';
+
+describe('registerGracefulShutdown', () => {
+  const originalListeners = {
+    SIGTERM: process.listeners('SIGTERM'),
+    SIGINT: process.listeners('SIGINT'),
+  };
+
+  afterEach(() => {
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+    for (const listener of originalListeners.SIGTERM) {
+      process.on('SIGTERM', listener);
+    }
+    for (const listener of originalListeners.SIGINT) {
+      process.on('SIGINT', listener);
+    }
+  });
+
+  it('enables shutdown hooks and registers signal handlers', async () => {
+    const close = jest.fn().mockResolvedValue(undefined);
+    const enableShutdownHooks = jest.fn();
+    const app = {
+      close,
+      enableShutdownHooks,
+    } as unknown as INestApplication;
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as typeof process.exit);
+
+    const shutdown = registerGracefulShutdown(app, {
+      logger: new Logger('TestShutdown'),
+    });
+
+    expect(enableShutdownHooks).toHaveBeenCalled();
+    expect(process.listeners('SIGTERM').length).toBeGreaterThan(0);
+
+    await shutdown('SIGTERM');
+
+    expect(close).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    exitSpy.mockRestore();
+  });
+});

--- a/backend/src/config/graceful-shutdown.ts
+++ b/backend/src/config/graceful-shutdown.ts
@@ -1,0 +1,59 @@
+import { INestApplication, Logger } from '@nestjs/common';
+
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+export interface GracefulShutdownOptions {
+  /** Max time to wait for in-flight requests before forcing exit */
+  timeoutMs?: number;
+  logger?: Logger;
+}
+
+/**
+ * Registers SIGTERM/SIGINT handlers for zero-downtime Kubernetes deploys.
+ * Enables Nest lifecycle hooks so TypeORM, Bull, and other modules close cleanly.
+ */
+export function registerGracefulShutdown(
+  app: INestApplication,
+  options: GracefulShutdownOptions = {},
+): (signal: string) => Promise<void> {
+  const logger = options.logger ?? new Logger('GracefulShutdown');
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+
+  app.enableShutdownHooks();
+
+  let shuttingDown = false;
+
+  const shutdown = async (signal: string) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    logger.log(`Received ${signal}, starting graceful shutdown`);
+
+    const forceExitTimer = setTimeout(() => {
+      logger.error(`Shutdown timed out after ${timeoutMs}ms, forcing exit`);
+      process.exit(1);
+    }, timeoutMs);
+    forceExitTimer.unref();
+
+    try {
+      await app.close();
+      clearTimeout(forceExitTimer);
+      logger.log('Application closed successfully');
+      process.exit(0);
+    } catch (error) {
+      clearTimeout(forceExitTimer);
+      logger.error('Error during graceful shutdown', error as Error);
+      process.exit(1);
+    }
+  };
+
+  process.once('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
+  process.once('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
+
+  return shutdown;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -26,6 +26,7 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { RateLimitInterceptor } from './common/interceptors/rate-limit.interceptor';
 import { ConfigService } from '@nestjs/config';
 import { LoggerService } from './common/services/logger.service';
+import { registerGracefulShutdown } from './config/graceful-shutdown';
 
 const bootstrapLogger = new Logger('Bootstrap');
 
@@ -204,6 +205,8 @@ async function bootstrap() {
     },
     customSiteTitle: 'Chioma API Docs',
   });
+
+  registerGracefulShutdown(app, { logger: bootstrapLogger });
 
   const port = process.env.PORT ?? 5000;
   await app.listen(port);


### PR DESCRIPTION
## Summary

Backend production-readiness work for operational deployment:

- **#957** — Startup environment validation (`env.validation.ts`) so staging/production fail fast on missing or unsafe configuration
- **#988** — Graceful shutdown on SIGTERM/SIGINT for zero-downtime Kubernetes rollouts
- **#994** — Backup verification improvements (gzip integrity, metadata-only mode, `make verify-backup-metadata`)
- **#991** — Production readiness runbook and backup verification documentation

Closes #957
Closes #988
Closes #991
Closes #994

## Changes

| Area | Files |
|------|-------|
| Env validation | `backend/src/config/env.validation.ts`, `app.module.ts` |
| Graceful shutdown | `backend/src/config/graceful-shutdown.ts`, `main.ts` |
| Backups | `backend/scripts/verify-backup.sh`, `Makefile` |
| Docs | `PRODUCTION_READINESS.md`, `BACKUP_VERIFICATION.md`, `CONFIGURATION_MANAGEMENT.md` |
| Tests | `env.validation.spec.ts`, `graceful-shutdown.spec.ts` |

## Test plan

- [x] `cd backend && make ci`
- [ ] Deploy to staging; confirm app starts without config validation errors
- [ ] Verify `GET /health` and `GET /health/detailed`
- [ ] Rolling restart — confirm graceful shutdown logs, no 5xx spike
- [ ] `make verify-backup-metadata` against staging backup volume
- [ ] Full `make verify-backup` restore drill (weekly ops)
- [ ] Production verification after staging sign-off

## Related commands

```bash
cd backend
make ci
make verify-backup-metadata
make verify-backup