### PR TITLE
feat: Web Vitals monitoring (LCP, CLS, INP)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -74,6 +74,22 @@ window.__CHIOMA_ERROR_REPORTER__ = (payload) => {
 };
 ```
 
+### Real-user Web Vitals
+
+Core Web Vitals (LCP, CLS, INP) are collected via `useReportWebVitals` from `next/web-vitals`:
+
+- Client reporter: `components/web-vitals/WebVitalsReporter.tsx` (mounted in `RootLayoutClient`)
+- Anonymized sink: `POST /api/web-vitals` (pathname-only route, no query/PII)
+- Viewable dashboard: [`/vitals`](http://localhost:3000/vitals)
+
+Optional external hook:
+
+```ts
+window.__CHIOMA_WEB_VITALS_REPORTER__ = (payload) => {
+  // Forward { name, value, rating, route, ... } to your RUM vendor
+};
+```
+
 ## Pipeline Validation with Makefile
 
 ### Frontend Pipeline Checks

--- a/frontend/__tests__/app/api/web-vitals.route.test.ts
+++ b/frontend/__tests__/app/api/web-vitals.route.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { POST, GET } from '@/app/api/web-vitals/route';
+import { NextRequest } from 'next/server';
+
+function jsonRequest(url: string, body?: unknown, method = 'POST') {
+  return new NextRequest(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe('/api/web-vitals', () => {
+  beforeEach(async () => {
+    // Seed via POST so GET has something deterministic for this process
+  });
+
+  it('rejects invalid payloads', async () => {
+    const res = await POST(
+      jsonRequest('http://localhost/api/web-vitals', { name: 'LCP' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts sanitizes and stores core vitals', async () => {
+    const res = await POST(
+      jsonRequest('http://localhost/api/web-vitals', {
+        name: 'LCP',
+        value: 2100,
+        rating: 'needs-improvement',
+        id: 'lcp-test-1',
+        navigationType: 'navigate',
+        route: '/properties?email=a@b.com',
+        entries: [{ dangerous: true }],
+      }),
+    );
+    expect(res.status).toBe(202);
+
+    const getRes = await GET(
+      new NextRequest('http://localhost/api/web-vitals?name=LCP&limit=5'),
+    );
+    expect(getRes.status).toBe(200);
+    const data = await getRes.json();
+    expect(data.metrics.length).toBeGreaterThan(0);
+    expect(data.metrics[0].route).toBe('/properties');
+    expect(JSON.stringify(data)).not.toContain('email=');
+    expect(JSON.stringify(data)).not.toContain('dangerous');
+    expect(data.latest.LCP).toBeDefined();
+  });
+});

--- a/frontend/__tests__/lib/web-vitals.test.ts
+++ b/frontend/__tests__/lib/web-vitals.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  sanitizeRoute,
+  toWebVitalPayload,
+  reportWebVital,
+  setWebVitalSink,
+} from '@/lib/web-vitals';
+
+describe('sanitizeRoute', () => {
+  it('keeps pathname only', () => {
+    expect(sanitizeRoute('/properties?q=secret@email.com')).toBe('/properties');
+  });
+
+  it('strips hash and normalizes trailing slash', () => {
+    expect(sanitizeRoute('/user/analytics/#section')).toBe('/user/analytics');
+  });
+
+  it('extracts pathname from absolute URLs', () => {
+    expect(sanitizeRoute('https://chioma.app/user?wallet=GABCDEF')).toBe(
+      '/user',
+    );
+  });
+
+  it('falls back to / for empty input', () => {
+    expect(sanitizeRoute('')).toBe('/');
+    expect(sanitizeRoute(null)).toBe('/');
+  });
+});
+
+describe('toWebVitalPayload', () => {
+  it('builds a PII-safe payload and omits entries', () => {
+    const payload = toWebVitalPayload(
+      {
+        name: 'LCP',
+        value: 1234.5,
+        rating: 'good',
+        delta: 10,
+        id: 'v1-abc',
+        navigationType: 'navigate',
+        entries: [{ name: 'should-not-appear' }],
+      },
+      '/properties?token=abc',
+    );
+
+    expect(payload).toEqual({
+      name: 'LCP',
+      value: 1234.5,
+      rating: 'good',
+      delta: 10,
+      id: 'v1-abc',
+      navigationType: 'navigate',
+      route: '/properties',
+      timestamp: expect.any(String),
+    });
+    expect(payload).not.toHaveProperty('entries');
+    expect(JSON.stringify(payload)).not.toContain('should-not-appear');
+    expect(JSON.stringify(payload)).not.toContain('token=');
+  });
+
+  it('maps unknown ratings safely', () => {
+    const payload = toWebVitalPayload(
+      { name: 'CLS', value: 0.05, id: 'x', rating: 'weird' },
+      '/',
+    );
+    expect(payload.rating).toBe('unknown');
+  });
+});
+
+describe('reportWebVital', () => {
+  beforeEach(() => {
+    setWebVitalSink(null);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 202 }),
+    );
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+    });
+  });
+
+  afterEach(() => {
+    setWebVitalSink(null);
+    vi.unstubAllGlobals();
+    delete window.__CHIOMA_WEB_VITALS_REPORTER__;
+  });
+
+  it('forwards to sink, beacon, and optional window reporter', () => {
+    const sink = vi.fn();
+    const external = vi.fn();
+    setWebVitalSink(sink);
+    window.__CHIOMA_WEB_VITALS_REPORTER__ = external;
+
+    const result = reportWebVital(
+      {
+        name: 'INP',
+        value: 80,
+        rating: 'good',
+        id: 'inp-1',
+        navigationType: 'navigate',
+      },
+      '/vitals?user=secret',
+    );
+
+    expect(result.route).toBe('/vitals');
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'INP', route: '/vitals' }),
+    );
+    expect(external).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'INP', route: '/vitals' }),
+    );
+    expect(navigator.sendBeacon).toHaveBeenCalled();
+    const beaconArg = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as Blob;
+    expect(beaconArg.type).toBe('application/json');
+  });
+});

--- a/frontend/app/RootLayoutClient.tsx
+++ b/frontend/app/RootLayoutClient.tsx
@@ -12,6 +12,7 @@ import { ModalManager } from '@/components/modals';
 import { OfflineIndicator } from '@/components/offline';
 import { ToastProvider } from '@/components/ui';
 import { RouteAnnouncer } from '@/components/accessibility/RouteAnnouncer';
+import { WebVitalsReporter } from '@/components/web-vitals';
 
 export function RootLayoutClient({ children }: { children: React.ReactNode }) {
   return (
@@ -20,6 +21,7 @@ export function RootLayoutClient({ children }: { children: React.ReactNode }) {
         <ErrorProvider>
           <StoreHydrator />
           <ErrorMonitoringProvider />
+          <WebVitalsReporter />
           <PwaController />
           <NetworkStatusBanner />
           <RateLimitNotifier />

--- a/frontend/app/api/web-vitals/route.ts
+++ b/frontend/app/api/web-vitals/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  sanitizeRoute,
+  toWebVitalPayload,
+  type RawWebVitalMetric,
+  type WebVitalPayload,
+} from '@/lib/web-vitals';
+
+const MAX_BUFFER = 200;
+
+/** In-process ring buffer for local aggregation / GET dashboard. */
+const buffer: WebVitalPayload[] = [];
+
+function push(payload: WebVitalPayload) {
+  buffer.unshift(payload);
+  if (buffer.length > MAX_BUFFER) buffer.length = MAX_BUFFER;
+}
+
+function isValidBody(body: unknown): body is RawWebVitalMetric & {
+  route?: string;
+  timestamp?: string;
+} {
+  if (!body || typeof body !== 'object') return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.name === 'string' &&
+    typeof b.value === 'number' &&
+    Number.isFinite(b.value) &&
+    typeof b.id === 'string'
+  );
+}
+
+/**
+ * Ingest anonymized Web Vitals from the browser (sendBeacon / fetch).
+ * Re-sanitizes on the server so query strings / entries never stick.
+ */
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (!isValidBody(body)) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const payload = toWebVitalPayload(
+    {
+      name: body.name,
+      value: body.value,
+      rating: typeof body.rating === 'string' ? body.rating : undefined,
+      delta: typeof body.delta === 'number' ? body.delta : undefined,
+      id: body.id,
+      navigationType:
+        typeof body.navigationType === 'string'
+          ? body.navigationType
+          : undefined,
+    },
+    typeof body.route === 'string' ? body.route : sanitizeRoute('/'),
+  );
+
+  // Prefer client-provided sanitized route if already set
+  if (typeof body.route === 'string') {
+    payload.route = sanitizeRoute(body.route);
+  }
+
+  push(payload);
+
+  // Structured log for terminal / log aggregation
+  console.info(
+    JSON.stringify({
+      type: 'web_vital',
+      ...payload,
+    }),
+  );
+
+  return NextResponse.json({ ok: true }, { status: 202 });
+}
+
+/**
+ * Recent aggregated vitals (this Node process). Useful for local demos
+ * and ops dashboards without an external RUM vendor.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const name = searchParams.get('name');
+  const limitRaw = searchParams.get('limit');
+  const limit = Math.min(
+    Math.max(parseInt(limitRaw || '50', 10) || 50, 1),
+    MAX_BUFFER,
+  );
+
+  let items = buffer;
+  if (name) {
+    items = buffer.filter((m) => m.name === name);
+  }
+
+  const latest: Partial<Record<string, WebVitalPayload>> = {};
+  for (const m of buffer) {
+    if (!latest[m.name]) latest[m.name] = m;
+  }
+
+  return NextResponse.json({
+    count: items.length,
+    latest,
+    metrics: items.slice(0, limit),
+  });
+}

--- a/frontend/app/user/financials/page.tsx
+++ b/frontend/app/user/financials/page.tsx
@@ -380,9 +380,7 @@ export default function FinancialsPage() {
   }, [txPage]);
   const revenueData = useMemo(() => {
     const items = txPage?.data ?? [];
-    return items.length === 0
-      ? MOCK_REVENUE_DATA
-      : deriveMonthlyRevenue(items);
+    return items.length === 0 ? MOCK_REVENUE_DATA : deriveMonthlyRevenue(items);
   }, [txPage]);
 
   const xlmBalance = readAssetBalance(networkAccount, 'XLM');

--- a/frontend/app/vitals/page.tsx
+++ b/frontend/app/vitals/page.tsx
@@ -1,0 +1,26 @@
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/landing/Footer';
+import { WebVitalsPanel } from '@/components/web-vitals';
+
+export const metadata = {
+  title: 'Web Vitals',
+  description:
+    'Real-user Core Web Vitals (LCP, CLS, INP) collected by Chioma — anonymized pathname-only payloads.',
+};
+
+export default function WebVitalsPage() {
+  return (
+    <main className="relative min-h-screen bg-ink-900 text-cream">
+      <div
+        className="pointer-events-none absolute inset-0 bg-grain opacity-60"
+        aria-hidden
+      />
+
+      <div className="relative z-10">
+        <Navbar />
+        <WebVitalsPanel />
+        <Footer />
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/web-vitals/WebVitalsPanel.tsx
+++ b/frontend/components/web-vitals/WebVitalsPanel.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Gauge, RefreshCw, Trash2 } from 'lucide-react';
+import {
+  CORE_WEB_VITAL_NAMES,
+  type CoreWebVitalName,
+  type WebVitalPayload,
+  type WebVitalRating,
+} from '@/lib/web-vitals';
+import { useWebVitalsStore } from '@/store/webVitalsStore';
+
+const METRIC_COPY: Record<CoreWebVitalName, { title: string; hint: string }> = {
+  LCP: {
+    title: 'Largest Contentful Paint',
+    hint: 'How quickly the main content appears',
+  },
+  CLS: {
+    title: 'Cumulative Layout Shift',
+    hint: 'Visual stability while the page loads',
+  },
+  INP: {
+    title: 'Interaction to Next Paint',
+    hint: 'Responsiveness to clicks and taps',
+  },
+};
+
+function formatValue(name: string, value: number): string {
+  if (name === 'CLS') return value.toFixed(3);
+  return `${Math.round(value)}ms`;
+}
+
+function ratingLabel(rating: WebVitalRating | 'unknown'): string {
+  if (rating === 'needs-improvement') return 'Needs work';
+  if (rating === 'unknown') return 'Pending';
+  return rating.charAt(0).toUpperCase() + rating.slice(1);
+}
+
+function ratingStyles(rating: WebVitalRating | 'unknown'): string {
+  switch (rating) {
+    case 'good':
+      return 'text-brand-green border-brand-green/30 bg-brand-green/10';
+    case 'needs-improvement':
+      return 'text-brass-300 border-brass-500/30 bg-brass-500/10';
+    case 'poor':
+      return 'text-ember border-ember/30 bg-ember/10';
+    default:
+      return 'text-cream-dim border-cream/10 bg-ink-800';
+  }
+}
+
+function MetricTile({
+  name,
+  metric,
+  index,
+}: {
+  name: CoreWebVitalName;
+  metric?: WebVitalPayload;
+  index: number;
+}) {
+  const copy = METRIC_COPY[name];
+
+  return (
+    <motion.div
+      data-testid={`web-vital-card-${name}`}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.45, delay: 0.08 * index }}
+      className="py-8 px-6 lg:px-8 text-center lg:text-left"
+    >
+      <div className="flex items-center justify-center lg:justify-start gap-3 mb-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brass-400">
+          {name}
+        </p>
+        {metric ? (
+          <span
+            className={`rounded-full border px-2.5 py-0.5 text-[10px] font-semibold tracking-wide ${ratingStyles(metric.rating)}`}
+          >
+            {ratingLabel(metric.rating)}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="font-display text-4xl md:text-5xl text-cream tabular-nums leading-none">
+        {metric ? (
+          <span className="text-brass-300">
+            {formatValue(name, metric.value)}
+          </span>
+        ) : (
+          <span className="text-cream/25">—</span>
+        )}
+      </p>
+
+      <p className="mt-3 text-sm text-cream font-medium">{copy.title}</p>
+      <p className="mt-1 text-sm text-cream-dim leading-snug">{copy.hint}</p>
+
+      {metric ? (
+        <p className="mt-4 font-mono text-[11px] text-cream-dim/70">
+          {metric.route}
+          <span className="mx-1.5 text-cream/20">·</span>
+          {metric.navigationType}
+        </p>
+      ) : (
+        <p className="mt-4 text-xs text-cream-dim/50">
+          Waiting for a real-user sample…
+        </p>
+      )}
+    </motion.div>
+  );
+}
+
+export function WebVitalsPanel() {
+  const sessionMetrics = useWebVitalsStore((s) => s.metrics);
+  const clear = useWebVitalsStore((s) => s.clear);
+  const [serverMetrics, setServerMetrics] = useState<WebVitalPayload[]>([]);
+  const [serverLatest, setServerLatest] = useState<
+    Partial<Record<string, WebVitalPayload>>
+  >({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sessionLatest = useMemo(() => {
+    const map: Partial<Record<string, WebVitalPayload>> = {};
+    for (const m of sessionMetrics) {
+      if (!map[m.name]) map[m.name] = m;
+    }
+    return map;
+  }, [sessionMetrics]);
+
+  const fetchServer = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/web-vitals?limit=50', {
+        cache: 'no-store',
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as {
+        metrics: WebVitalPayload[];
+        latest: Partial<Record<string, WebVitalPayload>>;
+      };
+      setServerMetrics(data.metrics ?? []);
+      setServerLatest(data.latest ?? {});
+    } catch {
+      setError('Could not load aggregated vitals from the API sink.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Defer so the initial fetch does not setState synchronously in this effect.
+    const boot = window.setTimeout(() => {
+      void fetchServer();
+    }, 0);
+    const id = window.setInterval(() => void fetchServer(), 5000);
+    return () => {
+      window.clearTimeout(boot);
+      window.clearInterval(id);
+    };
+  }, [fetchServer]);
+
+  const displayLatest = useMemo(() => {
+    return {
+      ...serverLatest,
+      ...sessionLatest,
+    };
+  }, [serverLatest, sessionLatest]);
+
+  const history = useMemo(() => {
+    const byId = new Map<string, WebVitalPayload>();
+    for (const m of [...sessionMetrics, ...serverMetrics]) {
+      const key = `${m.id}:${m.name}:${m.timestamp}`;
+      if (!byId.has(key)) byId.set(key, m);
+    }
+    return Array.from(byId.values()).slice(0, 40);
+  }, [sessionMetrics, serverMetrics]);
+
+  return (
+    <div data-testid="web-vitals-panel">
+      {/* Intro */}
+      <section className="relative pt-10 pb-16 lg:pt-14 lg:pb-20">
+        <div className="container mx-auto px-4 sm:px-6">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="max-w-2xl"
+            >
+              <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-brass-400 mb-6">
+                <span className="w-8 rule-glint" aria-hidden />
+                Real-user monitoring
+              </p>
+
+              <h1 className="font-display text-4xl md:text-5xl lg:text-6xl text-cream leading-[1.08]">
+                How the product{' '}
+                <em className="text-brass-300 not-italic border-b-4 border-brass-500/40">
+                  feels
+                </em>{' '}
+                in the wild.
+              </h1>
+
+              <p className="mt-6 text-lg text-cream-dim leading-relaxed max-w-xl">
+                LCP, CLS, and INP from this session and the local aggregation
+                sink. Routes are pathname-only, no query strings, wallets, or
+                personal data.
+              </p>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.45, delay: 0.12 }}
+              className="flex flex-wrap items-center gap-3"
+            >
+              <button
+                type="button"
+                onClick={() => void fetchServer()}
+                disabled={loading}
+                className="inline-flex items-center gap-2 rounded-full bg-cream text-ink-900 px-5 py-2.5 text-sm font-semibold hover:bg-brass-300 transition-colors disabled:opacity-50"
+              >
+                <RefreshCw
+                  className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`}
+                />
+                Refresh sink
+              </button>
+              <button
+                type="button"
+                onClick={clear}
+                className="inline-flex items-center gap-2 rounded-full border border-cream/15 bg-ink-800 px-5 py-2.5 text-sm font-semibold text-cream hover:border-brass-500/40 hover:text-brass-300 transition-colors"
+              >
+                <Trash2 className="h-4 w-4" />
+                Clear session
+              </button>
+            </motion.div>
+          </div>
+
+          {error ? (
+            <p className="mt-6 text-sm text-ember" role="status">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      {/* Core metrics — Stats strip pattern */}
+      <section className="relative border-y border-cream/8 bg-ink-800/60">
+        <div className="container mx-auto px-4 sm:px-6">
+          <div className="grid sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-cream/8">
+            {CORE_WEB_VITAL_NAMES.map((name, index) => (
+              <MetricTile
+                key={name}
+                name={name}
+                metric={displayLatest[name]}
+                index={index}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* History */}
+      <section className="relative py-20 lg:py-28">
+        <div className="container mx-auto px-4 sm:px-6">
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.45 }}
+            className="max-w-2xl mb-12"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brass-400 mb-4">
+              Recent samples
+            </p>
+            <h2 className="font-display text-3xl md:text-4xl text-cream leading-tight">
+              Session store and server ring buffer.
+            </h2>
+            <p className="mt-3 text-cream-dim text-sm leading-relaxed">
+              Anonymized payloads only — metric name, value, rating, and route
+              pathname.
+            </p>
+          </motion.div>
+
+          {history.length === 0 ? (
+            <div className="border-t border-cream/8 py-16 text-center">
+              <Gauge
+                className="mx-auto h-8 w-8 text-brass-400/50 mb-4"
+                strokeWidth={1.5}
+              />
+              <p className="font-display text-2xl text-cream mb-2">
+                No samples yet
+              </p>
+              <p className="text-sm text-cream-dim max-w-md mx-auto">
+                Browse a few pages, interact with the UI, then return here. CLS
+                and INP often finalize when you switch tabs or leave a page.
+              </p>
+            </div>
+          ) : (
+            <div>
+              {/* Column labels */}
+              <div className="hidden md:grid grid-cols-12 gap-4 border-b border-cream/8 pb-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-cream-dim/60">
+                <div className="col-span-2">Metric</div>
+                <div className="col-span-2">Value</div>
+                <div className="col-span-2">Rating</div>
+                <div className="col-span-4">Route</div>
+                <div className="col-span-2 text-right">Time</div>
+              </div>
+
+              <ul>
+                {history.map((m, index) => (
+                  <motion.li
+                    key={`${m.id}-${m.name}-${m.timestamp}`}
+                    initial={{ opacity: 0, y: 10 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, margin: '-40px' }}
+                    transition={{
+                      duration: 0.35,
+                      delay: Math.min(index, 8) * 0.03,
+                    }}
+                    className="grid grid-cols-1 md:grid-cols-12 gap-2 md:gap-4 border-t border-cream/8 py-5 hover:border-brass-500/30 transition-colors"
+                  >
+                    <div className="md:col-span-2 flex items-center gap-2">
+                      <span className="md:hidden text-[11px] uppercase tracking-widest text-cream-dim/50">
+                        Metric
+                      </span>
+                      <span className="text-sm font-semibold text-cream">
+                        {m.name}
+                      </span>
+                    </div>
+                    <div className="md:col-span-2 flex items-center gap-2">
+                      <span className="md:hidden text-[11px] uppercase tracking-widest text-cream-dim/50">
+                        Value
+                      </span>
+                      <span className="font-display text-xl text-brass-300 tabular-nums">
+                        {formatValue(m.name, m.value)}
+                      </span>
+                    </div>
+                    <div className="md:col-span-2 flex items-center gap-2">
+                      <span className="md:hidden text-[11px] uppercase tracking-widest text-cream-dim/50">
+                        Rating
+                      </span>
+                      <span
+                        className={`rounded-full border px-2.5 py-0.5 text-[11px] font-semibold ${ratingStyles(m.rating)}`}
+                      >
+                        {ratingLabel(m.rating)}
+                      </span>
+                    </div>
+                    <div className="md:col-span-4 flex items-center gap-2 min-w-0">
+                      <span className="md:hidden text-[11px] uppercase tracking-widest text-cream-dim/50">
+                        Route
+                      </span>
+                      <span className="font-mono text-xs text-cream-dim truncate">
+                        {m.route}
+                      </span>
+                    </div>
+                    <div className="md:col-span-2 flex items-center justify-between md:justify-end gap-2">
+                      <span className="md:hidden text-[11px] uppercase tracking-widest text-cream-dim/50">
+                        Time
+                      </span>
+                      <span className="text-xs text-cream-dim/70 tabular-nums">
+                        {new Date(m.timestamp).toLocaleTimeString()}
+                      </span>
+                    </div>
+                  </motion.li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/web-vitals/WebVitalsReporter.tsx
+++ b/frontend/components/web-vitals/WebVitalsReporter.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { useReportWebVitals } from 'next/web-vitals';
+import { reportWebVital, setWebVitalSink } from '@/lib/web-vitals';
+import { useWebVitalsStore } from '@/store/webVitalsStore';
+
+/**
+ * Mounts once at the root. Collects real-user Web Vitals via next/web-vitals
+ * and forwards anonymized payloads to the in-app store + API sink.
+ *
+ * Callback identity is stable so Next does not re-emit historical metrics
+ * on every render (see useReportWebVitals docs).
+ */
+export function WebVitalsReporter() {
+  const pathname = usePathname();
+  const pathnameRef = useRef(pathname);
+  const addMetric = useWebVitalsStore((s) => s.addMetric);
+
+  useEffect(() => {
+    pathnameRef.current = pathname;
+  }, [pathname]);
+
+  useEffect(() => {
+    setWebVitalSink(addMetric);
+    return () => setWebVitalSink(null);
+  }, [addMetric]);
+
+  const onReport = useCallback(
+    (metric: Parameters<typeof reportWebVital>[0]) => {
+      reportWebVital(metric, pathnameRef.current);
+    },
+    [],
+  );
+
+  useReportWebVitals(onReport);
+
+  return null;
+}

--- a/frontend/components/web-vitals/index.ts
+++ b/frontend/components/web-vitals/index.ts
@@ -1,0 +1,2 @@
+export { WebVitalsReporter } from './WebVitalsReporter';
+export { WebVitalsPanel } from './WebVitalsPanel';

--- a/frontend/hooks/use-retry-state.ts
+++ b/frontend/hooks/use-retry-state.ts
@@ -96,7 +96,8 @@ export function useRetryState(): RetryState {
   return useSyncExternalStore(subscribe, getCachedSnapshot, getCachedSnapshot);
 }
 
-const cachedEndpointMetrics: Map<string, RetryEndpointMetrics | null> = new Map();
+const cachedEndpointMetrics: Map<string, RetryEndpointMetrics | null> =
+  new Map();
 
 export function useEndpointRetryMetrics(
   endpoint: string,

--- a/frontend/lib/web-vitals/index.ts
+++ b/frontend/lib/web-vitals/index.ts
@@ -1,0 +1,11 @@
+export {
+  CORE_WEB_VITAL_NAMES,
+  isCoreWebVitalName,
+  type CoreWebVitalName,
+  type RawWebVitalMetric,
+  type WebVitalName,
+  type WebVitalPayload,
+  type WebVitalRating,
+} from './types';
+export { sanitizeRoute, toWebVitalPayload } from './sanitize';
+export { reportWebVital, setWebVitalSink, type WebVitalSink } from './report';

--- a/frontend/lib/web-vitals/report.ts
+++ b/frontend/lib/web-vitals/report.ts
@@ -1,0 +1,79 @@
+import { toWebVitalPayload } from './sanitize';
+import type { RawWebVitalMetric, WebVitalPayload } from './types';
+
+declare global {
+  interface Window {
+    __CHIOMA_WEB_VITALS_REPORTER__?: (payload: WebVitalPayload) => void;
+  }
+}
+
+export type WebVitalSink = (payload: WebVitalPayload) => void;
+
+let extraSink: WebVitalSink | null = null;
+
+/** Register an in-app sink (e.g. zustand store). */
+export function setWebVitalSink(sink: WebVitalSink | null) {
+  extraSink = sink;
+}
+
+function postToApi(payload: WebVitalPayload) {
+  if (typeof window === 'undefined') return;
+
+  const body = JSON.stringify(payload);
+
+  try {
+    if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+      const blob = new Blob([body], { type: 'application/json' });
+      const sent = navigator.sendBeacon('/api/web-vitals', blob);
+      if (sent) return;
+    }
+  } catch {
+    // fall through to fetch
+  }
+
+  void fetch('/api/web-vitals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // Swallow network errors — vitals must never break the app
+  });
+}
+
+/**
+ * Report a single Web Vital. Safe for production: no PII, non-throwing.
+ */
+export function reportWebVital(
+  metric: RawWebVitalMetric,
+  route?: string | null,
+) {
+  const payload = toWebVitalPayload(
+    metric,
+    route ??
+      (typeof window !== 'undefined' ? window.location.pathname : undefined),
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+     
+    console.info('[Chioma Web Vital]', payload);
+  }
+
+  try {
+    extraSink?.(payload);
+  } catch {
+    // ignore sink failures
+  }
+
+  if (typeof window !== 'undefined' && window.__CHIOMA_WEB_VITALS_REPORTER__) {
+    try {
+      window.__CHIOMA_WEB_VITALS_REPORTER__(payload);
+    } catch {
+      // ignore external reporter failures
+    }
+  }
+
+  postToApi(payload);
+
+  return payload;
+}

--- a/frontend/lib/web-vitals/report.ts
+++ b/frontend/lib/web-vitals/report.ts
@@ -55,7 +55,6 @@ export function reportWebVital(
   );
 
   if (process.env.NODE_ENV !== 'production') {
-     
     console.info('[Chioma Web Vital]', payload);
   }
 

--- a/frontend/lib/web-vitals/sanitize.ts
+++ b/frontend/lib/web-vitals/sanitize.ts
@@ -1,0 +1,69 @@
+import type {
+  RawWebVitalMetric,
+  WebVitalPayload,
+  WebVitalRating,
+} from './types';
+
+const ALLOWED_RATINGS: readonly WebVitalRating[] = [
+  'good',
+  'needs-improvement',
+  'poor',
+];
+
+/**
+ * Strip query/hash and reject absolute URLs so metrics never carry PII
+ * from search params (wallet, email, tokens, etc.).
+ */
+export function sanitizeRoute(input?: string | null): string {
+  if (!input || typeof input !== 'string') return '/';
+
+  let path = input.trim();
+
+  try {
+    if (/^https?:\/\//i.test(path)) {
+      path = new URL(path).pathname;
+    }
+  } catch {
+    return '/';
+  }
+
+  const q = path.indexOf('?');
+  if (q !== -1) path = path.slice(0, q);
+  const h = path.indexOf('#');
+  if (h !== -1) path = path.slice(0, h);
+
+  path = path.replace(/\/{2,}/g, '/');
+  if (!path.startsWith('/')) path = `/${path}`;
+  if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1);
+
+  return path || '/';
+}
+
+function toRating(rating?: string): WebVitalRating | 'unknown' {
+  if (rating && (ALLOWED_RATINGS as readonly string[]).includes(rating)) {
+    return rating as WebVitalRating;
+  }
+  return 'unknown';
+}
+
+/**
+ * Build a PII-safe payload. Explicitly omits `entries` and any user identifiers.
+ */
+export function toWebVitalPayload(
+  metric: RawWebVitalMetric,
+  route?: string | null,
+): WebVitalPayload {
+  return {
+    name: metric.name,
+    value: Number.isFinite(metric.value) ? metric.value : 0,
+    rating: toRating(metric.rating),
+    delta: Number.isFinite(metric.delta) ? (metric.delta as number) : 0,
+    id: typeof metric.id === 'string' ? metric.id.slice(0, 64) : 'unknown',
+    navigationType:
+      typeof metric.navigationType === 'string'
+        ? metric.navigationType
+        : 'unknown',
+    route: sanitizeRoute(route),
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/frontend/lib/web-vitals/types.ts
+++ b/frontend/lib/web-vitals/types.ts
@@ -1,0 +1,41 @@
+/**
+ * PII-safe Core Web Vitals payload.
+ * Never include wallet addresses, emails, query strings, or DOM entries.
+ */
+
+export const CORE_WEB_VITAL_NAMES = ['LCP', 'CLS', 'INP'] as const;
+
+export type CoreWebVitalName = (typeof CORE_WEB_VITAL_NAMES)[number];
+
+export type WebVitalName =
+  CoreWebVitalName | 'FCP' | 'TTFB' | 'FID' | (string & {});
+
+export type WebVitalRating = 'good' | 'needs-improvement' | 'poor';
+
+/** Shape accepted from next/web-vitals Metric (subset we use). */
+export interface RawWebVitalMetric {
+  name: string;
+  value: number;
+  rating?: string;
+  delta?: number;
+  id: string;
+  navigationType?: string;
+  /** Must never be forwarded — can contain DOM / attribution details. */
+  entries?: unknown;
+}
+
+export interface WebVitalPayload {
+  name: WebVitalName;
+  value: number;
+  rating: WebVitalRating | 'unknown';
+  delta: number;
+  id: string;
+  navigationType: string;
+  /** Pathname only — no query or hash. */
+  route: string;
+  timestamp: string;
+}
+
+export function isCoreWebVitalName(name: string): name is CoreWebVitalName {
+  return (CORE_WEB_VITAL_NAMES as readonly string[]).includes(name);
+}

--- a/frontend/lib/web-vitals/types.ts
+++ b/frontend/lib/web-vitals/types.ts
@@ -7,8 +7,10 @@ export const CORE_WEB_VITAL_NAMES = ['LCP', 'CLS', 'INP'] as const;
 
 export type CoreWebVitalName = (typeof CORE_WEB_VITAL_NAMES)[number];
 
-export type WebVitalName =
-  CoreWebVitalName | 'FCP' | 'TTFB' | 'FID' | (string & {});
+type KnownWebVitalName = CoreWebVitalName | 'FCP' | 'TTFB' | 'FID';
+
+/** Known vitals plus open string for forward-compat with next/web-vitals. */
+export type WebVitalName = KnownWebVitalName | (string & {});
 
 export type WebVitalRating = 'good' | 'needs-improvement' | 'poor';
 

--- a/frontend/store/webVitalsStore.ts
+++ b/frontend/store/webVitalsStore.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { create } from 'zustand';
+import { withMiddleware } from './middleware';
+import type { WebVitalPayload } from '@/lib/web-vitals';
+
+const MAX_ENTRIES = 100;
+
+interface WebVitalsState {
+  metrics: WebVitalPayload[];
+  addMetric: (payload: WebVitalPayload) => void;
+  clear: () => void;
+  /** Latest sample per metric name (session). */
+  latestByName: () => Partial<Record<string, WebVitalPayload>>;
+}
+
+export const useWebVitalsStore = create<WebVitalsState>()(
+  withMiddleware(
+    (set, get) => ({
+      metrics: [],
+      addMetric: (payload) =>
+        set((state) => {
+          state.metrics.unshift(payload);
+          if (state.metrics.length > MAX_ENTRIES) {
+            state.metrics.length = MAX_ENTRIES;
+          }
+        }),
+      clear: () =>
+        set((state) => {
+          state.metrics = [];
+        }),
+      latestByName: () => {
+        const map: Partial<Record<string, WebVitalPayload>> = {};
+        for (const m of get().metrics) {
+          if (!map[m.name]) map[m.name] = m;
+        }
+        return map;
+      },
+    }),
+    'web-vitals',
+  ),
+);


### PR DESCRIPTION
## Summary
- Hook `useReportWebVitals` from `next/web-vitals` in a root-mounted client reporter
- Send PII-safe payloads (pathname only, no query/`entries`) to `POST /api/web-vitals`, a session store, and optional `window.__CHIOMA_WEB_VITALS_REPORTER__`
- Add a branded `/vitals` dashboard showing LCP/CLS/INP plus recent anonymized samples

Closes #1276

## Test plan
- [ ] `cd frontend && pnpm test -- __tests__/lib/web-vitals.test.ts __tests__/app/api/web-vitals.route.test.ts`
- [ ] `cd frontend && pnpm run build` (or `make ci`)
- [ ] Open `/`, navigate to `/properties`, interact with the UI
- [ ] Open `/vitals` and confirm LCP/CLS/INP cards populate (CLS/INP may finalize on tab hide)
- [ ] Confirm `GET /api/web-vitals` returns pathname-only routes (no query strings)
- [ ] Attach screenshot/recording of `/vitals` for reviewers

## Demo note
Screenshot `/vitals` after browsing a few pages. Console shows `[Chioma Web Vital]` in development; the API route logs JSON lines with `type: "web_vital"`.

<img width="1838" height="1116" alt="Screenshot 2026-07-22 at 12 41 32 AM" src="https://github.com/user-attachments/assets/1621f6d8-1619-482d-b4cc-14f2aff3c955" />

<img width="1838" height="1116" alt="Screenshot 2026-07-22 at 12 41 42 AM" src="https://github.com/user-attachments/assets/bdc6e8f0-a200-4df8-ad55-6bc67d433ce2" />

<img width="1838" height="1116" alt="Screenshot 2026-07-22 at 12 41 47 AM" src="https://github.com/user-attachments/assets/7029bafc-76e7-4100-be94-9ea711f1b973" />

