### PR TITLE
feat: add escrow, tenant screening, messaging, and logging API integrations

### DIFF
--- a/frontend/lib/api/escrow.ts
+++ b/frontend/lib/api/escrow.ts
@@ -1,0 +1,98 @@
+import { apiClient } from '../api-client';
+
+export type EscrowStatus =
+  | 'created'
+  | 'funded'
+  | 'released'
+  | 'refunded'
+  | 'disputed'
+  | 'resolved';
+
+export interface Escrow {
+  id: string;
+  propertyId: string;
+  tenantId: string;
+  landlordId: string;
+  amount: number;
+  currency: string;
+  status: EscrowStatus;
+  createdAt: string;
+  updatedAt: string;
+  releasedAt: string | null;
+  refundedAt: string | null;
+}
+
+export interface EscrowDispute {
+  id: string;
+  escrowId: string;
+  initiatedBy: string;
+  reason: string;
+  status: 'open' | 'under_review' | 'resolved';
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+export interface CreateEscrowPayload {
+  propertyId: string;
+  tenantId: string;
+  landlordId: string;
+  amount: number;
+  currency?: string;
+}
+
+export const escrowApi = {
+  create: async (payload: CreateEscrowPayload): Promise<Escrow> => {
+    const response = await apiClient.post<Escrow>('/escrow', payload);
+    return response.data;
+  },
+
+  getDetails: async (escrowId: string): Promise<Escrow> => {
+    const response = await apiClient.get<Escrow>(
+      `/escrow/${encodeURIComponent(escrowId)}`,
+    );
+    return response.data;
+  },
+
+  releaseFunds: async (escrowId: string): Promise<Escrow> => {
+    const response = await apiClient.post<Escrow>(
+      `/escrow/${encodeURIComponent(escrowId)}/release`,
+    );
+    return response.data;
+  },
+
+  refund: async (escrowId: string): Promise<Escrow> => {
+    const response = await apiClient.post<Escrow>(
+      `/escrow/${encodeURIComponent(escrowId)}/refund`,
+    );
+    return response.data;
+  },
+
+  getStatus: async (escrowId: string): Promise<{ status: EscrowStatus }> => {
+    const response = await apiClient.get<{ status: EscrowStatus }>(
+      `/escrow/${encodeURIComponent(escrowId)}/status`,
+    );
+    return response.data;
+  },
+
+  openDispute: async (
+    escrowId: string,
+    reason: string,
+  ): Promise<EscrowDispute> => {
+    const response = await apiClient.post<EscrowDispute>(
+      `/escrow/${encodeURIComponent(escrowId)}/dispute`,
+      { reason },
+    );
+    return response.data;
+  },
+
+  getDispute: async (escrowId: string): Promise<EscrowDispute | null> => {
+    try {
+      const response = await apiClient.get<EscrowDispute>(
+        `/escrow/${encodeURIComponent(escrowId)}/dispute`,
+      );
+      return response.data;
+    } catch {
+      return null;
+    }
+  },
+};

--- a/frontend/lib/api/logging.ts
+++ b/frontend/lib/api/logging.ts
@@ -1,0 +1,102 @@
+import { apiClient } from '../api-client';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface RequestLog {
+  id: string;
+  method: string;
+  path: string;
+  statusCode: number;
+  latencyMs: number;
+  timestamp: string;
+  correlationId: string;
+  sensitiveDataMasked: boolean;
+}
+
+export interface LogFilter {
+  level?: LogLevel;
+  startDate?: string;
+  endDate?: string;
+  path?: string;
+  minStatusCode?: number;
+  maxStatusCode?: number;
+  page?: number;
+  limit?: number;
+}
+
+export interface LogsPage {
+  logs: RequestLog[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface ErrorRate {
+  windowMs: number;
+  total: number;
+  errors: number;
+  rate: number;
+}
+
+export interface DebugReport {
+  generatedAt: string;
+  errorRate: ErrorRate;
+  slowestEndpoints: Array<{ path: string; avgLatencyMs: number }>;
+  topErrors: Array<{ statusCode: number; count: number }>;
+}
+
+const SENSITIVE_FIELDS = ['password', 'token', 'secret', 'authorization', 'creditCard'];
+
+export function maskSensitiveFields<T extends Record<string, unknown>>(
+  data: T,
+): T {
+  return Object.fromEntries(
+    Object.entries(data).map(([k, v]) => [
+      k,
+      SENSITIVE_FIELDS.some((f) => k.toLowerCase().includes(f))
+        ? '***'
+        : v,
+    ]),
+  ) as T;
+}
+
+export const loggingApi = {
+  getLogs: async (filter: LogFilter = {}): Promise<LogsPage> => {
+    const params = new URLSearchParams();
+    if (filter.level) params.set('level', filter.level);
+    if (filter.startDate) params.set('startDate', filter.startDate);
+    if (filter.endDate) params.set('endDate', filter.endDate);
+    if (filter.path) params.set('path', filter.path);
+    if (filter.minStatusCode != null)
+      params.set('minStatusCode', String(filter.minStatusCode));
+    if (filter.maxStatusCode != null)
+      params.set('maxStatusCode', String(filter.maxStatusCode));
+    if (filter.page != null) params.set('page', String(filter.page));
+    if (filter.limit != null) params.set('limit', String(filter.limit));
+
+    const query = params.toString();
+    const response = await apiClient.get<LogsPage>(
+      `/logs${query ? `?${query}` : ''}`,
+    );
+    return response.data;
+  },
+
+  getErrorRate: async (windowMs = 60_000): Promise<ErrorRate> => {
+    const response = await apiClient.get<ErrorRate>(
+      `/logs/error-rate?windowMs=${windowMs}`,
+    );
+    return response.data;
+  },
+
+  getDebugReport: async (): Promise<DebugReport> => {
+    const response = await apiClient.get<DebugReport>('/logs/debug-report');
+    return response.data;
+  },
+
+  rotateLog: async (): Promise<{ rotatedAt: string }> => {
+    const response = await apiClient.post<{ rotatedAt: string }>(
+      '/logs/rotate',
+    );
+    return response.data;
+  },
+};

--- a/frontend/lib/api/messaging.ts
+++ b/frontend/lib/api/messaging.ts
@@ -1,0 +1,95 @@
+import { apiClient } from '../api-client';
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  recipientId: string;
+  content: string;
+  isRead: boolean;
+  deliveryStatus: 'sent' | 'delivered' | 'read';
+  createdAt: string;
+}
+
+export interface Conversation {
+  id: string;
+  participantIds: string[];
+  lastMessage: Message | null;
+  unreadCount: number;
+  updatedAt: string;
+}
+
+export interface MessagesPage {
+  messages: Message[];
+  total: number;
+  page: number;
+  limit: number;
+  hasNextPage: boolean;
+}
+
+export interface SendMessagePayload {
+  conversationId: string;
+  recipientId: string;
+  content: string;
+}
+
+let ws: WebSocket | null = null;
+
+export const messagingApi = {
+  sendMessage: async (payload: SendMessagePayload): Promise<Message> => {
+    const response = await apiClient.post<Message>('/messages', payload);
+    return response.data;
+  },
+
+  getMessages: async (
+    conversationId: string,
+    page = 1,
+    limit = 20,
+  ): Promise<MessagesPage> => {
+    const response = await apiClient.get<MessagesPage>(
+      `/messages/${encodeURIComponent(conversationId)}?page=${page}&limit=${limit}`,
+    );
+    return response.data;
+  },
+
+  markAsRead: async (messageId: string): Promise<void> => {
+    await apiClient.patch(`/messages/${encodeURIComponent(messageId)}/read`);
+  },
+
+  deleteMessage: async (messageId: string): Promise<void> => {
+    await apiClient.delete(`/messages/${encodeURIComponent(messageId)}`);
+  },
+
+  getConversations: async (): Promise<Conversation[]> => {
+    const response = await apiClient.get<Conversation[]>('/conversations');
+    return response.data;
+  },
+
+  connectRealtime: (
+    onMessage: (msg: Message) => void,
+    onError?: (err: Event) => void,
+  ): (() => void) => {
+    if (typeof window === 'undefined') return () => {};
+
+    const wsUrl =
+      process.env.NEXT_PUBLIC_WS_URL ?? 'ws://localhost:5000/ws/messages';
+
+    ws = new WebSocket(wsUrl);
+
+    ws.onmessage = (event: MessageEvent) => {
+      try {
+        const msg = JSON.parse(event.data as string) as Message;
+        onMessage(msg);
+      } catch {
+        // ignore malformed frames
+      }
+    };
+
+    if (onError) ws.onerror = onError;
+
+    return () => {
+      ws?.close();
+      ws = null;
+    };
+  },
+};

--- a/frontend/lib/api/tenant-screening.ts
+++ b/frontend/lib/api/tenant-screening.ts
@@ -1,0 +1,98 @@
+import { apiClient } from '../api-client';
+
+export type ScreeningStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'error';
+
+export interface ScreeningRequest {
+  tenantId: string;
+  propertyId: string;
+  consentGranted: boolean;
+}
+
+export interface ScreeningSubmission {
+  screeningId: string;
+  status: ScreeningStatus;
+  estimatedCompletionMs: number;
+  createdAt: string;
+}
+
+export interface ScreeningResult {
+  screeningId: string;
+  tenantId: string;
+  status: ScreeningStatus;
+  creditScore: number | null;
+  incomeVerified: boolean;
+  backgroundClear: boolean;
+  recommendation: 'approve' | 'decline' | 'review';
+  completedAt: string | null;
+  expiresAt: string | null;
+}
+
+const POLL_INTERVAL_MS = 3_000;
+const MAX_POLL_ATTEMPTS = 60;
+
+export const tenantScreeningApi = {
+  submitRequest: async (
+    payload: ScreeningRequest,
+  ): Promise<ScreeningSubmission> => {
+    const response = await apiClient.post<ScreeningSubmission>(
+      '/screening/requests',
+      payload,
+    );
+    return response.data;
+  },
+
+  getStatus: async (screeningId: string): Promise<ScreeningSubmission> => {
+    const response = await apiClient.get<ScreeningSubmission>(
+      `/screening/requests/${encodeURIComponent(screeningId)}/status`,
+    );
+    return response.data;
+  },
+
+  getResults: async (screeningId: string): Promise<ScreeningResult> => {
+    const response = await apiClient.get<ScreeningResult>(
+      `/screening/requests/${encodeURIComponent(screeningId)}/results`,
+    );
+    return response.data;
+  },
+
+  /** Poll until status is terminal or MAX_POLL_ATTEMPTS is reached. */
+  pollUntilComplete: async (
+    screeningId: string,
+    onProgress?: (status: ScreeningStatus) => void,
+  ): Promise<ScreeningResult> => {
+    const TERMINAL: ScreeningStatus[] = ['completed', 'failed', 'error'];
+    let attempts = 0;
+
+    while (attempts < MAX_POLL_ATTEMPTS) {
+      const submission = await tenantScreeningApi.getStatus(screeningId);
+      onProgress?.(submission.status);
+
+      if (TERMINAL.includes(submission.status)) {
+        return tenantScreeningApi.getResults(screeningId);
+      }
+
+      await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+      attempts++;
+    }
+
+    throw new Error(
+      `Screening ${screeningId} did not complete within the polling window`,
+    );
+  },
+
+  getCache: async (tenantId: string): Promise<ScreeningResult | null> => {
+    try {
+      const response = await apiClient.get<ScreeningResult>(
+        `/screening/cache/${encodeURIComponent(tenantId)}`,
+      );
+      return response.data;
+    } catch {
+      return null;
+    }
+  },
+};


### PR DESCRIPTION
## Summary

All new files live under `frontend/lib/api/` and use the existing `apiClient` throughout.

- **#1164**: `escrow.ts` — `escrowApi` with `create`, `getDetails`, `releaseFunds`, `refund`, `getStatus`, `openDispute`, and `getDispute`.
- **#1166**: `tenant-screening.ts` — `tenantScreeningApi` with `submitRequest`, `getStatus`, `getResults`, `pollUntilComplete` (handles long-running requests with status polling up to 60 retries), and `getCache`.
- **#1168**: `messaging.ts` — `messagingApi` with `sendMessage`, `getMessages` (paginated), `markAsRead`, `deleteMessage`, `getConversations`, and `connectRealtime` (WebSocket for real-time updates with a disconnect cleanup function returned from the call).
- **#1184**: `logging.ts` — `loggingApi` with `getLogs` (with `LogFilter` for level/date/path/status filtering), `getErrorRate`, `getDebugReport`, `rotateLog`, and a `maskSensitiveFields` utility for client-side data masking before logging.

## Test plan
- [ ] `pnpm run type-check` passes with no errors in the new files
- [ ] `apiClient` import resolves correctly in all four modules
- [ ] WebSocket in `messagingApi.connectRealtime` is no-op during SSR (`typeof window === 'undefined'`)

Closes #1164
Closes #1166
Closes #1168
Closes #1184