### PR TITLE
[CONTRACT] Expand test coverage for agent_registry

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fastrand"

--- a/contract/contracts/agent_registry/src/tests.rs
+++ b/contract/contracts/agent_registry/src/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Bytes, Env, String,
+};
 
 fn create_contract(env: &Env) -> AgentRegistryContractClient<'_> {
     let contract_id = env.register(AgentRegistryContract, ());
@@ -745,4 +748,263 @@ fn test_transaction_completion_webhook_delivery() {
     client.complete_transaction(&txn_id_2, &agent);
     let agent_info_after_second = client.get_agent_info(&agent).unwrap();
     assert_eq!(agent_info_after_second.completed_agreements, 2);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Event Emission Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_emits_event() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    let events_before = env.events().all().len();
+
+    client.initialize(&admin);
+
+    let events = env.events().all();
+    assert!(events.len() > events_before);
+}
+
+#[test]
+fn test_register_agent_emits_event() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    assert!(!env.events().all().is_empty());
+}
+
+#[test]
+fn test_verify_agent_emits_event() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    client.verify_agent(&admin, &agent);
+
+    assert!(!env.events().all().is_empty());
+}
+
+#[test]
+fn test_register_transaction_emits_event() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+
+    let txn_id = String::from_str(&env, "TXN-EVT-001");
+    let parties = vec![&env, tenant];
+    client.register_transaction(&txn_id, &agent, &parties);
+
+    assert!(!env.events().all().is_empty());
+}
+
+#[test]
+fn test_rate_agent_emits_event() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    let landlord = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    client.verify_agent(&admin, &agent);
+    let txn_id = String::from_str(&env, "TXN-EVT-002");
+    let parties = vec![&env, tenant.clone(), landlord.clone()];
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &agent);
+
+    let events_before = env.events().all().len();
+    client.rate_agent(&tenant, &agent, &5, &txn_id);
+
+    let events = env.events().all();
+    assert!(events.len() > events_before);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edge Cases & Error Path Assertions
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_state_returns_none_before_initialization() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    assert!(client.get_state().is_none());
+}
+
+#[test]
+fn test_get_agent_info_returns_none_for_non_existent_agent() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let stranger = Address::generate(&env);
+    assert!(client.get_agent_info(&stranger).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_register_transaction_fails_when_not_initialized() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let agent = Address::generate(&env);
+    env.mock_all_auths();
+    let txn_id = String::from_str(&env, "TXN-NO-INIT");
+    let parties = vec![&env, Address::generate(&env)];
+    client.register_transaction(&txn_id, &agent, &parties);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_register_transaction_fails_when_agent_not_found() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let txn_id = String::from_str(&env, "TXN-NO-AGENT");
+    let parties = vec![&env, Address::generate(&env)];
+    client.register_transaction(&txn_id, &agent, &parties);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_complete_transaction_fails_when_not_initialized() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    env.mock_all_auths();
+    let txn_id = String::from_str(&env, "TXN-NO-INIT");
+    client.complete_transaction(&txn_id, &Address::generate(&env));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_complete_transaction_fails_when_transaction_not_found() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let txn_id = String::from_str(&env, "TXN-NOT-FOUND");
+    client.complete_transaction(&txn_id, &Address::generate(&env));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_complete_transaction_fails_with_wrong_agent() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let wrong_agent = Address::generate(&env);
+    let tenant = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    let profile_hash = String::from_str(&env, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+    client.register_agent(&agent, &profile_hash);
+    let txn_id = String::from_str(&env, "TXN-WRONG-AGENT");
+    let parties = vec![&env, tenant];
+    client.register_transaction(&txn_id, &agent, &parties);
+    client.complete_transaction(&txn_id, &wrong_agent);
+}
+
+#[test]
+fn test_multiple_agents_have_independent_state() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let agent1 = Address::generate(&env);
+    let agent2 = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let hash1 = String::from_str(&env, "QmHashOne");
+    let hash2 = String::from_str(&env, "QmHashTwo");
+    client.register_agent(&agent1, &hash1);
+    client.register_agent(&agent2, &hash2);
+
+    assert_eq!(client.get_agent_count(), 2);
+
+    let info1 = client.get_agent_info(&agent1).unwrap();
+    let info2 = client.get_agent_info(&agent2).unwrap();
+    assert_eq!(info1.external_profile_hash, hash1);
+    assert_eq!(info2.external_profile_hash, hash2);
+    assert_ne!(info1.agent, info2.agent);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Upgrade Proposal Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_upgrade_propose_fails_when_not_initialized() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    env.mock_all_auths();
+    let proposer = Address::generate(&env);
+    let pid = String::from_str(&env, "UPGRADE-001");
+    let wasm_hash = Bytes::from_array(&env, &[0u8; 32]);
+    let notes = String::from_str(&env, "test upgrade");
+    client.propose_upgrade(&proposer, &pid, &wasm_hash, &notes, &1000);
+}
+
+#[test]
+fn test_upgrade_propose_fails_when_not_admin() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let pid = String::from_str(&env, "UPGRADE-002");
+    let wasm_hash = Bytes::from_array(&env, &[0u8; 32]);
+    let notes = String::from_str(&env, "test upgrade");
+    let result = client.try_propose_upgrade(&proposer, &pid, &wasm_hash, &notes, &1000);
+    assert_eq!(result, Err(Ok(AgentError::Unauthorized)));
+}
+
+#[test]
+fn test_upgrade_propose_and_get() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let pid = String::from_str(&env, "UPGRADE-003");
+    let wasm_hash = Bytes::from_array(&env, &[1u8; 32]);
+    let notes = String::from_str(&env, "valid upgrade");
+    let result = client.try_propose_upgrade(&admin, &pid, &wasm_hash, &notes, &1000);
+    assert!(result.is_ok());
+
+    let proposal = client.try_get_upgrade_proposal(&pid).unwrap().unwrap();
+    assert_eq!(proposal.id, pid);
+    assert_eq!(proposal.proposer, admin);
+    assert_eq!(proposal.wasm_hash, wasm_hash);
+    assert_eq!(proposal.notes, notes);
+    assert!(!proposal.executed);
 }


### PR DESCRIPTION
## Summary

Expands test coverage for the `agent_registry` contract from 29 to 45 tests, adding coverage for event emissions, error paths, edge cases, and upgrade proposals.

## Changes

### Event Emission Tests (5 new)
- `test_initialize_emits_event`
- `test_register_agent_emits_event`
- `test_verify_agent_emits_event`
- `test_register_transaction_emits_event`
- `test_rate_agent_emits_event`

### Error Path Tests (5 new)
- `test_register_transaction_fails_when_not_initialized`
- `test_register_transaction_fails_when_agent_not_found`
- `test_complete_transaction_fails_when_not_initialized`
- `test_complete_transaction_fails_when_transaction_not_found`
- `test_complete_transaction_fails_with_wrong_agent`

### Edge Case Tests (3 new)
- `test_get_state_returns_none_before_initialization`
- `test_get_agent_info_returns_none_for_non_existent_agent`
- `test_multiple_agents_have_independent_state`

### Upgrade Proposal Tests (3 new)
- `test_upgrade_propose_fails_when_not_initialized`
- `test_upgrade_propose_fails_when_not_admin`
- `test_upgrade_propose_and_get`

## Verification
- `cargo test -p agent_registry` — ✅ all 45 tests pass
- `cargo fmt --all -- --check` — ✅ clean
- `cargo clippy --all-targets --all-features -- -D warnings` — ✅ clean

Closes #1283