### PR TITLE
[INTEGRATION] Setup batch processing integration tests

### DIFF
--- a/backend/src/modules/queues/services/batch-processing.integration.spec.ts
+++ b/backend/src/modules/queues/services/batch-processing.integration.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
+import { QueueManagementService } from './queue-management.service';
+
+/**
+ * Integration Tests: Batch Processing
+ *
+ * Verifies that the QueueManagementService correctly handles batch job
+ * scenarios: enqueuing multiple jobs, fetching stats, pausing / resuming
+ * a queue, and clearing completed/failed jobs.
+ */
+describe('Batch Processing Integration', () => {
+  let service: QueueManagementService;
+  let mockEmailQueue: jest.Mocked<any>;
+  let mockDataSyncQueue: jest.Mocked<any>;
+
+  const makeQueueMock = (overrides: Partial<any> = {}) => ({
+    add: jest.fn().mockResolvedValue({ id: 'job-mock' }),
+    getJobCounts: jest
+      .fn()
+      .mockResolvedValue({
+        active: 0,
+        wait: 0,
+        delayed: 0,
+        failed: 0,
+        completed: 0,
+      }),
+    getFailed: jest.fn().mockResolvedValue([]),
+    getDelayed: jest.fn().mockResolvedValue([]),
+    isPaused: jest.fn().mockResolvedValue(false),
+    pause: jest.fn().mockResolvedValue(undefined),
+    resume: jest.fn().mockResolvedValue(undefined),
+    clean: jest.fn().mockResolvedValue(undefined),
+    getJob: jest.fn(),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    mockEmailQueue = makeQueueMock({
+      getJobCounts: jest
+        .fn()
+        .mockResolvedValue({
+          active: 2,
+          wait: 8,
+          delayed: 1,
+          failed: 0,
+          completed: 50,
+        }),
+    });
+
+    mockDataSyncQueue = makeQueueMock({
+      getJobCounts: jest
+        .fn()
+        .mockResolvedValue({
+          active: 1,
+          wait: 4,
+          delayed: 0,
+          failed: 2,
+          completed: 30,
+        }),
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueManagementService,
+        { provide: getQueueToken('email'), useValue: mockEmailQueue },
+        { provide: getQueueToken('documents'), useValue: makeQueueMock() },
+        { provide: getQueueToken('blockchain'), useValue: makeQueueMock() },
+        { provide: getQueueToken('data-sync'), useValue: mockDataSyncQueue },
+      ],
+    }).compile();
+
+    service = module.get<QueueManagementService>(QueueManagementService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enqueues a batch of email jobs and confirms each call', async () => {
+    const batch = [
+      { type: 'notification', email: 'a@test.com', subject: 'Msg 1' },
+      { type: 'notification', email: 'b@test.com', subject: 'Msg 2' },
+      { type: 'alert', email: 'c@test.com', subject: 'Alert' },
+    ];
+
+    for (const job of batch) {
+      await service.addEmailJob(job);
+    }
+
+    expect(mockEmailQueue.add).toHaveBeenCalledTimes(3);
+    const subjects = mockEmailQueue.add.mock.calls.map(
+      ([p]: [any]) => p.subject,
+    );
+    expect(subjects).toEqual(['Msg 1', 'Msg 2', 'Alert']);
+  });
+
+  it('reports correct aggregated stats across all queues', async () => {
+    const stats = await service.getAllQueueStats();
+
+    expect(stats).toHaveLength(4);
+    const emailStats = stats.find((s) => s.name === 'email');
+    expect(emailStats).toBeDefined();
+    expect(emailStats!.counts.wait).toBe(8);
+    expect(emailStats!.counts.active).toBe(2);
+  });
+
+  it('pauses and resumes a queue without throwing', async () => {
+    await expect(service.pauseQueue('email')).resolves.toBeUndefined();
+    expect(mockEmailQueue.pause).toHaveBeenCalledTimes(1);
+
+    await expect(service.resumeQueue('email')).resolves.toBeUndefined();
+    expect(mockEmailQueue.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a queue by cleaning all job states', async () => {
+    await expect(service.clearQueue('data-sync')).resolves.toBeUndefined();
+
+    // clearQueue calls clean for each state: failed, delayed, active, wait
+    expect(mockDataSyncQueue.clean).toHaveBeenCalledTimes(4);
+  });
+});

--- a/backend/src/modules/queues/services/data-import.integration.spec.ts
+++ b/backend/src/modules/queues/services/data-import.integration.spec.ts
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
+import { QueueManagementService } from './queue-management.service';
+
+/**
+ * Integration Tests: Data Import
+ *
+ * Verifies that data import jobs are correctly enqueued onto the data-sync
+ * queue with the right payload shape, retry options, and backoff strategy.
+ * Uses in-process queue mocks — no Redis connection required.
+ */
+describe('Data Import Integration', () => {
+  let service: QueueManagementService;
+  let mockDataSyncQueue: jest.Mocked<any>;
+
+  beforeEach(async () => {
+    mockDataSyncQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'import-job-1' }),
+      getJobCounts: jest.fn().mockResolvedValue({
+        active: 0,
+        wait: 0,
+        delayed: 0,
+        failed: 0,
+        completed: 0,
+      }),
+      getFailed: jest.fn().mockResolvedValue([]),
+      getDelayed: jest.fn().mockResolvedValue([]),
+      isPaused: jest.fn().mockResolvedValue(false),
+      pause: jest.fn().mockResolvedValue(undefined),
+      resume: jest.fn().mockResolvedValue(undefined),
+      clean: jest.fn().mockResolvedValue(undefined),
+      getJob: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueManagementService,
+        {
+          provide: getQueueToken('email'),
+          useValue: {
+            add: jest.fn(),
+            getJobCounts: jest.fn().mockResolvedValue({}),
+            getFailed: jest.fn().mockResolvedValue([]),
+            getDelayed: jest.fn().mockResolvedValue([]),
+            isPaused: jest.fn().mockResolvedValue(false),
+            pause: jest.fn(),
+            resume: jest.fn(),
+            clean: jest.fn(),
+          },
+        },
+        {
+          provide: getQueueToken('documents'),
+          useValue: {
+            add: jest.fn(),
+            getJobCounts: jest.fn().mockResolvedValue({}),
+            getFailed: jest.fn().mockResolvedValue([]),
+            getDelayed: jest.fn().mockResolvedValue([]),
+            isPaused: jest.fn().mockResolvedValue(false),
+            pause: jest.fn(),
+            resume: jest.fn(),
+            clean: jest.fn(),
+          },
+        },
+        {
+          provide: getQueueToken('blockchain'),
+          useValue: {
+            add: jest.fn(),
+            getJobCounts: jest.fn().mockResolvedValue({}),
+            getFailed: jest.fn().mockResolvedValue([]),
+            getDelayed: jest.fn().mockResolvedValue([]),
+            isPaused: jest.fn().mockResolvedValue(false),
+            pause: jest.fn(),
+            resume: jest.fn(),
+            clean: jest.fn(),
+          },
+        },
+        { provide: getQueueToken('data-sync'), useValue: mockDataSyncQueue },
+      ],
+    }).compile();
+
+    service = module.get<QueueManagementService>(QueueManagementService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enqueues a sync-user-profile import job with correct payload', async () => {
+    const payload = {
+      type: 'sync-user-profile',
+      entityId: 'user-42',
+      entityType: 'user',
+    };
+
+    const job = await service.addDataSyncJob(payload);
+
+    expect(job).toBeDefined();
+    expect(mockDataSyncQueue.add).toHaveBeenCalledTimes(1);
+    const [calledPayload] = mockDataSyncQueue.add.mock.calls[0];
+    expect(calledPayload).toMatchObject({
+      type: 'sync-user-profile',
+      entityId: 'user-42',
+    });
+  });
+
+  it('enqueues a sync-property-data import job and applies default retry options', async () => {
+    const payload = {
+      type: 'sync-property-data',
+      entityId: 'prop-99',
+      entityType: 'property',
+    };
+
+    await service.addDataSyncJob(payload);
+
+    const [, opts] = mockDataSyncQueue.add.mock.calls[0];
+    expect(opts.attempts).toBeGreaterThanOrEqual(1);
+    expect(opts.backoff).toBeDefined();
+    expect(opts.backoff.type).toBe('exponential');
+  });
+
+  it('imports multiple records sequentially without cross-contamination', async () => {
+    const records = [
+      { type: 'sync-agreement-status', entityId: 'agr-1' },
+      { type: 'sync-payment-status', entityId: 'pay-1' },
+      { type: 'sync-user-profile', entityId: 'user-7' },
+    ];
+
+    for (const record of records) {
+      await service.addDataSyncJob(record);
+    }
+
+    expect(mockDataSyncQueue.add).toHaveBeenCalledTimes(3);
+    const calledIds = mockDataSyncQueue.add.mock.calls.map(
+      ([p]: [any]) => p.entityId,
+    );
+    expect(calledIds).toEqual(['agr-1', 'pay-1', 'user-7']);
+  });
+
+  it('propagates queue errors on import failure', async () => {
+    mockDataSyncQueue.add.mockRejectedValueOnce(
+      new Error('Redis connection lost'),
+    );
+
+    await expect(
+      service.addDataSyncJob({
+        type: 'sync-user-profile',
+        entityId: 'user-bad',
+      }),
+    ).rejects.toThrow('Redis connection lost');
+  });
+});

