### PR TITLE
fix: integrate frontend auth client (#1160)

### DIFF
--- a/frontend/__tests__/store/auth-store.test.ts
+++ b/frontend/__tests__/store/auth-store.test.ts
@@ -1,7 +1,18 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useAuthStore, useAuth } from '@/store/authStore';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    post: postMock,
+  },
+}));
+
+import { useAuth, useAuthStore } from '@/store/authStore';
+
+// --- Helpers -----------------------------------------------------------------
 
 function resetStore() {
   useAuthStore.setState({
@@ -21,17 +32,13 @@ const mockUser = {
   role: 'user' as const,
 };
 
-const expectedStoredUser = {
-  ...mockUser,
-  role: process.env.NODE_ENV === 'production' ? 'user' : 'admin',
-};
-
-// ─── Tests ───────────────────────────────────────────────────────────────────
+// --- Tests -------------------------------------------------------------------
 
 describe('authStore', () => {
   beforeEach(() => {
     localStorage.clear();
     document.cookie = '';
+    postMock.mockReset();
     resetStore();
   });
 
@@ -44,20 +51,18 @@ describe('authStore', () => {
   });
 
   it('setTokens persists auth to state and localStorage', () => {
-    useAuthStore.getState().setTokens('at-1', 'rt-1', mockUser);
+    useAuthStore.getState().setTokens('at-1', null, mockUser);
 
     const state = useAuthStore.getState();
-    expect(state.user).toEqual(expectedStoredUser);
+    expect(state.user).toEqual(mockUser);
     expect(state.accessToken).toBe('at-1');
-    expect(state.refreshToken).toBe('rt-1');
+    expect(state.refreshToken).toBeNull();
     expect(state.isAuthenticated).toBe(true);
     expect(state.loading).toBe(false);
 
     expect(localStorage.getItem('chioma_access_token')).toBe('at-1');
-    expect(localStorage.getItem('chioma_refresh_token')).toBe('rt-1');
-    expect(localStorage.getItem('chioma_user')).toBe(
-      JSON.stringify(expectedStoredUser),
-    );
+    expect(localStorage.getItem('chioma_refresh_token')).toBeNull();
+    expect(localStorage.getItem('chioma_user')).toBe(JSON.stringify(mockUser));
   });
 
   it('hydrate restores state from localStorage', () => {
@@ -68,7 +73,7 @@ describe('authStore', () => {
     useAuthStore.getState().hydrate();
 
     const state = useAuthStore.getState();
-    expect(state.user).toEqual(expectedStoredUser);
+    expect(state.user).toEqual(mockUser);
     expect(state.accessToken).toBe('at-2');
     expect(state.isAuthenticated).toBe(true);
     expect(state.loading).toBe(false);
@@ -95,26 +100,76 @@ describe('authStore', () => {
     expect(localStorage.getItem('chioma_access_token')).toBeNull();
   });
 
-  it('login sets tokens via dev bypass', async () => {
+  it('login authenticates against the backend response', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        accessToken: 'at-login',
+        user: mockUser,
+      },
+      status: 200,
+    });
+
     const result = await useAuthStore
       .getState()
       .login('test@chioma.local', 'pass');
 
     expect(result.success).toBe(true);
+    expect(postMock).toHaveBeenCalledWith('/auth/login', {
+      email: 'test@chioma.local',
+      password: 'pass',
+    });
 
     const state = useAuthStore.getState();
     expect(state.isAuthenticated).toBe(true);
-    expect(state.user?.email).toBe('test@chioma.local');
+    expect(state.user).toEqual({
+      ...mockUser,
+      avatar: undefined,
+    });
+    expect(state.accessToken).toBe('at-login');
+  });
+
+  it('returns an actionable message when MFA is required', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        mfaRequired: true,
+        mfaToken: 'mfa-token',
+        user: mockUser,
+      },
+      status: 200,
+    });
+
+    const result = await useAuthStore.getState().login(mockUser.email, 'pass');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Multi-factor authentication is required to finish signing in.',
+    });
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+  });
+
+  it('refreshSession updates the stored access token', async () => {
+    useAuthStore.getState().setTokens('at-old', null, mockUser);
+    postMock.mockResolvedValueOnce({
+      data: {
+        accessToken: 'at-refreshed',
+      },
+      status: 200,
+    });
+
+    const result = await useAuthStore.getState().refreshSession();
+
+    expect(result.success).toBe(true);
+    expect(postMock).toHaveBeenCalledWith('/auth/refresh', {}, { retries: 0 });
+    expect(useAuthStore.getState().accessToken).toBe('at-refreshed');
+    expect(localStorage.getItem('chioma_access_token')).toBe('at-refreshed');
   });
 
   it('logout clears state and localStorage', async () => {
-    useAuthStore.getState().setTokens('at-4', 'rt-4', mockUser);
-
-    // Stub fetch to prevent network call
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
-    );
+    useAuthStore.getState().setTokens('at-4', null, mockUser);
+    postMock.mockResolvedValueOnce({
+      data: { message: 'Logged out successfully' },
+      status: 200,
+    });
 
     await useAuthStore.getState().logout();
 
@@ -123,8 +178,7 @@ describe('authStore', () => {
     expect(state.accessToken).toBeNull();
     expect(state.isAuthenticated).toBe(false);
     expect(localStorage.getItem('chioma_access_token')).toBeNull();
-
-    vi.unstubAllGlobals();
+    expect(postMock).toHaveBeenCalledWith('/auth/logout', {}, { retries: 0 });
   });
 
   it('useAuth alias points to the same store', () => {

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -19,6 +19,7 @@ type RequestConfig = {
   headers?: Record<string, string>;
   body?: unknown;
   cache?: RequestCache;
+  credentials?: RequestCredentials;
   retries?: number;
   timeoutMs?: number;
   signal?: AbortSignal;
@@ -107,6 +108,7 @@ class ApiClient {
       headers = {},
       body,
       cache = 'no-cache',
+      credentials = 'include',
       retries = 3,
       timeoutMs = 12000,
       signal,
@@ -149,6 +151,7 @@ class ApiClient {
             headers: requestHeaders,
             body: body ? JSON.stringify(body) : undefined,
             cache,
+            credentials,
             signal: controller.signal,
           });
 

--- a/frontend/lib/api/backend-proxy.ts
+++ b/frontend/lib/api/backend-proxy.ts
@@ -21,6 +21,27 @@ function forwardHeaders(request: NextRequest): HeadersInit {
   return headers;
 }
 
+function appendSetCookieHeaders(
+  sourceHeaders: Headers,
+  targetHeaders: Headers,
+): void {
+  const headersWithGetSetCookie = sourceHeaders as Headers & {
+    getSetCookie?: () => string[];
+  };
+
+  if (typeof headersWithGetSetCookie.getSetCookie === 'function') {
+    for (const cookie of headersWithGetSetCookie.getSetCookie()) {
+      targetHeaders.append('set-cookie', cookie);
+    }
+    return;
+  }
+
+  const setCookie = sourceHeaders.get('set-cookie');
+  if (setCookie) {
+    targetHeaders.append('set-cookie', setCookie);
+  }
+}
+
 export async function proxyToBackend(
   request: NextRequest,
   pathSegments: string[],
@@ -55,6 +76,7 @@ export async function proxyToBackend(
     if (responseContentType) {
       responseHeaders.set('content-type', responseContentType);
     }
+    appendSetCookieHeaders(response.headers, responseHeaders);
 
     if (!text) {
       return new NextResponse(null, {

--- a/frontend/store/AuthHydrator.tsx
+++ b/frontend/store/AuthHydrator.tsx
@@ -4,18 +4,26 @@ import { useEffect } from 'react';
 import { useAuthStore } from './authStore';
 
 /**
- * AuthHydrator — Reads persisted auth state from localStorage on mount.
+ * AuthHydrator -- Reads persisted auth state from localStorage on mount.
  *
  * Place this once inside the root layout's <body>. Unlike the old
- * AuthProvider (React Context), it does NOT wrap children — Zustand
+ * AuthProvider (React Context), it does NOT wrap children -- Zustand
  * stores are global singletons accessible from any component.
  */
 export function AuthHydrator() {
   const hydrate = useAuthStore((s) => s.hydrate);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const refreshSession = useAuthStore((s) => s.refreshSession);
 
   useEffect(() => {
     hydrate();
   }, [hydrate]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    void refreshSession();
+  }, [isAuthenticated, refreshSession]);
 
   return null;
 }

--- a/frontend/store/authStore.ts
+++ b/frontend/store/authStore.ts
@@ -1,9 +1,11 @@
 'use client';
 
+import { AppError } from '@/lib/errors';
+import { apiClient } from '@/lib/api-client';
 import { create } from 'zustand';
 import { withMiddleware } from './middleware';
 
-// ─── Types ───────────────────────────────────────────────────────────────────
+// --- Types -------------------------------------------------------------------
 
 export interface User {
   id: string;
@@ -31,23 +33,55 @@ interface RegisterPayload {
   role?: 'user' | 'admin';
 }
 
+interface AuthApiUser {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  role: string;
+  avatar?: string;
+}
+
+interface AuthSuccessResponse {
+  accessToken: string;
+  refreshToken?: string | null;
+  user: AuthApiUser;
+  mfaRequired?: false;
+}
+
+interface MfaRequiredResponse {
+  mfaRequired: true;
+  mfaToken: string;
+  user: AuthApiUser;
+}
+
+interface RefreshResponse {
+  accessToken: string;
+}
+
+interface MessageResponse {
+  message: string;
+}
+
+type AuthResult = { success: boolean; error?: string };
+
 interface AuthActions {
-  login: (
-    email: string,
-    password: string,
-  ) => Promise<{ success: boolean; error?: string }>;
-  register: (
-    payload: RegisterPayload,
-  ) => Promise<{ success: boolean; error?: string }>;
+  login: (email: string, password: string) => Promise<AuthResult>;
+  register: (payload: RegisterPayload) => Promise<AuthResult>;
   logout: () => Promise<void>;
-  setTokens: (accessToken: string, refreshToken: string, user: User) => void;
+  refreshSession: () => Promise<AuthResult>;
+  setTokens: (
+    accessToken: string,
+    refreshToken: string | null,
+    user: User,
+  ) => void;
   setWalletAddress: (address: string | null) => void;
   hydrate: () => void;
 }
 
 export type AuthStore = AuthState & AuthActions;
 
-// ─── Constants ───────────────────────────────────────────────────────────────
+// --- Constants ---------------------------------------------------------------
 
 const AUTH_STORAGE_KEYS = {
   ACCESS_TOKEN: 'chioma_access_token',
@@ -58,17 +92,21 @@ const AUTH_STORAGE_KEYS = {
 
 const AUTH_COOKIE_NAME = 'chioma_auth_token';
 
-// ─── Cookie Helpers ──────────────────────────────────────────────────────────
+// --- Cookie Helpers ----------------------------------------------------------
 
 function setAuthCookie(token: string) {
+  if (typeof document === 'undefined') return;
+
   document.cookie = `${AUTH_COOKIE_NAME}=${token}; path=/; max-age=${60 * 60 * 24 * 7}; SameSite=Lax`;
 }
 
 function removeAuthCookie() {
+  if (typeof document === 'undefined') return;
+
   document.cookie = `${AUTH_COOKIE_NAME}=; path=/; max-age=0; SameSite=Lax`;
 }
 
-// ─── Storage Helpers ─────────────────────────────────────────────────────────
+// --- Storage Helpers ---------------------------------------------------------
 
 function readStoredAuth(): Omit<AuthState, 'loading'> {
   if (typeof window === 'undefined') {
@@ -103,7 +141,6 @@ function readStoredAuth(): Omit<AuthState, 'loading'> {
       };
     }
   } catch {
-    // Corrupted storage — clear and start fresh
     localStorage.removeItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN);
     localStorage.removeItem(AUTH_STORAGE_KEYS.REFRESH_TOKEN);
     localStorage.removeItem(AUTH_STORAGE_KEYS.USER);
@@ -121,6 +158,8 @@ function readStoredAuth(): Omit<AuthState, 'loading'> {
 }
 
 function clearStorage() {
+  if (typeof window === 'undefined') return;
+
   localStorage.removeItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN);
   localStorage.removeItem(AUTH_STORAGE_KEYS.REFRESH_TOKEN);
   localStorage.removeItem(AUTH_STORAGE_KEYS.USER);
@@ -128,19 +167,51 @@ function clearStorage() {
   removeAuthCookie();
 }
 
-function persistAuth(accessToken: string, refreshToken: string, user: User) {
+function persistAuth(
+  accessToken: string,
+  refreshToken: string | null,
+  user: User,
+) {
   localStorage.setItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN, accessToken);
-  localStorage.setItem(AUTH_STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
+
+  if (refreshToken) {
+    localStorage.setItem(AUTH_STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
+  } else {
+    localStorage.removeItem(AUTH_STORAGE_KEYS.REFRESH_TOKEN);
+  }
+
   localStorage.setItem(AUTH_STORAGE_KEYS.USER, JSON.stringify(user));
   setAuthCookie(accessToken);
 }
 
-// ─── Store ───────────────────────────────────────────────────────────────────
+function normalizeUser(user: AuthApiUser): User {
+  return {
+    id: user.id,
+    email: user.email,
+    firstName: user.firstName ?? '',
+    lastName: user.lastName ?? '',
+    role: user.role === 'admin' ? 'admin' : 'user',
+    avatar: user.avatar,
+  };
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof AppError) {
+    return error.userMessage || error.message || fallback;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+// --- Store -------------------------------------------------------------------
 
 export const useAuthStore = create<AuthStore>()(
   withMiddleware(
     (set, get) => ({
-      // Initial state — SSR-safe defaults; call hydrate() on client mount
       user: null,
       accessToken: null,
       refreshToken: null,
@@ -148,19 +219,10 @@ export const useAuthStore = create<AuthStore>()(
       loading: true,
       walletAddress: null,
 
-      /**
-       * Hydrate from localStorage on client mount.
-       * Should be called once from the root layout/component.
-       */
       hydrate: () => {
         const stored = readStoredAuth();
         set((state) => {
-          let user = stored.user;
-          // FORCED TO ADMIN FOR DEVELOPMENT - Global bypass for all admin pages
-          if (user && process.env.NODE_ENV !== 'production') {
-            user = { ...user, role: 'admin' };
-          }
-          state.user = user;
+          state.user = stored.user;
           state.accessToken = stored.accessToken;
           state.refreshToken = stored.refreshToken;
           state.isAuthenticated = stored.isAuthenticated;
@@ -169,19 +231,10 @@ export const useAuthStore = create<AuthStore>()(
         });
       },
 
-      /**
-       * Directly set tokens & user (useful after registration or
-       * when the backend response is already available).
-       */
-      setTokens: (accessToken: string, refreshToken: string, user: User) => {
-        // FORCED TO ADMIN FOR DEVELOPMENT - Global bypass for all admin pages
-        let finalUser = user;
-        if (user && process.env.NODE_ENV !== 'production') {
-          finalUser = { ...user, role: 'admin' };
-        }
-        persistAuth(accessToken, refreshToken, finalUser);
+      setTokens: (accessToken: string, refreshToken: string | null, user: User) => {
+        persistAuth(accessToken, refreshToken, user);
         set((state) => {
-          state.user = finalUser;
+          state.user = user;
           state.accessToken = accessToken;
           state.refreshToken = refreshToken;
           state.isAuthenticated = true;
@@ -189,127 +242,125 @@ export const useAuthStore = create<AuthStore>()(
         });
       },
 
-      /**
-       * Set wallet address and persist to localStorage.
-       */
       setWalletAddress: (address: string | null) => {
         if (address) {
           localStorage.setItem(AUTH_STORAGE_KEYS.WALLET_ADDRESS, address);
         } else {
           localStorage.removeItem(AUTH_STORAGE_KEYS.WALLET_ADDRESS);
         }
+
         set((state) => {
           state.walletAddress = address;
         });
       },
 
-      /**
-       * Login with email/password — calls the backend auth endpoint.
-       */
-      login: async (
-        email: string,
-      ): Promise<{ success: boolean; error?: string }> => {
-        // --- REAL AUTHENTICATION LOGIC (Commented out for development) ---
-        /*
+      login: async (email: string, password: string): Promise<AuthResult> => {
         try {
-          const response = await fetch('/api/auth/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ email, password }),
+          const response = await apiClient.post<
+            AuthSuccessResponse | MfaRequiredResponse
+          >('/auth/login', {
+            email,
+            password,
           });
 
-          if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}));
+          if ('mfaRequired' in response.data && response.data.mfaRequired) {
             return {
               success: false,
-              error: errorData.message || 'Invalid credentials. Please try again.',
+              error:
+                'Multi-factor authentication is required to finish signing in.',
             };
           }
 
-          const data = await response.json();
-          get().setTokens(data.accessToken, data.refreshToken, data.user);
+          get().setTokens(
+            response.data.accessToken,
+            response.data.refreshToken ?? null,
+            normalizeUser(response.data.user),
+          );
+
           return { success: true };
-        } catch {
+        } catch (error) {
           return {
             success: false,
-            error: 'Network error. Please check your connection.',
+            error: getErrorMessage(
+              error,
+              'Invalid credentials. Please try again.',
+            ),
           };
         }
-        */
-
-        // DEV BYPASS: map demo emails to roles for local testing.
-        const normalizedEmail = (email || 'dev@chioma.local').toLowerCase();
-        const inferredRole: User['role'] = normalizedEmail.includes('admin')
-          ? 'admin'
-          : 'user';
-
-        get().setTokens('mock-access-token', 'mock-refresh-token', {
-          id: 'dev-123',
-          email: normalizedEmail,
-          firstName:
-            inferredRole.charAt(0).toUpperCase() + inferredRole.slice(1),
-          lastName: 'User',
-          role: inferredRole,
-        });
-        return { success: true };
       },
 
-      /**
-       * Register a new account — calls the backend auth endpoint.
-       */
-      register: async (
-        payload: RegisterPayload,
-      ): Promise<{ success: boolean; error?: string }> => {
-        // --- REAL REGISTRATION LOGIC (Commented out for development) ---
-        /*
+      register: async (payload: RegisterPayload): Promise<AuthResult> => {
         try {
-          const response = await fetch('/api/auth/register', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          });
-          if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}));
-            return {
-              success: false,
-              error: errorData.message || 'Registration failed. Please try again.',
-            };
-          }
-          const data = await response.json();
-          get().setTokens(data.accessToken, data.refreshToken, data.user);
-          return { success: true };
-        } catch {
-          return { success: false, error: 'Network error. Please check your connection.' };
-        }
-        */
+          const response = await apiClient.post<AuthSuccessResponse>(
+            '/auth/register',
+            payload,
+          );
 
-        // DEV BYPASS: immediately log in after registration.
-        get().setTokens('mock-access-token', 'mock-refresh-token', {
-          id: 'dev-' + Date.now(),
-          email: payload.email,
-          firstName: payload.firstName,
-          lastName: payload.lastName,
-          role: payload.role ?? 'user',
-        });
-        return { success: true };
+          get().setTokens(
+            response.data.accessToken,
+            response.data.refreshToken ?? null,
+            normalizeUser(response.data.user),
+          );
+
+          return { success: true };
+        } catch (error) {
+          return {
+            success: false,
+            error: getErrorMessage(
+              error,
+              'Registration failed. Please try again.',
+            ),
+          };
+        }
       },
 
-      /**
-       * Logout — clears tokens from storage, cookie, and state.
-       */
-      logout: async () => {
-        const token = localStorage.getItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN);
+      refreshSession: async (): Promise<AuthResult> => {
+        const currentUser = get().user;
 
-        // Best-effort call to backend logout
-        if (token) {
-          try {
-            await fetch('/api/auth/logout', {
-              method: 'POST',
-              headers: { Authorization: `Bearer ${token}` },
-            });
-          } catch {
-            // Silently fail — we still clear local state
-          }
+        if (!currentUser) {
+          return { success: false, error: 'No authenticated user to refresh.' };
+        }
+
+        try {
+          const response = await apiClient.post<RefreshResponse>(
+            '/auth/refresh',
+            {},
+            { retries: 0 },
+          );
+
+          get().setTokens(
+            response.data.accessToken,
+            get().refreshToken,
+            currentUser,
+          );
+
+          return { success: true };
+        } catch (error) {
+          clearStorage();
+          set((state) => {
+            state.user = null;
+            state.accessToken = null;
+            state.refreshToken = null;
+            state.isAuthenticated = false;
+            state.walletAddress = null;
+            state.loading = false;
+          });
+
+          return {
+            success: false,
+            error: getErrorMessage(
+              error,
+              'Your session expired. Please sign in again.',
+            ),
+          };
+        }
+      },
+
+      logout: async () => {
+        try {
+          await apiClient.post<MessageResponse>('/auth/logout', {}, { retries: 0 });
+        } catch {
+          // Best-effort logout: always clear the local session.
         }
 
         clearStorage();
@@ -328,6 +379,6 @@ export const useAuthStore = create<AuthStore>()(
   ),
 );
 
-// ─── Convenience Hook (backward-compatible with old AuthContext) ─────────────
+// --- Convenience Hook (backward-compatible with old AuthContext) -------------
 
 export const useAuth = useAuthStore;


### PR DESCRIPTION
Closes #1160
Closes #1181
Closes #1147

## Changes
- replace the frontend auth store development bypass with real backend login and registration requests
- add refresh-session handling during hydration so stored sessions can renew their access token through the backend
- forward backend auth cookies through the Next.js proxy and include credentials in the shared api client so refresh/logout flows work end to end
- update auth-store tests to cover backend login, MFA-required responses, refresh, and logout behavior

## Testing
- Not run (per request)