### PR TITLE
test: add database replication integration coverage

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -232,32 +232,5 @@
     "picomatch@<2.3.2": "^2.3.2",
     "picomatch@>=4.0.0 <4.0.4": "^4.0.4"
   },
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@nestjs/core",
-      "@scarf/scarf",
-      "@swc/core",
-      "sqlite3"
-    ],
-    "packageExtensions": {
-      "@mapbox/node-pre-gyp": {
-        "dependencies": {
-          "minimist": "^1.2.8",
-          "nopt": "^5.0.0"
-        }
-      }
-    },
-    "overrides": {
-      "axios": "^1.15.2",
-      "tar": "^7.5.10",
-      "@isaacs/brace-expansion": "5.0.1",
-      "minimatch": "^9.0.8",
-      "serialize-javascript": "^7.0.3",
-      "multer": "^2.1.1",
-      "fast-xml-parser": "^5.5.6",
-      "picomatch@<2.3.2": "^2.3.2",
-      "picomatch@>=4.0.0 <4.0.4": "^4.0.4"
-    }
-  }
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }

--- a/backend/pnpm-workspace.yaml
+++ b/backend/pnpm-workspace.yaml
@@ -1,0 +1,25 @@
+packages:
+  - .
+
+onlyBuiltDependencies:
+  - '@nestjs/core'
+  - '@scarf/scarf'
+  - '@swc/core'
+  - sqlite3
+
+packageExtensions:
+  '@mapbox/node-pre-gyp':
+    dependencies:
+      minimist: ^1.2.8
+      nopt: ^5.0.0
+
+overrides:
+  axios: ^1.15.2
+  tar: ^7.5.10
+  '@isaacs/brace-expansion': 5.0.1
+  minimatch: ^9.0.8
+  serialize-javascript: ^7.0.3
+  multer: ^2.1.1
+  fast-xml-parser: ^5.5.6
+  picomatch@<2.3.2: ^2.3.2
+  picomatch@>=4.0.0 <4.0.4: ^4.0.4

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -64,6 +64,7 @@ import { TransactionModule } from './modules/transactions/transaction.module';
 import { ApiVersionModule } from './common/api-versioning/api-version.module';
 import { ResponseTimeInterceptor } from './common/interceptors/response-time.interceptor';
 import { TimeoutInterceptor } from './common/interceptors/timeout.interceptor';
+import { createDatabaseConnectionOptions } from './database/database-config';
 
 const appLogger = new Logger('AppModule');
 
@@ -186,39 +187,29 @@ const appLogger = new Logger('AppModule');
             logging: false,
           };
         }
-        const config = {
-          type: 'postgres' as const,
-          host: process.env.DB_HOST,
-          port: parseInt(process.env.DB_PORT || '5432'),
-          username: process.env.DB_USERNAME,
-          password: process.env.DB_PASSWORD,
-          database: process.env.DB_NAME,
-          namingStrategy: new SnakeNamingStrategy(),
-          entities: [__dirname + '/modules/**/*.entity{.ts,.js}'],
-          migrations: isTest ? [] : [__dirname + '/migrations/*{.ts,.js}'],
-          synchronize: false,
-          logging: process.env.TYPEORM_LOGGING === 'true',
-          logger: 'advanced-console' as const,
-          // Connection pooling configuration
-          extra: {
-            max: parseInt(process.env.DB_POOL_MAX || '20'),
-            min: parseInt(process.env.DB_POOL_MIN || '5'),
-            idleTimeoutMillis: parseInt(
-              process.env.DB_POOL_IDLE_TIMEOUT || '30000',
-            ),
-            connectionTimeoutMillis: parseInt(
-              process.env.DB_POOL_CONNECTION_TIMEOUT || '2000',
-            ),
-          },
+        const config = createDatabaseConnectionOptions(
+          __dirname,
+          isTest ? [] : [__dirname + '/migrations/*{.ts,.js}'],
+        );
+        const debugConfig = config as {
+          host?: string;
+          port?: number;
+          username?: string;
+          database?: string;
+          replication?: unknown;
+          synchronize?: boolean;
+          logging?: boolean;
+          extra?: unknown;
         };
         console.log('[DEBUG] TypeORM Config:', {
-          host: config.host,
-          port: config.port,
-          username: config.username,
-          database: config.database,
-          synchronize: config.synchronize,
-          logging: config.logging,
-          pool: config.extra,
+          host: debugConfig.host,
+          port: debugConfig.port,
+          username: debugConfig.username,
+          database: debugConfig.database,
+          replicationEnabled: Boolean(debugConfig.replication),
+          synchronize: debugConfig.synchronize,
+          logging: debugConfig.logging,
+          pool: debugConfig.extra,
         });
         return config;
       },

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import * as path from 'path';
 import { DataSource } from 'typeorm';
