### PR TITLE
feat: add developer webhooks controller

### DIFF
--- a/backend/src/modules/webhooks/dto/create-webhook-endpoint.dto.ts
+++ b/backend/src/modules/webhooks/dto/create-webhook-endpoint.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MinLength,
+} from 'class-validator';
+
+export class CreateWebhookEndpointDto {
+  @ApiProperty({ example: 'https://example.com/webhooks/chioma' })
+  @IsUrl()
+  url: string;
+
+  @ApiProperty({
+    example: ['payment.received', 'agreement.activated'],
+    isArray: true,
+    type: String,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  events: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Shared secret used to sign outbound payloads. A default from WEBHOOK_SIGNATURE_SECRET is used when omitted.',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  secret?: string;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/backend/src/modules/webhooks/dto/retry-webhook-delivery.dto.ts
+++ b/backend/src/modules/webhooks/dto/retry-webhook-delivery.dto.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class RetryWebhookDeliveryDto {
+  @ApiPropertyOptional({
+    description:
+      'ID of an existing delivery to redeliver. When omitted, event and payload are used to trigger a new delivery.',
+  })
+  @IsOptional()
+  @IsString()
+  deliveryId?: string;
+
+  @ApiPropertyOptional({ example: 'payment.received' })
+  @IsOptional()
+  @IsString()
+  event?: string;
+
+  @ApiPropertyOptional({
+    description: 'JSON-encoded string or object payload to send',
+  })
+  @IsOptional()
+  payload?: unknown;
+}

--- a/backend/src/modules/webhooks/dto/trigger-webhook-event.dto.ts
+++ b/backend/src/modules/webhooks/dto/trigger-webhook-event.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class TriggerWebhookEventDto {
+  @ApiProperty({ example: 'payment.received' })
+  @IsString()
+  @IsNotEmpty()
+  event: string;
+
+  @ApiPropertyOptional({
+    description: 'JSON-encoded string or object payload to send',
+  })
+  @IsOptional()
+  payload?: unknown;
+}

--- a/backend/src/modules/webhooks/dto/update-webhook-endpoint.dto.ts
+++ b/backend/src/modules/webhooks/dto/update-webhook-endpoint.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateWebhookEndpointDto } from './create-webhook-endpoint.dto';
+
+export class UpdateWebhookEndpointDto extends PartialType(
+  CreateWebhookEndpointDto,
+) {}

--- a/backend/src/modules/webhooks/webhooks.controller.spec.ts
+++ b/backend/src/modules/webhooks/webhooks.controller.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+import { CreateWebhookEndpointDto } from './dto/create-webhook-endpoint.dto';
+import { UpdateWebhookEndpointDto } from './dto/update-webhook-endpoint.dto';
+
+describe('WebhooksController', () => {
+  let controller: WebhooksController;
+  let service: jest.Mocked<
+    Pick<
+      WebhooksService,
+      | 'createEndpoint'
+      | 'listEndpointsForUser'
+      | 'listDeliveriesForUser'
+      | 'updateEndpoint'
+      | 'deleteEndpoint'
+      | 'triggerTestEvent'
+      | 'retryDelivery'
+    >
+  >;
+
+  const req = { user: { id: 'user-1' } };
+
+  beforeEach(async () => {
+    service = {
+      createEndpoint: jest.fn(),
+      listEndpointsForUser: jest.fn(),
+      listDeliveriesForUser: jest.fn(),
+      updateEndpoint: jest.fn(),
+      deleteEndpoint: jest.fn(),
+      triggerTestEvent: jest.fn(),
+      retryDelivery: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WebhooksController],
+      providers: [{ provide: WebhooksService, useValue: service }],
+    }).compile();
+
+    controller = module.get<WebhooksController>(WebhooksController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('delegates endpoint creation to the service, scoped to the caller', async () => {
+      const dto: CreateWebhookEndpointDto = {
+        url: 'https://example.com/webhook',
+        events: ['payment.received'],
+      };
+      const created = { id: 'ep-1', ...dto };
+      service.createEndpoint.mockResolvedValue(created as never);
+
+      await expect(controller.create(req, dto)).resolves.toEqual(created);
+      expect(service.createEndpoint).toHaveBeenCalledWith('user-1', dto);
+    });
+  });
+
+  describe('list', () => {
+    it('delegates listing to the service, scoped to the caller', async () => {
+      const endpoints = [{ id: 'ep-1' }];
+      service.listEndpointsForUser.mockResolvedValue(endpoints as never);
+
+      await expect(controller.list(req)).resolves.toEqual(endpoints);
+      expect(service.listEndpointsForUser).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('listDeliveries', () => {
+    it('delegates delivery history lookup to the service', async () => {
+      const deliveries = [{ id: 'del-1' }];
+      service.listDeliveriesForUser.mockResolvedValue(deliveries as never);
+
+      await expect(controller.listDeliveries(req, 'ep-1')).resolves.toEqual(
+        deliveries,
+      );
+      expect(service.listDeliveriesForUser).toHaveBeenCalledWith(
+        'user-1',
+        'ep-1',
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('delegates the update to the service', async () => {
+      const dto: UpdateWebhookEndpointDto = { url: 'https://new.example.com' };
+      const updated = { id: 'ep-1', ...dto };
+      service.updateEndpoint.mockResolvedValue(updated as never);
+
+      await expect(controller.update(req, 'ep-1', dto)).resolves.toEqual(
+        updated,
+      );
+      expect(service.updateEndpoint).toHaveBeenCalledWith(
+        'user-1',
+        'ep-1',
+        dto,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates deletion to the service and returns a success flag', async () => {
+      service.deleteEndpoint.mockResolvedValue(undefined);
+
+      await expect(controller.remove(req, 'ep-1')).resolves.toEqual({
+        success: true,
+      });
+      expect(service.deleteEndpoint).toHaveBeenCalledWith('user-1', 'ep-1');
+    });
+  });
+
+  describe('test', () => {
+    it('normalizes a JSON string payload before delegating to the service', async () => {
+      const delivery = { id: 'del-1', successful: true };
+      service.triggerTestEvent.mockResolvedValue(delivery as never);
+
+      await expect(
+        controller.test(req, 'ep-1', {
+          event: 'payment.received',
+          payload: '{"amount":100}',
+        }),
+      ).resolves.toEqual(delivery);
+      expect(service.triggerTestEvent).toHaveBeenCalledWith(
+        'user-1',
+        'ep-1',
+        'payment.received',
+        { amount: 100 },
+      );
+    });
+
+    it('passes an object payload through unchanged', async () => {
+      service.triggerTestEvent.mockResolvedValue({} as never);
+
+      await controller.test(req, 'ep-1', {
+        event: 'payment.received',
+        payload: { amount: 50 },
+      });
+
+      expect(service.triggerTestEvent).toHaveBeenCalledWith(
+        'user-1',
+        'ep-1',
+        'payment.received',
+        { amount: 50 },
+      );
+    });
+
+    it('defaults to an empty object when no payload is provided', async () => {
+      service.triggerTestEvent.mockResolvedValue({} as never);
+
+      await controller.test(req, 'ep-1', { event: 'payment.received' });
+
+      expect(service.triggerTestEvent).toHaveBeenCalledWith(
+        'user-1',
+        'ep-1',
+        'payment.received',
+        {},
+      );
+    });
+
+    it('wraps an unparsable string payload rather than dropping it', async () => {
+      service.triggerTestEvent.mockResolvedValue({} as never);
+
+      await controller.test(req, 'ep-1', {
+        event: 'payment.received',
+        payload: 'not json',
+      });
+
+      expect(service.triggerTestEvent).toHaveBeenCalledWith(
+        'user-1',
+        'ep-1',
+        'payment.received',
+        { raw: 'not json' },
+      );
+    });
+  });
+
+  describe('retry', () => {
+    it('delegates redelivery of an existing delivery by id', async () => {
+      const delivery = { id: 'del-2' };
+      service.retryDelivery.mockResolvedValue(delivery as never);
+
+      await expect(
+        controller.retry(req, 'ep-1', { deliveryId: 'del-1' }),
+      ).resolves.toEqual(delivery);
+      expect(service.retryDelivery).toHaveBeenCalledWith('user-1', 'ep-1', {
+        deliveryId: 'del-1',
+        event: undefined,
+        payload: {},
+      });
+    });
+
+    it('delegates a fresh delivery attempt using event and payload', async () => {
+      service.retryDelivery.mockResolvedValue({} as never);
+
+      await controller.retry(req, 'ep-1', {
+        event: 'payment.failed',
+        payload: '{"amount":75}',
+      });
+
+      expect(service.retryDelivery).toHaveBeenCalledWith('user-1', 'ep-1', {
+        deliveryId: undefined,
+        event: 'payment.failed',
+        payload: { amount: 75 },
+      });
+    });
+  });
+});

--- a/backend/src/modules/webhooks/webhooks.controller.ts
+++ b/backend/src/modules/webhooks/webhooks.controller.ts
@@ -1,0 +1,154 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { WebhooksService } from './webhooks.service';
+import { WebhookEvent } from './webhook-event';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateWebhookEndpointDto } from './dto/create-webhook-endpoint.dto';
+import { UpdateWebhookEndpointDto } from './dto/update-webhook-endpoint.dto';
+import { TriggerWebhookEventDto } from './dto/trigger-webhook-event.dto';
+import { RetryWebhookDeliveryDto } from './dto/retry-webhook-delivery.dto';
+
+function normalizePayload(payload: unknown): Record<string, unknown> {
+  if (payload === undefined || payload === null) return {};
+
+  if (typeof payload === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(payload);
+      return typeof parsed === 'object' && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : { value: parsed };
+    } catch {
+      return { raw: payload };
+    }
+  }
+
+  if (typeof payload === 'object') {
+    return payload as Record<string, unknown>;
+  }
+
+  return { value: payload };
+}
+
+@ApiTags('Developer Webhooks')
+@ApiBearerAuth('JWT-auth')
+@Controller('developer/webhooks')
+@UseGuards(JwtAuthGuard)
+export class WebhooksController {
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  @Post()
+  @ApiOperation({
+    summary: 'Register a webhook endpoint',
+    description:
+      'Register a URL to receive Chioma events. A signing secret is generated to use if none is provided.',
+  })
+  @ApiResponse({ status: 201, description: 'Webhook endpoint created' })
+  async create(
+    @Req() req: { user: { id: string } },
+    @Body() dto: CreateWebhookEndpointDto,
+  ) {
+    return this.webhooksService.createEndpoint(req.user.id, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List your webhook endpoints' })
+  @ApiResponse({ status: 200, description: 'List of webhook endpoints' })
+  async list(@Req() req: { user: { id: string } }) {
+    return this.webhooksService.listEndpointsForUser(req.user.id);
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'View delivery history for a webhook endpoint' })
+  @ApiParam({ name: 'id', description: 'Webhook endpoint ID' })
+  @ApiResponse({ status: 200, description: 'List of delivery attempts' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async listDeliveries(
+    @Req() req: { user: { id: string } },
+    @Param('id') id: string,
+  ) {
+    return this.webhooksService.listDeliveriesForUser(req.user.id, id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a webhook endpoint' })
+  @ApiParam({ name: 'id', description: 'Webhook endpoint ID' })
+  @ApiResponse({ status: 200, description: 'Webhook endpoint updated' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async update(
+    @Req() req: { user: { id: string } },
+    @Param('id') id: string,
+    @Body() dto: UpdateWebhookEndpointDto,
+  ) {
+    return this.webhooksService.updateEndpoint(req.user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a webhook endpoint' })
+  @ApiParam({ name: 'id', description: 'Webhook endpoint ID' })
+  @ApiResponse({ status: 200, description: 'Webhook endpoint deleted' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async remove(@Req() req: { user: { id: string } }, @Param('id') id: string) {
+    await this.webhooksService.deleteEndpoint(req.user.id, id);
+    return { success: true };
+  }
+
+  @Post(':id/test')
+  @ApiOperation({
+    summary: 'Send a test event to a webhook endpoint',
+    description:
+      'Delivers a signed test payload to the endpoint immediately and records the attempt.',
+  })
+  @ApiParam({ name: 'id', description: 'Webhook endpoint ID' })
+  @ApiResponse({ status: 201, description: 'Test delivery attempt recorded' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async test(
+    @Req() req: { user: { id: string } },
+    @Param('id') id: string,
+    @Body() dto: TriggerWebhookEventDto,
+  ) {
+    return this.webhooksService.triggerTestEvent(
+      req.user.id,
+      id,
+      dto.event as WebhookEvent,
+      normalizePayload(dto.payload),
+    );
+  }
+
+  @Post(':id/retry')
+  @ApiOperation({
+    summary: 'Retry a webhook delivery',
+    description:
+      'Redelivers an existing delivery by deliveryId, or triggers a new delivery attempt using the provided event and payload.',
+  })
+  @ApiParam({ name: 'id', description: 'Webhook endpoint ID' })
+  @ApiResponse({ status: 201, description: 'Retry delivery attempt recorded' })
+  @ApiResponse({ status: 400, description: 'Missing event or deliveryId' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async retry(
+    @Req() req: { user: { id: string } },
+    @Param('id') id: string,
+    @Body() dto: RetryWebhookDeliveryDto,
+  ) {
+    return this.webhooksService.retryDelivery(req.user.id, id, {
+      deliveryId: dto.deliveryId,
+      event: dto.event as WebhookEvent | undefined,
+      payload: normalizePayload(dto.payload),
+    });
+  }
+}

--- a/backend/src/modules/webhooks/webhooks.module.ts
+++ b/backend/src/modules/webhooks/webhooks.module.ts
@@ -6,12 +6,14 @@ import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookSignatureService } from './webhook-signature.service';
 import { WebhooksService } from './webhooks.service';
 import { WebhookSignatureGuard } from './guards/webhook-signature.guard';
+import { WebhooksController } from './webhooks.controller';
 
 @Module({
   imports: [
     ConfigModule,
     TypeOrmModule.forFeature([WebhookEndpoint, WebhookDelivery]),
   ],
+  controllers: [WebhooksController],
   providers: [WebhookSignatureService, WebhooksService, WebhookSignatureGuard],
   exports: [WebhookSignatureService, WebhooksService, WebhookSignatureGuard],
 })

--- a/backend/src/modules/webhooks/webhooks.service.spec.ts
+++ b/backend/src/modules/webhooks/webhooks.service.spec.ts
@@ -42,6 +42,13 @@ describe('WebhooksService', () => {
     endpointRepository = {
       find: jest.fn(),
       findOne: jest.fn(),
+      create: jest.fn().mockImplementation((dto) => ({ ...dto })),
+      save: jest
+        .fn()
+        .mockImplementation((e) =>
+          Promise.resolve({ ...e, id: e.id ?? 'endpoint-1' }),
+        ),
+      remove: jest.fn().mockImplementation((e) => Promise.resolve(e)),
     };
 
     deliveryRepository = {
@@ -49,6 +56,8 @@ describe('WebhooksService', () => {
       save: jest
         .fn()
         .mockImplementation((d) => Promise.resolve({ ...d, id: 'delivery-1' })),
+      findOne: jest.fn(),
+      find: jest.fn(),
     };
 
     configService = {
@@ -304,6 +313,248 @@ describe('WebhooksService', () => {
       endpointRepository.find.mockResolvedValue([]);
       const result = await service.findEndpoints(['unknown-id']);
       expect(result).toEqual([]);
+    });
+  });
+
+  // ── createEndpoint ─────────────────────────────────────────────────────────
+
+  describe('createEndpoint', () => {
+    it('creates an endpoint scoped to the given user with defaults applied', async () => {
+      const result = await service.createEndpoint('user-1', {
+        url: 'https://example.com/webhook',
+        events: ['payment.received'],
+      });
+
+      expect(endpointRepository.create).toHaveBeenCalledWith({
+        userId: 'user-1',
+        url: 'https://example.com/webhook',
+        events: ['payment.received'],
+        secret: null,
+        isActive: true,
+      });
+      expect(endpointRepository.save).toHaveBeenCalled();
+      expect(result.userId).toBe('user-1');
+    });
+
+    it('respects an explicit secret and isActive value', async () => {
+      await service.createEndpoint('user-1', {
+        url: 'https://example.com/webhook',
+        events: ['payment.received'],
+        secret: 'my-secret',
+        isActive: false,
+      });
+
+      expect(endpointRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ secret: 'my-secret', isActive: false }),
+      );
+    });
+  });
+
+  // ── listEndpointsForUser ───────────────────────────────────────────────────
+
+  describe('listEndpointsForUser', () => {
+    it('lists only endpoints belonging to the user, newest first', async () => {
+      endpointRepository.find.mockResolvedValue([mockEndpoint()]);
+
+      const result = await service.listEndpointsForUser('user-1');
+
+      expect(endpointRepository.find).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // ── getEndpointForUser ─────────────────────────────────────────────────────
+
+  describe('getEndpointForUser', () => {
+    it('returns the endpoint when owned by the user', async () => {
+      const endpoint = mockEndpoint();
+      endpointRepository.findOne.mockResolvedValue(endpoint);
+
+      await expect(
+        service.getEndpointForUser('user-1', 'endpoint-1'),
+      ).resolves.toBe(endpoint);
+      expect(endpointRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'endpoint-1', userId: 'user-1' },
+      });
+    });
+
+    it('throws NotFoundException when the endpoint does not exist or is not owned by the user', async () => {
+      endpointRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getEndpointForUser('user-1', 'missing'),
+      ).rejects.toThrow('Webhook endpoint not found');
+    });
+  });
+
+  // ── updateEndpoint ─────────────────────────────────────────────────────────
+
+  describe('updateEndpoint', () => {
+    it('applies only the provided fields', async () => {
+      const endpoint = mockEndpoint({ url: 'https://old.example.com' });
+      endpointRepository.findOne.mockResolvedValue(endpoint);
+
+      const result = await service.updateEndpoint('user-1', 'endpoint-1', {
+        url: 'https://new.example.com',
+      });
+
+      expect(result.url).toBe('https://new.example.com');
+      expect(result.events).toEqual(endpoint.events);
+    });
+
+    it('throws NotFoundException when the endpoint is not owned by the user', async () => {
+      endpointRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateEndpoint('user-1', 'missing', { url: 'https://x.com' }),
+      ).rejects.toThrow('Webhook endpoint not found');
+    });
+  });
+
+  // ── deleteEndpoint ─────────────────────────────────────────────────────────
+
+  describe('deleteEndpoint', () => {
+    it('removes the endpoint when owned by the user', async () => {
+      const endpoint = mockEndpoint();
+      endpointRepository.findOne.mockResolvedValue(endpoint);
+
+      await service.deleteEndpoint('user-1', 'endpoint-1');
+
+      expect(endpointRepository.remove).toHaveBeenCalledWith(endpoint);
+    });
+
+    it('throws NotFoundException when the endpoint is not owned by the user', async () => {
+      endpointRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.deleteEndpoint('user-1', 'missing')).rejects.toThrow(
+        'Webhook endpoint not found',
+      );
+    });
+  });
+
+  // ── listDeliveriesForUser ──────────────────────────────────────────────────
+
+  describe('listDeliveriesForUser', () => {
+    it('lists deliveries for an endpoint owned by the user', async () => {
+      endpointRepository.findOne.mockResolvedValue(mockEndpoint());
+      deliveryRepository.find.mockResolvedValue([mockDelivery()]);
+
+      const result = await service.listDeliveriesForUser(
+        'user-1',
+        'endpoint-1',
+      );
+
+      expect(deliveryRepository.find).toHaveBeenCalledWith({
+        where: { endpointId: 'endpoint-1' },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('throws NotFoundException when the endpoint is not owned by the user', async () => {
+      endpointRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.listDeliveriesForUser('user-1', 'missing'),
+      ).rejects.toThrow('Webhook endpoint not found');
+    });
+  });
+
+  // ── triggerTestEvent ───────────────────────────────────────────────────────
+
+  describe('triggerTestEvent', () => {
+    it('delivers a test event to an endpoint owned by the user', async () => {
+      const endpoint = mockEndpoint();
+      endpointRepository.findOne.mockResolvedValue(endpoint);
+      (mockedAxios.post as jest.Mock).mockResolvedValue({
+        status: 200,
+        data: 'ok',
+      });
+
+      const result = await service.triggerTestEvent(
+        'user-1',
+        'endpoint-1',
+        'payment.received',
+        { amount: 10 },
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        endpoint.url,
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(result.successful).toBe(true);
+    });
+
+    it('throws NotFoundException when the endpoint is not owned by the user', async () => {
+      endpointRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.triggerTestEvent('user-1', 'missing', 'payment.received', {}),
+      ).rejects.toThrow('Webhook endpoint not found');
+    });
+  });
+
+  // ── retryDelivery ──────────────────────────────────────────────────────────
+
+  describe('retryDelivery', () => {
+    it('redelivers an existing delivery using its original event and payload', async () => {
+      const endpoint = mockEndpoint();
+      const delivery = mockDelivery({
+        event: 'payment.failed',
+        payload: { amount: 20 },
+      });
+      endpointRepository.findOne.mockResolvedValue(endpoint);
+      deliveryRepository.findOne.mockResolvedValue(delivery);
+      (mockedAxios.post as jest.Mock).mockResolvedValue({
+        status: 200,
+        data: 'ok',
+      });
+
+      await service.retryDelivery('user-1', 'endpoint-1', {
+        deliveryId: 'delivery-1',
+      });
+
+      const rawBody = (mockedAxios.post as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(rawBody).event).toBe('payment.failed');
+    });
+
+    it('throws NotFoundException when the delivery does not belong to the endpoint', async () => {
+      endpointRepository.findOne.mockResolvedValue(mockEndpoint());
+      deliveryRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.retryDelivery('user-1', 'endpoint-1', {
+          deliveryId: 'missing',
+        }),
+      ).rejects.toThrow('Webhook delivery not found');
+    });
+
+    it('triggers a new delivery when an event is provided without a deliveryId', async () => {
+      endpointRepository.findOne.mockResolvedValue(mockEndpoint());
+      (mockedAxios.post as jest.Mock).mockResolvedValue({
+        status: 200,
+        data: 'ok',
+      });
+
+      await service.retryDelivery('user-1', 'endpoint-1', {
+        event: 'payment.received',
+        payload: { amount: 5 },
+      });
+
+      expect(deliveryRepository.findOne).not.toHaveBeenCalled();
+      expect(mockedAxios.post).toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when neither deliveryId nor event is provided', async () => {
+      endpointRepository.findOne.mockResolvedValue(mockEndpoint());
+
+      await expect(
+        service.retryDelivery('user-1', 'endpoint-1', {}),
+      ).rejects.toThrow('event is required when deliveryId is not provided');
     });
   });
 });

--- a/backend/src/modules/webhooks/webhooks.service.ts
+++ b/backend/src/modules/webhooks/webhooks.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Repository, In } from 'typeorm';
@@ -7,6 +12,13 @@ import { WebhookEndpoint } from './entities/webhook-endpoint.entity';
 import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookEvent } from './webhook-event';
 import { WebhookSignatureService } from './webhook-signature.service';
+
+export interface WebhookEndpointInput {
+  url: string;
+  events: string[];
+  secret?: string;
+  isActive?: boolean;
+}
 
 @Injectable()
 export class WebhooksService {
@@ -106,5 +118,117 @@ export class WebhooksService {
         id: In(ids),
       },
     });
+  }
+
+  async createEndpoint(
+    userId: string,
+    input: WebhookEndpointInput,
+  ): Promise<WebhookEndpoint> {
+    const endpoint = this.endpointRepository.create({
+      userId,
+      url: input.url,
+      events: input.events as WebhookEvent[],
+      secret: input.secret ?? null,
+      isActive: input.isActive ?? true,
+    });
+
+    return this.endpointRepository.save(endpoint);
+  }
+
+  async listEndpointsForUser(userId: string): Promise<WebhookEndpoint[]> {
+    return this.endpointRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getEndpointForUser(
+    userId: string,
+    id: string,
+  ): Promise<WebhookEndpoint> {
+    const endpoint = await this.endpointRepository.findOne({
+      where: { id, userId },
+    });
+
+    if (!endpoint) {
+      throw new NotFoundException('Webhook endpoint not found');
+    }
+
+    return endpoint;
+  }
+
+  async updateEndpoint(
+    userId: string,
+    id: string,
+    input: Partial<WebhookEndpointInput>,
+  ): Promise<WebhookEndpoint> {
+    const endpoint = await this.getEndpointForUser(userId, id);
+
+    if (input.url !== undefined) endpoint.url = input.url;
+    if (input.events !== undefined)
+      endpoint.events = input.events as WebhookEvent[];
+    if (input.secret !== undefined) endpoint.secret = input.secret;
+    if (input.isActive !== undefined) endpoint.isActive = input.isActive;
+
+    return this.endpointRepository.save(endpoint);
+  }
+
+  async deleteEndpoint(userId: string, id: string): Promise<void> {
+    const endpoint = await this.getEndpointForUser(userId, id);
+    await this.endpointRepository.remove(endpoint);
+  }
+
+  async listDeliveriesForUser(
+    userId: string,
+    endpointId: string,
+  ): Promise<WebhookDelivery[]> {
+    await this.getEndpointForUser(userId, endpointId);
+
+    return this.deliveryRepository.find({
+      where: { endpointId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async triggerTestEvent(
+    userId: string,
+    endpointId: string,
+    event: WebhookEvent,
+    payload: Record<string, unknown>,
+  ): Promise<WebhookDelivery> {
+    const endpoint = await this.getEndpointForUser(userId, endpointId);
+    return this.deliverEvent(endpoint, event, payload);
+  }
+
+  async retryDelivery(
+    userId: string,
+    endpointId: string,
+    options: {
+      deliveryId?: string;
+      event?: WebhookEvent;
+      payload?: Record<string, unknown>;
+    },
+  ): Promise<WebhookDelivery> {
+    const endpoint = await this.getEndpointForUser(userId, endpointId);
+
+    if (options.deliveryId) {
+      const delivery = await this.deliveryRepository.findOne({
+        where: { id: options.deliveryId, endpointId },
+      });
+
+      if (!delivery) {
+        throw new NotFoundException('Webhook delivery not found');
+      }
+
+      return this.deliverEvent(endpoint, delivery.event, delivery.payload);
+    }
+
+    if (!options.event) {
+      throw new BadRequestException(
+        'event is required when deliveryId is not provided',
+      );
+    }
+
+    return this.deliverEvent(endpoint, options.event, options.payload ?? {});
   }
 }


### PR DESCRIPTION
## Summary
- Adds `WebhooksController` exposing developer-facing endpoints to register, list, update, and delete webhook endpoints, view delivery history, send test events, and retry deliveries (by delivery ID or a fresh event/payload)
- Extends `WebhooksService` with endpoint CRUD, delivery history lookup, test-event triggering, and retry logic
- Adds DTOs (`CreateWebhookEndpointDto`, `UpdateWebhookEndpointDto`, `TriggerWebhookEventDto`, `RetryWebhookDeliveryDto`) with `class-validator` validation
- All endpoints are scoped to the authenticated user and guarded by `JwtAuthGuard`

Closes #1340

## Test plan
- [x] `npx jest src/modules/webhooks` — 88/88 tests passing
- [x] `npx eslint src/modules/webhooks --max-warnings=0` — clean
- [x] `npx tsc -p tsconfig.build.json --noEmit` — clean