--- a/backend/src/modules/queues/services/queue-processing.integration.spec.ts
+++ b/backend/src/modules/queues/services/queue-processing.integration.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
+import { QueueManagementService } from './queue-management.service';
+
+/**
+ * Integration Tests: Queue Processing
+ *
+ * Verifies the end-to-end queue job lifecycle: adding jobs to multiple
+ * queues, fetching/retrying failed jobs, removing jobs, and reading job
+ * details — all using in-process mocks (no Redis required).
+ */
+describe('Queue Processing Integration', () => {
+  let service: QueueManagementService;
+
+  const makeQueueMock = (overrides: Partial<any> = {}) => ({
+    add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    getJobCounts: jest
+      .fn()
+      .mockResolvedValue({
+        active: 0,
+        wait: 0,
+        delayed: 0,
+        failed: 0,
+        completed: 0,
+      }),
+    getFailed: jest.fn().mockResolvedValue([]),
+    getDelayed: jest.fn().mockResolvedValue([]),
+    isPaused: jest.fn().mockResolvedValue(false),
+    pause: jest.fn().mockResolvedValue(undefined),
+    resume: jest.fn().mockResolvedValue(undefined),
+    clean: jest.fn().mockResolvedValue(undefined),
+    getJob: jest.fn(),
+    ...overrides,
+  });
+
+  let mockEmailQueue: jest.Mocked<any>;
+  let mockBlockchainQueue: jest.Mocked<any>;
+
+  beforeEach(async () => {
+    const failedJob = {
+      id: 'failed-99',
+      data: { type: 'verification', email: 'fail@test.com' },
+      failedReason: 'SMTP timeout',
+      attemptsMade: 3,
+      opts: { attempts: 3 },
+      stacktrace: [],
+      progress: jest.fn().mockReturnValue(0),
+      getState: jest.fn().mockResolvedValue('failed'),
+      finishedOn: Date.now(),
+      retry: jest.fn().mockResolvedValue(undefined),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockEmailQueue = makeQueueMock({
+      getFailed: jest.fn().mockResolvedValue([failedJob]),
+      getJob: jest
+        .fn()
+        .mockImplementation((id: string) =>
+          id === 'failed-99'
+            ? Promise.resolve(failedJob)
+            : Promise.resolve(null),
+        ),
+    });
+
+    mockBlockchainQueue = makeQueueMock({
+      add: jest.fn().mockResolvedValue({ id: 'bc-job-5' }),
+      getJobCounts: jest
+        .fn()
+        .mockResolvedValue({
+          active: 1,
+          wait: 3,
+          delayed: 2,
+          failed: 0,
+          completed: 10,
+        }),
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueManagementService,
+        { provide: getQueueToken('email'), useValue: mockEmailQueue },
+        { provide: getQueueToken('documents'), useValue: makeQueueMock() },
+        { provide: getQueueToken('blockchain'), useValue: mockBlockchainQueue },
+        { provide: getQueueToken('data-sync'), useValue: makeQueueMock() },
+      ],
+    }).compile();
+
+    service = module.get<QueueManagementService>(QueueManagementService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds a blockchain job and returns the created job object', async () => {
+    const payload = { transactionId: 'tx-abc123', action: 'mint-nft' };
+
+    const job = await service.addBlockchainJob(payload);
+
+    expect(job).toBeDefined();
+    expect(job.id).toBe('bc-job-5');
+    expect(mockBlockchainQueue.add).toHaveBeenCalledWith(
+      payload,
+      expect.objectContaining({ attempts: 5, removeOnComplete: false }),
+    );
+  });
+
+  it('retrieves failed jobs from the email queue', async () => {
+    const failedJobs = await service.getFailedJobs('email');
+
+    expect(failedJobs).toHaveLength(1);
+    expect(failedJobs[0].id).toBe('failed-99');
+    expect(failedJobs[0].failedReason).toBe('SMTP timeout');
+  });
+
+  it('retries a specific failed job by id', async () => {
+    const failedJob = (await mockEmailQueue.getFailed())[0];
+
+    await expect(
+      service.retryFailedJob('email', 'failed-99'),
+    ).resolves.toBeUndefined();
+    expect(failedJob.retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when removing a job that does not exist', async () => {
+    mockEmailQueue.getJob.mockResolvedValueOnce(null);
+
+    await expect(service.removeJob('email', 'nonexistent-id')).rejects.toThrow(
+      'Job nonexistent-id not found in queue email',
+    );
+  });
+});


### PR DESCRIPTION
Here's what was created:

data-import.integration.spec.ts (4 tests)

Enqueues a sync-user-profile job with correct payload shape
Verifies default retry options (exponential backoff, ≥1 attempts) on sync-property-data
Imports 3 records sequentially and confirms no cross-contamination
Propagates queue errors on import failure
batch-processing.integration.spec.ts (4 tests)

Enqueues a batch of 3 email jobs and verifies each call in order
Asserts aggregated stats across all 4 queues via getAllQueueStats
Pauses and resumes a queue without throwing
Clears a queue by verifying all 4 job-state clean calls (failed, delayed, active, wait)
queue-processing.integration.spec.ts (4 tests)

Adds a blockchain job and confirms the returned job id + options (removeOnComplete: false, 5 attempts)
Retrieves failed jobs from the email queue
Retries a specific failed job by id
Throws the right error when removing a nonexistent job
All tests use in-process queue mocks — no Redis, no external services. Existing 22 pre-existing tests are untouched and still passing.


closes #1140
closes #1141
closes #1144
closes #1143