-import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import * as dotenv from 'dotenv';
+import { createDatabaseConnectionOptions } from './database-config';
 
 dotenv.config();
 
@@ -18,47 +18,9 @@ const backendRootDir = path.join(rootDir, '..');
  *
  * Connection: prefer `DATABASE_URL` when set; otherwise `DB_HOST`, `DB_PORT`, etc.
  */
-export const AppDataSource = new DataSource({
-  type: 'postgres',
-  url: process.env.DATABASE_URL || undefined,
-  host: process.env.DATABASE_URL
-    ? undefined
-    : process.env.DB_HOST || 'localhost',
-  port: process.env.DATABASE_URL
-    ? undefined
-    : parseInt(process.env.DB_PORT || '5432', 10),
-  username: process.env.DATABASE_URL
-    ? undefined
-    : process.env.DB_USERNAME || 'postgres',
-  password: process.env.DATABASE_URL
-    ? undefined
-    : process.env.DB_PASSWORD || 'password',
-  database: process.env.DATABASE_URL
-    ? undefined
-    : process.env.DB_NAME || 'chioma_db',
-  ssl:
-    process.env.DB_SSL === 'true'
-      ? {
-          rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED === 'true',
-        }
-      : false,
-  namingStrategy: new SnakeNamingStrategy(),
-  entities: [path.join(rootDir, 'modules', '**', '*.entity{.ts,.js}')],
-  migrations: [
+export const AppDataSource = new DataSource(
+  createDatabaseConnectionOptions(rootDir, [
     path.join(rootDir, 'migrations', '*{.ts,.js}'),
     path.join(backendRootDir, 'migrations', '*{.ts,.js}'),
-  ],
-  migrationsTableName: 'migrations',
-  migrationsTransactionMode: 'each',
-  synchronize: false,
-  logging: process.env.TYPEORM_LOGGING === 'true',
-  // Connection pooling configuration
-  extra: {
-    max: parseInt(process.env.DB_POOL_MAX || '20'),
-    min: parseInt(process.env.DB_POOL_MIN || '5'),
-    idleTimeoutMillis: parseInt(process.env.DB_POOL_IDLE_TIMEOUT || '30000'),
-    connectionTimeoutMillis: parseInt(
-      process.env.DB_POOL_CONNECTION_TIMEOUT || '2000',
-    ),
-  },
-});
+  ]),
+);

--- a/backend/src/database/database-config.ts
+++ b/backend/src/database/database-config.ts
@@ -1,0 +1,127 @@
+import { DataSourceOptions } from 'typeorm';
+import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
+type DatabaseEnv = Record<string, string | undefined>;
+
+interface ReplicationNodeConfig {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  database: string;
+  ssl: false | { rejectUnauthorized: boolean };
+}
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function buildSslConfig(
+  env: DatabaseEnv,
+): false | { rejectUnauthorized: boolean } {
+  if (env.DB_SSL !== 'true') {
+    return false;
+  }
+
+  return {
+    rejectUnauthorized: env.DB_SSL_REJECT_UNAUTHORIZED === 'true',
+  };
+}
+
+function buildPrimaryNode(env: DatabaseEnv): ReplicationNodeConfig {
+  return {
+    host: env.DB_HOST || 'localhost',
+    port: parseNumber(env.DB_PORT, 5432),
+    username: env.DB_USERNAME || 'postgres',
+    password: env.DB_PASSWORD || 'password',
+    database: env.DB_NAME || 'chioma_db',
+    ssl: buildSslConfig(env),
+  };
+}
+
+export function hasReplicaDatabaseConfig(
+  env: DatabaseEnv = process.env,
+): boolean {
+  return Boolean(
+    env.DB_REPLICA_HOST &&
+    env.DB_REPLICA_USERNAME &&
+    env.DB_REPLICA_PASSWORD &&
+    env.DB_REPLICA_NAME,
+  );
+}
+
+export function buildReplicationConfig(
+  env: DatabaseEnv = process.env,
+): NonNullable<PostgresConnectionOptions['replication']> | undefined {
+  if (env.DATABASE_URL || !hasReplicaDatabaseConfig(env)) {
+    return undefined;
+  }
+
+  return {
+    master: buildPrimaryNode(env),
+    slaves: [
+      {
+        host: env.DB_REPLICA_HOST!,
+        port: parseNumber(env.DB_REPLICA_PORT, 5432),
+        username: env.DB_REPLICA_USERNAME!,
+        password: env.DB_REPLICA_PASSWORD!,
+        database: env.DB_REPLICA_NAME!,
+        ssl: buildSslConfig(env),
+      },
+    ],
+  };
+}
+
+export function createDatabaseConnectionOptions(
+  rootDir: string,
+  migrations: string[],
+  env: DatabaseEnv = process.env,
+): DataSourceOptions {
+  const baseOptions: DataSourceOptions = {
+    type: 'postgres',
+    namingStrategy: new SnakeNamingStrategy(),
+    entities: [`${rootDir}/modules/**/*.entity{.ts,.js}`],
+    migrations,
+    migrationsTableName: 'migrations',
+    migrationsTransactionMode: 'each',
+    synchronize: false,
+    logging: env.TYPEORM_LOGGING === 'true',
+    logger: 'advanced-console',
+    extra: {
+      max: parseNumber(env.DB_POOL_MAX, 20),
+      min: parseNumber(env.DB_POOL_MIN, 5),
+      idleTimeoutMillis: parseNumber(env.DB_POOL_IDLE_TIMEOUT, 30000),
+      connectionTimeoutMillis: parseNumber(
+        env.DB_POOL_CONNECTION_TIMEOUT,
+        2000,
+      ),
+    },
+  };
+
+  if (env.DATABASE_URL) {
+    return {
+      ...baseOptions,
+      url: env.DATABASE_URL,
+    };
+  }
+
+  const replication = buildReplicationConfig(env);
+  if (replication) {
+    return {
+      ...baseOptions,
+      replication,
+    };
+  }
+
+  return {
+    ...baseOptions,
+    host: env.DB_HOST,
+    port: parseNumber(env.DB_PORT, 5432),
+    username: env.DB_USERNAME,
+    password: env.DB_PASSWORD,
+    database: env.DB_NAME,
+    ssl: buildSslConfig(env),
+  };
+}

--- a/backend/src/modules/monitoring/database-replication.service.ts
+++ b/backend/src/modules/monitoring/database-replication.service.ts
@@ -1,0 +1,217 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
+import { hasReplicaDatabaseConfig } from '../../database/database-config';
+import { MetricsService } from './metrics.service';
+
+export interface ReplicaMetrics {
+  replica: string;
+  state: string;
+  syncState: string;
+  lagBytes: number;
+  lagSeconds: number;
+  healthy: boolean;
+}
+
+export interface DatabaseReplicationSnapshot {
+  timestamp: Date;
+  replicationConfigured: boolean;
+  primaryWritable: boolean;
+  failoverReady: boolean;
+  healthyReplicaCount: number;
+  replicas: ReplicaMetrics[];
+}
+
+export interface ReplicaConsistencyResult {
+  query: string;
+  matched: boolean;
+  primaryRows: unknown[];
+  replicaRows: unknown[];
+}
+
+export interface ReplicaRecoveryStatus {
+  replica: string;
+  inRecovery: boolean;
+  replayPaused: boolean;
+}
+
+@Injectable()
+export class DatabaseReplicationService {
+  private readonly logger = new Logger(DatabaseReplicationService.name);
+  private readonly maxLagSeconds = Number.parseInt(
+    process.env.DB_REPLICATION_MAX_LAG_SECONDS ?? '10',
+    10,
+  );
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly metricsService: MetricsService,
+  ) {}
+
+  isReplicationConfigured(
+    env: Record<string, string | undefined> = process.env,
+  ) {
+    return hasReplicaDatabaseConfig(env);
+  }
+
+  async getReplicationStatus(): Promise<DatabaseReplicationSnapshot> {
+    if (!this.isReplicationConfigured()) {
+      return {
+        timestamp: new Date(),
+        replicationConfigured: false,
+        primaryWritable: false,
+        failoverReady: false,
+        healthyReplicaCount: 0,
+        replicas: [],
+      };
+    }
+
+    const [primaryResult] = await this.dataSource.query(`
+      SELECT NOT pg_is_in_recovery() AS primary_writable
+    `);
+
+    const rows = await this.dataSource.query(`
+      SELECT
+        COALESCE(application_name, client_addr::text, 'replica') AS replica,
+        state,
+        sync_state,
+        COALESCE(pg_wal_lsn_diff(sent_lsn, replay_lsn), 0)::bigint AS lag_bytes,
+        COALESCE(EXTRACT(EPOCH FROM replay_lag), 0)::float AS replay_lag_seconds
+      FROM pg_stat_replication
+    `);
+
+    const replicas = rows.map((row: Record<string, unknown>) =>
+      this.toReplicaMetrics(row),
+    );
+
+    for (const replica of replicas) {
+      this.metricsService.setReplicationLag(
+        replica.replica,
+        replica.lagSeconds,
+      );
+      this.metricsService.setReplicaHealth(replica.replica, replica.healthy);
+    }
+    this.metricsService.setReplicaCount(replicas.length);
+
+    const primaryWritable = Boolean(primaryResult?.primary_writable);
+    const healthyReplicaCount = replicas.filter(
+      (replica) => replica.healthy,
+    ).length;
+
+    return {
+      timestamp: new Date(),
+      replicationConfigured: true,
+      primaryWritable,
+      failoverReady: primaryWritable && healthyReplicaCount > 0,
+      healthyReplicaCount,
+      replicas,
+    };
+  }
+
+  async verifyReplicaConsistency(
+    query: string,
+    parameters: unknown[] = [],
+  ): Promise<ReplicaConsistencyResult> {
+    if (!this.isReplicationConfigured()) {
+      throw new Error('Replication is not configured');
+    }
+
+    const primaryRunner = this.dataSource.createQueryRunner('master');
+    const replicaRunner = this.dataSource.createQueryRunner('slave');
+
+    await Promise.all([primaryRunner.connect(), replicaRunner.connect()]);
+
+    try {
+      const [primaryRows, replicaRows] = await Promise.all([
+        primaryRunner.query(query, parameters),
+        replicaRunner.query(query, parameters),
+      ]);
+
+      return {
+        query,
+        matched:
+          this.serializeForComparison(primaryRows) ===
+          this.serializeForComparison(replicaRows),
+        primaryRows,
+        replicaRows,
+      };
+    } finally {
+      await this.releaseRunners(primaryRunner, replicaRunner);
+    }
+  }
+
+  async getRecoveryStatus(): Promise<ReplicaRecoveryStatus[]> {
+    if (!this.isReplicationConfigured()) {
+      return [];
+    }
+
+    const replicaRunner = this.dataSource.createQueryRunner('slave');
+    await replicaRunner.connect();
+
+    try {
+      const rows = await replicaRunner.query(`
+        SELECT
+          COALESCE(inet_server_addr()::text, 'replica') AS replica,
+          pg_is_in_recovery() AS in_recovery,
+          pg_is_wal_replay_paused() AS replay_paused
+      `);
+
+      return rows.map((row: Record<string, unknown>) => ({
+        replica: String(row.replica ?? 'replica'),
+        inRecovery: Boolean(row.in_recovery),
+        replayPaused: Boolean(row.replay_paused),
+      }));
+    } finally {
+      await this.releaseRunners(replicaRunner);
+    }
+  }
+
+  private toReplicaMetrics(row: Record<string, unknown>): ReplicaMetrics {
+    const replica = String(row.replica ?? 'replica');
+    const state = String(row.state ?? 'unknown');
+    const lagSeconds = Number(row.replay_lag_seconds ?? 0);
+    const lagBytes = Number(row.lag_bytes ?? 0);
+    const healthy = state === 'streaming' && lagSeconds <= this.maxLagSeconds;
+
+    if (!healthy) {
+      this.logger.warn(
+        `Replica ${replica} is unhealthy: state=${state}, lag=${lagSeconds}s`,
+      );
+    }
+
+    return {
+      replica,
+      state,
+      syncState: String(row.sync_state ?? 'unknown'),
+      lagBytes,
+      lagSeconds,
+      healthy,
+    };
+  }
+
+  private async releaseRunners(...runners: QueryRunner[]): Promise<void> {
+    await Promise.allSettled(runners.map((runner) => runner.release()));
+  }
+
+  private serializeForComparison(value: unknown): string {
+    const normalize = (input: unknown): unknown => {
+      if (Array.isArray(input)) {
+        return input.map((entry) => normalize(entry));
+      }
+
+      if (input && typeof input === 'object') {
+        return Object.keys(input as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, key) => {
+            acc[key] = normalize((input as Record<string, unknown>)[key]);
+            return acc;
+          }, {});
+      }
+
+      return input;
+    };
+
+    return JSON.stringify(normalize(value));
+  }
+}

--- a/backend/src/modules/monitoring/metrics.service.ts
+++ b/backend/src/modules/monitoring/metrics.service.ts
@@ -113,6 +113,26 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  private readonly dbReplicationLagSeconds = new Gauge({
+    name: 'database_replication_lag_seconds',
+    help: 'Replication lag for each database replica in seconds',
+    labelNames: ['replica'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly dbReplicaHealthy = new Gauge({
+    name: 'database_replica_healthy',
+    help: 'Replica health state where 1 is healthy and 0 is unhealthy',
+    labelNames: ['replica'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly dbReplicaCount = new Gauge({
+    name: 'database_replica_count',
+    help: 'Number of configured database replicas currently observed',
+    registers: [this.registry],
+  });
+
   private readonly rentPayments = new Counter({
     name: 'rent_payments_total',
     help: 'Total rent payment attempts',
@@ -193,6 +213,18 @@ export class MetricsService implements OnModuleInit {
     this.dbQueryAvgTimeMs.set(avgTimeMs);
     this.dbTps.set(tps);
     this.dbCacheHitRatio.set(cacheHitRatio);
+  }
+
+  setReplicationLag(replica: string, lagSeconds: number): void {
+    this.dbReplicationLagSeconds.set({ replica }, lagSeconds);
+  }
+
+  setReplicaHealth(replica: string, healthy: boolean): void {
+    this.dbReplicaHealthy.set({ replica }, healthy ? 1 : 0);
+  }
+
+  setReplicaCount(count: number): void {
+    this.dbReplicaCount.set(count);
   }
 
   recordDatabaseQuery(queryType: string, durationMs: number): void {

--- a/backend/src/modules/monitoring/monitoring.module.ts
+++ b/backend/src/modules/monitoring/monitoring.module.ts
@@ -13,6 +13,7 @@ import { ErrorEscalationService } from './error-escalation.service';
 import { StructuredLoggerService } from './structured-logger.service';
 import { PerformanceMonitorService } from './performance-monitor.service';
 import { DatabaseMonitorService } from './database-monitor.service';
+import { DatabaseReplicationService } from './database-replication.service';
 import { WebhookSignatureService } from '../webhooks/webhook-signature.service';
 import { WebhookSignatureGuard } from '../webhooks/guards/webhook-signature.guard';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -34,6 +35,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     PerformanceMonitorService,
     PerformanceMiddleware,
     DatabaseMonitorService,
+    DatabaseReplicationService,
     WebhookSignatureService,
     WebhookSignatureGuard,
   ],
@@ -46,6 +48,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     PerformanceMonitorService,
     PerformanceMiddleware,
     DatabaseMonitorService,
+    DatabaseReplicationService,
   ],
 })
 export class MonitoringModule implements NestModule {

--- a/backend/test/database-replication.e2e-spec.ts
+++ b/backend/test/database-replication.e2e-spec.ts
@@ -1,0 +1,286 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { QueryRunner } from 'typeorm';
+import {
+  createDatabaseConnectionOptions,
+  hasReplicaDatabaseConfig,
+} from '../src/database/database-config';
+import { MetricsService } from '../src/modules/monitoring/metrics.service';
+import { DatabaseReplicationService } from '../src/modules/monitoring/database-replication.service';
+
+const makeQueryRunner = (queryImplementation?: jest.Mock): QueryRunner =>
+  ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    query: queryImplementation ?? jest.fn().mockResolvedValue([]),
+    release: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as QueryRunner;
+
+describe('Database Replication Integration (e2e)', () => {
+  const originalEnv = { ...process.env };
+
+  let module: TestingModule;
+  let service: DatabaseReplicationService;
+  let metricsService: MetricsService;
+  let mockDataSource: {
+    query: jest.Mock;
+    createQueryRunner: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    process.env = {
+      ...originalEnv,
+      DB_HOST: 'primary-db',
+      DB_PORT: '5432',
+      DB_USERNAME: 'postgres',
+      DB_PASSWORD: 'postgres-secret',
+      DB_NAME: 'chioma',
+      DB_REPLICA_HOST: 'replica-db',
+      DB_REPLICA_PORT: '5432',
+      DB_REPLICA_USERNAME: 'replica-user',
+      DB_REPLICA_PASSWORD: 'replica-secret',
+      DB_REPLICA_NAME: 'chioma',
+      DB_REPLICATION_MAX_LAG_SECONDS: '10',
+    };
+
+    mockDataSource = {
+      query: jest.fn(),
+      createQueryRunner: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        MetricsService,
+        DatabaseReplicationService,
+        {
+          provide: getDataSourceToken(),
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile();
+
+    service = module.get(DatabaseReplicationService);
+    metricsService = module.get(MetricsService);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    if (module) {
+      await module.close();
+    }
+  });
+
+  describe('Replication setup', () => {
+    it('builds replication-aware TypeORM options when replica env vars are present', () => {
+      const options = createDatabaseConnectionOptions(
+        '/virtual/backend/src',
+        ['/virtual/backend/src/migrations/*.ts'],
+        process.env,
+      );
+
+      expect(hasReplicaDatabaseConfig(process.env)).toBe(true);
+      expect(options).toHaveProperty('replication');
+      expect(options).toMatchObject({
+        replication: {
+          master: {
+            host: 'primary-db',
+            port: 5432,
+            username: 'postgres',
+            database: 'chioma',
+          },
+          slaves: [
+            {
+              host: 'replica-db',
+              port: 5432,
+              username: 'replica-user',
+              database: 'chioma',
+            },
+          ],
+        },
+      });
+    });
+
+    it('falls back to the standard primary connection config when replica env vars are absent', () => {
+      delete process.env.DB_REPLICA_HOST;
+      delete process.env.DB_REPLICA_PORT;
+      delete process.env.DB_REPLICA_USERNAME;
+      delete process.env.DB_REPLICA_PASSWORD;
+      delete process.env.DB_REPLICA_NAME;
+
+      const options = createDatabaseConnectionOptions(
+        '/virtual/backend/src',
+        ['/virtual/backend/src/migrations/*.ts'],
+        process.env,
+      );
+
+      expect(hasReplicaDatabaseConfig(process.env)).toBe(false);
+      expect(options).not.toHaveProperty('replication');
+      expect(options).toMatchObject({
+        host: 'primary-db',
+        port: 5432,
+        username: 'postgres',
+        database: 'chioma',
+      });
+    });
+  });
+
+  describe('Replication monitoring and failover', () => {
+    it('captures streaming replica metrics and reports failover readiness', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([{ primary_writable: true }])
+        .mockResolvedValueOnce([
+          {
+            replica: 'replica-db',
+            state: 'streaming',
+            sync_state: 'async',
+            lag_bytes: 128,
+            replay_lag_seconds: 0.5,
+          },
+        ]);
+
+      const snapshot = await service.getReplicationStatus();
+      const metrics = await metricsService.getMetrics();
+
+      expect(snapshot.replicationConfigured).toBe(true);
+      expect(snapshot.primaryWritable).toBe(true);
+      expect(snapshot.failoverReady).toBe(true);
+      expect(snapshot.healthyReplicaCount).toBe(1);
+      expect(snapshot.replicas).toEqual([
+        {
+          replica: 'replica-db',
+          state: 'streaming',
+          syncState: 'async',
+          lagBytes: 128,
+          lagSeconds: 0.5,
+          healthy: true,
+        },
+      ]);
+      expect(metrics).toContain('database_replication_lag_seconds');
+      expect(metrics).toContain('replica="replica-db"');
+      expect(metrics).toContain('database_replica_count');
+    });
+
+    it('marks failover as not ready when the replica is unhealthy or lagging', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([{ primary_writable: true }])
+        .mockResolvedValueOnce([
+          {
+            replica: 'replica-db',
+            state: 'startup',
+            sync_state: 'async',
+            lag_bytes: 4096,
+            replay_lag_seconds: 12,
+          },
+        ]);
+
+      const snapshot = await service.getReplicationStatus();
+
+      expect(snapshot.failoverReady).toBe(false);
+      expect(snapshot.healthyReplicaCount).toBe(0);
+      expect(snapshot.replicas[0]).toMatchObject({
+        replica: 'replica-db',
+        healthy: false,
+        lagSeconds: 12,
+      });
+    });
+
+    it('returns a disabled snapshot when replication is not configured', async () => {
+      delete process.env.DB_REPLICA_HOST;
+      delete process.env.DB_REPLICA_PORT;
+      delete process.env.DB_REPLICA_USERNAME;
+      delete process.env.DB_REPLICA_PASSWORD;
+      delete process.env.DB_REPLICA_NAME;
+
+      const snapshot = await service.getReplicationStatus();
+
+      expect(snapshot).toMatchObject({
+        replicationConfigured: false,
+        primaryWritable: false,
+        failoverReady: false,
+        healthyReplicaCount: 0,
+        replicas: [],
+      });
+      expect(mockDataSource.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Consistency verification', () => {
+    it('verifies primary and replica return consistent data and releases both runners', async () => {
+      const primaryRunner = makeQueryRunner(
+        jest.fn().mockResolvedValue([{ id: 1, status: 'open' }]),
+      );
+      const replicaRunner = makeQueryRunner(
+        jest.fn().mockResolvedValue([{ status: 'open', id: 1 }]),
+      );
+      mockDataSource.createQueryRunner
+        .mockReturnValueOnce(primaryRunner)
+        .mockReturnValueOnce(replicaRunner);
+
+      const result = await service.verifyReplicaConsistency(
+        'SELECT id, status FROM disputes ORDER BY id',
+      );
+
+      expect(mockDataSource.createQueryRunner).toHaveBeenNthCalledWith(
+        1,
+        'master',
+      );
+      expect(mockDataSource.createQueryRunner).toHaveBeenNthCalledWith(
+        2,
+        'slave',
+      );
+      expect(result.matched).toBe(true);
+      expect(primaryRunner.connect).toHaveBeenCalledTimes(1);
+      expect(replicaRunner.connect).toHaveBeenCalledTimes(1);
+      expect(primaryRunner.release).toHaveBeenCalledTimes(1);
+      expect(replicaRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('detects data divergence between primary and replica results', async () => {
+      const primaryRunner = makeQueryRunner(
+        jest.fn().mockResolvedValue([{ id: 1, status: 'resolved' }]),
+      );
+      const replicaRunner = makeQueryRunner(
+        jest.fn().mockResolvedValue([{ id: 1, status: 'open' }]),
+      );
+      mockDataSource.createQueryRunner
+        .mockReturnValueOnce(primaryRunner)
+        .mockReturnValueOnce(replicaRunner);
+
+      const result = await service.verifyReplicaConsistency(
+        'SELECT id, status FROM disputes ORDER BY id',
+      );
+
+      expect(result.matched).toBe(false);
+      expect(result.primaryRows).toEqual([{ id: 1, status: 'resolved' }]);
+      expect(result.replicaRows).toEqual([{ id: 1, status: 'open' }]);
+    });
+  });
+
+  describe('Recovery procedures', () => {
+    it('reports recovery status for the replica and cleans up the query runner', async () => {
+      const replicaRunner = makeQueryRunner(
+        jest.fn().mockResolvedValue([
+          {
+            replica: '10.0.0.22',
+            in_recovery: true,
+            replay_paused: false,
+          },
+        ]),
+      );
+      mockDataSource.createQueryRunner.mockReturnValue(replicaRunner);
+
+      const recovery = await service.getRecoveryStatus();
+
+      expect(recovery).toEqual([
+        {
+          replica: '10.0.0.22',
+          inRecovery: true,
+          replayPaused: false,
+        },
+      ]);
+      expect(mockDataSource.createQueryRunner).toHaveBeenCalledWith('slave');
+      expect(replicaRunner.connect).toHaveBeenCalledTimes(1);
+      expect(replicaRunner.release).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR resolves Issue #1146 by adding backend integration coverage for database replication setup, monitoring, failover readiness, consistency validation, replication lag tracking, and recovery status checks.

## What Changed
- Added a shared database connection config builder with optional replica support.
- Reused the shared config in the Nest runtime TypeORM setup and the TypeORM CLI data source.
- Added a `DatabaseReplicationService` for:
  - replication configuration detection
  - replication status snapshots
  - failover readiness checks
  - replica consistency verification
  - recovery status inspection
- Added replication Prometheus metrics for:
  - replica lag
  - replica health
  - replica count
- Added integration-style tests covering replication scenarios.
- Moved backend pnpm-specific settings into `backend/pnpm-workspace.yaml` so `pnpm install --frozen-lockfile` matches the backend lockfile configuration.

## Coverage Against Issue #1146
This PR covers:
- replication setup and monitoring
- failover mechanism validation
- data consistency verification
- replication lag monitoring
- recovery procedure checks

## Verification
Attempted:
- formatting of changed backend files
- `git diff --check`
- backend install verification
- targeted backend lint/type/test execution

Confirmed:
- `git diff --check` is clean
- backend pnpm lockfile/config mismatch is fixed
- the remaining install failures in this Codex environment are caused by blocked registry access, not by the repository changes

## Environment Limitation
Full local execution of `pnpm exec` test/lint/typecheck could not be completed in this Codex environment because npm registry tarball fetches are blocked here with repeated `EACCES`/timeout failures. GitHub Actions should be able to complete those steps with normal registry access.

## Issue
Closes #1146