### PR TITLE
feat: Property inquiries can be submitted but there is no inbox UI to…

### DIFF
--- a/backend/src/modules/inquiries/inquiries.module.ts
+++ b/backend/src/modules/inquiries/inquiries.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { InquiriesController } from './inquiries.controller';
 import { InquiriesService } from './inquiries.service';
@@ -8,7 +9,7 @@ import { PropertyInquiry } from './entities/property-inquiry.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PropertyInquiry, Property]),
+    TypeOrmModule.forFeature([PropertyInquiry, Property, User]),
     NotificationsModule,
   ],
   controllers: [InquiriesController],

--- a/backend/src/modules/inquiries/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/inquiries.service.spec.ts
@@ -11,6 +11,11 @@ describe('InquiriesService', () => {
 
   const propertyRepository = {
     findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const userRepository = {
+    find: jest.fn(),
   };
 
   const notificationsService = {
@@ -21,9 +26,12 @@ describe('InquiriesService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    propertyRepository.find.mockResolvedValue([]);
+    userRepository.find.mockResolvedValue([]);
     service = new InquiriesService(
       inquiryRepository as any,
       propertyRepository as any,
+      userRepository as any,
       notificationsService as any,
     );
   });
@@ -82,5 +90,99 @@ describe('InquiriesService', () => {
         message: 'hello',
       } as any),
     ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('enriches incoming inquiries with property details and sender contact', async () => {
+    inquiryRepository.find.mockResolvedValue([
+      {
+        id: 'inq-1',
+        propertyId: 'property-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+        senderName: 'Jane',
+        senderEmail: 'jane@example.com',
+        senderPhone: '+2340000000',
+      },
+    ]);
+    propertyRepository.find.mockResolvedValue([
+      {
+        id: 'property-1',
+        title: 'Lekki Apartment',
+        address: '1 Admiralty Way',
+        city: 'Lagos',
+        images: [{ url: 'https://img/1.png', isPrimary: true }],
+      },
+    ]);
+
+    const result = await service.listIncoming('owner-1');
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'inq-1',
+        property: {
+          id: 'property-1',
+          title: 'Lekki Apartment',
+          address: '1 Admiralty Way',
+          city: 'Lagos',
+          coverImageUrl: 'https://img/1.png',
+        },
+        counterparty: {
+          id: 'tenant-1',
+          name: 'Jane',
+          email: 'jane@example.com',
+          phone: '+2340000000',
+        },
+      }),
+    ]);
+  });
+
+  it('enriches outgoing inquiries with property details and landlord contact', async () => {
+    inquiryRepository.find.mockResolvedValue([
+      {
+        id: 'inq-1',
+        propertyId: 'property-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+      },
+    ]);
+    propertyRepository.find.mockResolvedValue([
+      {
+        id: 'property-1',
+        title: 'Lekki Apartment',
+        address: null,
+        city: null,
+        images: [],
+      },
+    ]);
+    userRepository.find.mockResolvedValue([
+      {
+        id: 'owner-1',
+        firstName: 'Ada',
+        lastName: 'Obi',
+        email: 'ada@example.com',
+        phoneNumber: null,
+      },
+    ]);
+
+    const result = await service.listOutgoing('tenant-1');
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'inq-1',
+        property: {
+          id: 'property-1',
+          title: 'Lekki Apartment',
+          address: null,
+          city: null,
+          coverImageUrl: null,
+        },
+        counterparty: {
+          id: 'owner-1',
+          name: 'Ada Obi',
+          email: 'ada@example.com',
+          phone: null,
+        },
+      }),
+    ]);
   });
 });

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -4,14 +4,35 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
 import { NotificationsService } from '../notifications/notifications.service';
 import {
   PropertyInquiry,
   PropertyInquiryStatus,
 } from './entities/property-inquiry.entity';
 import { CreatePropertyInquiryDto } from './dto/create-property-inquiry.dto';
+
+export interface InquiryPropertySummary {
+  id: string;
+  title: string;
+  address: string | null;
+  city: string | null;
+  coverImageUrl: string | null;
+}
+
+export interface InquiryCounterparty {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+}
+
+export type PropertyInquiryWithDetails = PropertyInquiry & {
+  property: InquiryPropertySummary | null;
+  counterparty: InquiryCounterparty | null;
+};
 
 @Injectable()
 export class InquiriesService {
@@ -20,6 +41,8 @@ export class InquiriesService {
     private readonly inquiryRepository: Repository<PropertyInquiry>,
     @InjectRepository(Property)
     private readonly propertyRepository: Repository<Property>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     private readonly notificationsService: NotificationsService,
   ) {}
 
@@ -66,18 +89,102 @@ export class InquiriesService {
     return saved;
   }
 
-  async listIncoming(userId: string): Promise<PropertyInquiry[]> {
-    return this.inquiryRepository.find({
+  async listIncoming(userId: string): Promise<PropertyInquiryWithDetails[]> {
+    const inquiries = await this.inquiryRepository.find({
       where: { toUserId: userId },
       order: { createdAt: 'DESC' },
     });
+
+    const properties = await this.loadProperties(
+      inquiries.map((inquiry) => inquiry.propertyId),
+    );
+
+    return inquiries.map((inquiry) => ({
+      ...inquiry,
+      property: properties.get(inquiry.propertyId) ?? null,
+      counterparty: {
+        id: inquiry.fromUserId,
+        name: inquiry.senderName || 'Unknown user',
+        email: inquiry.senderEmail,
+        phone: inquiry.senderPhone,
+      },
+    }));
   }
 
-  async listOutgoing(userId: string): Promise<PropertyInquiry[]> {
-    return this.inquiryRepository.find({
+  async listOutgoing(userId: string): Promise<PropertyInquiryWithDetails[]> {
+    const inquiries = await this.inquiryRepository.find({
       where: { fromUserId: userId },
       order: { createdAt: 'DESC' },
     });
+
+    const [properties, landlords] = await Promise.all([
+      this.loadProperties(inquiries.map((inquiry) => inquiry.propertyId)),
+      this.loadUsers(inquiries.map((inquiry) => inquiry.toUserId)),
+    ]);
+
+    return inquiries.map((inquiry) => ({
+      ...inquiry,
+      property: properties.get(inquiry.propertyId) ?? null,
+      counterparty: landlords.get(inquiry.toUserId) ?? null,
+    }));
+  }
+
+  private async loadProperties(
+    propertyIds: string[],
+  ): Promise<Map<string, InquiryPropertySummary>> {
+    const uniqueIds = [...new Set(propertyIds)];
+    if (uniqueIds.length === 0) {
+      return new Map();
+    }
+
+    const properties = await this.propertyRepository.find({
+      where: { id: In(uniqueIds) },
+      relations: ['images'],
+    });
+
+    return new Map(
+      properties.map((property) => [
+        property.id,
+        {
+          id: property.id,
+          title: property.title,
+          address: property.address ?? null,
+          city: property.city ?? null,
+          coverImageUrl:
+            property.images?.find((image) => image.isPrimary)?.url ??
+            property.images?.[0]?.url ??
+            null,
+        },
+      ]),
+    );
+  }
+
+  private async loadUsers(
+    userIds: string[],
+  ): Promise<Map<string, InquiryCounterparty>> {
+    const uniqueIds = [...new Set(userIds)];
+    if (uniqueIds.length === 0) {
+      return new Map();
+    }
+
+    const users = await this.userRepository.find({
+      where: { id: In(uniqueIds) },
+    });
+
+    return new Map(
+      users.map((user) => [
+        user.id,
+        {
+          id: user.id,
+          name:
+            [user.firstName, user.lastName].filter(Boolean).join(' ') ||
+            user.email ||
+            'Landlord',
+          email: user.email,
+          phone: user.phoneNumber,
+        },
+      ]),
+    );
   }
 
   async markViewed(id: string, userId: string): Promise<PropertyInquiry> {

--- a/frontend/app/user/analytics/page.tsx
+++ b/frontend/app/user/analytics/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
 import {
   Eye,
   MessageSquare,
@@ -33,14 +34,18 @@ function MetricCard({
   value,
   subtitle,
   icon: Icon,
+  href,
 }: {
   title: string;
   value: string;
   subtitle: string;
   icon: React.ComponentType<{ className?: string }>;
+  href?: string;
 }) {
-  return (
-    <div className="rounded-3xl border border-white/10 bg-white/5 backdrop-blur-xl p-5">
+  const content = (
+    <div
+      className={`rounded-3xl border border-white/10 bg-white/5 backdrop-blur-xl p-5 h-full ${href ? 'transition-colors hover:bg-white/10' : ''}`}
+    >
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-blue-200/70 text-sm">{title}</p>
@@ -52,6 +57,14 @@ function MetricCard({
         </div>
       </div>
     </div>
+  );
+
+  return href ? (
+    <Link href={href} className="block">
+      {content}
+    </Link>
+  ) : (
+    content
   );
 }
 
@@ -135,6 +148,7 @@ export default function UserAnalyticsPage() {
           value={summary.totalInquiries.toLocaleString()}
           subtitle={`${performance.averageInquiriesPerProperty} avg per property`}
           icon={MessageSquare}
+          href="/user/inquiries"
         />
         <MetricCard
           title="Conversion Rate"

--- a/frontend/app/user/financials/page.tsx
+++ b/frontend/app/user/financials/page.tsx
@@ -380,9 +380,7 @@ export default function FinancialsPage() {
   }, [txPage]);
   const revenueData = useMemo(() => {
     const items = txPage?.data ?? [];
-    return items.length === 0
-      ? MOCK_REVENUE_DATA
-      : deriveMonthlyRevenue(items);
+    return items.length === 0 ? MOCK_REVENUE_DATA : deriveMonthlyRevenue(items);
   }, [txPage]);
 
   const xlmBalance = readAssetBalance(networkAccount, 'XLM');

--- a/frontend/app/user/inquiries/page.tsx
+++ b/frontend/app/user/inquiries/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { Inbox, Send } from 'lucide-react';
+import { useAuthStore } from '@/store/authStore';
+import { InquiriesList } from '@/components/user/InquiriesList';
+
+type InquiryTab = 'incoming' | 'outgoing';
+
+export default function UserInquiriesPage() {
+  const { user, isAuthenticated, loading } = useAuthStore();
+  const [tab, setTab] = React.useState<InquiryTab>('incoming');
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-blue-500" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !user) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px] p-8 text-center">
+        <Inbox className="mb-5 h-16 w-16 text-blue-400/50" />
+        <h1 className="mb-2 text-2xl font-black text-white">Access Denied</h1>
+        <p className="mb-6 text-blue-200/50">
+          Inquiries are only available to verified users.
+        </p>
+        <Link
+          href="/"
+          className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+        >
+          Connect Wallet
+        </Link>
+      </div>
+    );
+  }
+
+  const tabs: { key: InquiryTab; label: string; icon: typeof Inbox }[] = [
+    { key: 'incoming', label: 'Incoming', icon: Inbox },
+    { key: 'outgoing', label: 'Sent', icon: Send },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-black tracking-tight text-white">
+          Inquiries
+        </h1>
+        <p className="mt-1 text-blue-200/50">
+          Questions about your listings, and questions you&apos;ve sent to other
+          landlords.
+        </p>
+      </div>
+
+      <div className="flex gap-2 border-b border-white/10">
+        {tabs.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setTab(key)}
+            className={`flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+              tab === key
+                ? 'border-blue-500 text-white'
+                : 'border-transparent text-blue-300/40 hover:text-blue-200/70'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <InquiriesList direction={tab} />
+    </div>
+  );
+}

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -414,7 +414,10 @@ export default function UserDashboardOverview() {
                 </span>
               </div>
             </div>
-            <div className="bg-white/5 rounded-2xl p-4 border border-white/5">
+            <Link
+              href="/user/inquiries"
+              className="block bg-white/5 rounded-2xl p-4 border border-white/5 transition-colors hover:bg-white/10"
+            >
               <p className="text-[10px] font-bold text-blue-300/40 uppercase tracking-widest">
                 Inquiries
               </p>
@@ -425,7 +428,7 @@ export default function UserDashboardOverview() {
                   +8%
                 </span>
               </div>
-            </div>
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/components/user/InquiriesList.tsx
+++ b/frontend/components/user/InquiriesList.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import React from 'react';
+import {
+  Search,
+  Filter,
+  Loader2,
+  Mail,
+  Phone,
+  Home,
+  MessageCircleQuestion,
+  CheckCircle2,
+  Circle,
+} from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  useIncomingInquiries,
+  useOutgoingInquiries,
+  useMarkInquiryViewed,
+} from '@/lib/query/hooks/use-inquiries';
+import type { InquiryRecord, PropertyInquiryStatus } from '@/lib/inquiries/api';
+
+const statusBadge: Record<PropertyInquiryStatus, string> = {
+  pending: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  viewed: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+};
+
+function matchesSearch(inquiry: InquiryRecord, search: string) {
+  const normalized = search.trim().toLowerCase();
+  if (!normalized) return true;
+
+  return [
+    inquiry.property?.title,
+    inquiry.property?.address,
+    inquiry.counterparty?.name,
+    inquiry.message,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+    .includes(normalized);
+}
+
+interface InquiryCardProps {
+  inquiry: InquiryRecord;
+  direction: 'incoming' | 'outgoing';
+  onOpen: (id: string) => void;
+}
+
+function InquiryCard({ inquiry, direction, onOpen }: InquiryCardProps) {
+  const [expanded, setExpanded] = React.useState(false);
+  const isUnread = direction === 'incoming' && inquiry.status === 'pending';
+
+  const handleToggle = () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && isUnread) {
+      onOpen(inquiry.id);
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-2xl border p-4 transition-colors ${
+        isUnread
+          ? 'border-blue-500/30 bg-blue-500/5'
+          : 'border-white/10 bg-white/5'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="flex w-full items-start gap-4 text-left"
+      >
+        <span className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-white/10 bg-white/5">
+          {inquiry.property?.coverImageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={inquiry.property.coverImageUrl}
+              alt={inquiry.property.title}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="flex h-full w-full items-center justify-center text-blue-300/40">
+              <Home className="h-5 w-5" />
+            </span>
+          )}
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="truncate font-bold text-white">
+              {inquiry.property?.title ?? 'Property no longer listed'}
+            </h3>
+            <span
+              className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${statusBadge[inquiry.status]}`}
+            >
+              {isUnread ? (
+                <Circle className="h-2.5 w-2.5 fill-current" />
+              ) : (
+                <CheckCircle2 className="h-3 w-3" />
+              )}
+              {inquiry.status}
+            </span>
+          </div>
+
+          <p className="mt-0.5 text-xs text-blue-300/40">
+            {direction === 'incoming' ? 'From ' : 'To '}
+            <span className="font-semibold text-blue-200/70">
+              {inquiry.counterparty?.name ?? 'Unknown user'}
+            </span>{' '}
+            &middot;{' '}
+            {formatDistanceToNow(new Date(inquiry.createdAt), {
+              addSuffix: true,
+            })}
+          </p>
+
+          <p
+            className={`mt-2 text-sm text-blue-200/60 ${expanded ? '' : 'truncate'}`}
+          >
+            {inquiry.message}
+          </p>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-white/10 pt-4">
+          {inquiry.counterparty?.email && (
+            <a
+              href={`mailto:${inquiry.counterparty.email}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-blue-300/70 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              <Mail className="h-3.5 w-3.5" />
+              {inquiry.counterparty.email}
+            </a>
+          )}
+          {inquiry.counterparty?.phone && (
+            <a
+              href={`tel:${inquiry.counterparty.phone}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-blue-300/70 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              <Phone className="h-3.5 w-3.5" />
+              {inquiry.counterparty.phone}
+            </a>
+          )}
+          {inquiry.property?.address && (
+            <span className="inline-flex items-center gap-1.5 text-xs text-blue-300/40">
+              <Home className="h-3.5 w-3.5" />
+              {[inquiry.property.address, inquiry.property.city]
+                .filter(Boolean)
+                .join(', ')}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface InquiriesListProps {
+  direction: 'incoming' | 'outgoing';
+  className?: string;
+}
+
+export function InquiriesList({
+  direction,
+  className = '',
+}: InquiriesListProps) {
+  const [search, setSearch] = React.useState('');
+  const [statusFilter, setStatusFilter] = React.useState<
+    PropertyInquiryStatus | 'ALL'
+  >('ALL');
+
+  const incoming = useIncomingInquiries();
+  const outgoing = useOutgoingInquiries();
+  const { data, isLoading, error } =
+    direction === 'incoming' ? incoming : outgoing;
+
+  const markViewed = useMarkInquiryViewed();
+
+  const inquiries = React.useMemo(() => {
+    return (data ?? []).filter(
+      (inquiry) =>
+        (statusFilter === 'ALL' || inquiry.status === statusFilter) &&
+        matchesSearch(inquiry, search),
+    );
+  }, [data, search, statusFilter]);
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-10 text-center">
+        <h3 className="mb-1 text-base font-semibold text-white">
+          Failed to load inquiries
+        </h3>
+        <p className="mb-4 text-sm text-blue-200/50">
+          There was an issue fetching your inquiries.
+        </p>
+        <button
+          onClick={() => window.location.reload()}
+          className="rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-white/20"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      <div className="flex flex-col items-stretch justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm sm:flex-row sm:items-center">
+        <div className="flex flex-1 flex-col gap-3 sm:flex-row">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-blue-300/40" />
+            <input
+              placeholder={
+                direction === 'incoming'
+                  ? 'Search by property or sender...'
+                  : 'Search by property or landlord...'
+              }
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 py-2.5 pl-9 pr-4 text-sm text-white placeholder:text-blue-300/30 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+            />
+          </div>
+          <select
+            value={statusFilter}
+            onChange={(e) =>
+              setStatusFilter(e.target.value as PropertyInquiryStatus | 'ALL')
+            }
+            className="cursor-pointer appearance-none rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+          >
+            <option value="ALL" className="bg-slate-900">
+              All Statuses
+            </option>
+            <option value="pending" className="bg-slate-900">
+              Pending
+            </option>
+            <option value="viewed" className="bg-slate-900">
+              Viewed
+            </option>
+          </select>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-blue-200/40">
+          <Filter className="h-4 w-4" />
+          <span>
+            {inquiries.length} inquir{inquiries.length !== 1 ? 'ies' : 'y'}
+          </span>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-12">
+          <Loader2 className="h-6 w-6 animate-spin text-blue-400" />
+          <span className="text-blue-200/50">Loading inquiries...</span>
+        </div>
+      ) : inquiries.length === 0 ? (
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-16 text-center">
+          <MessageCircleQuestion className="mx-auto mb-4 h-12 w-12 text-blue-300/20" />
+          <h3 className="mb-1 text-lg font-bold text-white">
+            No inquiries yet
+          </h3>
+          <p className="text-sm text-blue-200/40">
+            {direction === 'incoming'
+              ? 'Questions from prospective tenants about your listings will show up here.'
+              : "Inquiries you've sent to landlords will show up here."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {inquiries.map((inquiry) => (
+            <InquiryCard
+              key={inquiry.id}
+              inquiry={inquiry}
+              direction={direction}
+              onOpen={(id) => markViewed.mutate(id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/data/user-nav-items.ts
+++ b/frontend/data/user-nav-items.ts
@@ -11,6 +11,7 @@ import {
   Users,
   Flag,
   MessageSquare,
+  Inbox,
 } from 'lucide-react';
 
 export const userNavItems: navItems[] = [
@@ -43,6 +44,11 @@ export const userNavItems: navItems[] = [
     name: 'Messages',
     href: '/user/messages',
     icon: MessageSquare,
+  },
+  {
+    name: 'Inquiries',
+    href: '/user/inquiries',
+    icon: Inbox,
   },
   {
     name: 'Contracts',

--- a/frontend/hooks/use-retry-state.ts
+++ b/frontend/hooks/use-retry-state.ts
@@ -96,7 +96,8 @@ export function useRetryState(): RetryState {
   return useSyncExternalStore(subscribe, getCachedSnapshot, getCachedSnapshot);
 }
 
-const cachedEndpointMetrics: Map<string, RetryEndpointMetrics | null> = new Map();
+const cachedEndpointMetrics: Map<string, RetryEndpointMetrics | null> =
+  new Map();
 
 export function useEndpointRetryMetrics(
   endpoint: string,

--- a/frontend/lib/inquiries/api.ts
+++ b/frontend/lib/inquiries/api.ts
@@ -1,0 +1,54 @@
+import { apiClient } from '@/lib/api-client';
+
+export type PropertyInquiryStatus = 'pending' | 'viewed';
+
+export interface InquiryPropertySummary {
+  id: string;
+  title: string;
+  address: string | null;
+  city: string | null;
+  coverImageUrl: string | null;
+}
+
+export interface InquiryCounterparty {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+}
+
+export interface InquiryRecord {
+  id: string;
+  propertyId: string;
+  fromUserId: string;
+  toUserId: string;
+  message: string;
+  senderName: string | null;
+  senderEmail: string | null;
+  senderPhone: string | null;
+  status: PropertyInquiryStatus;
+  viewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  property: InquiryPropertySummary | null;
+  counterparty: InquiryCounterparty | null;
+}
+
+export async function listIncomingInquiries(): Promise<InquiryRecord[]> {
+  const { data } = await apiClient.get<InquiryRecord[]>('/inquiries/incoming');
+  return data;
+}
+
+export async function listOutgoingInquiries(): Promise<InquiryRecord[]> {
+  const { data } = await apiClient.get<InquiryRecord[]>('/inquiries/outgoing');
+  return data;
+}
+
+export async function markInquiryViewed(
+  inquiryId: string,
+): Promise<InquiryRecord> {
+  const { data } = await apiClient.patch<InquiryRecord>(
+    `/inquiries/${encodeURIComponent(inquiryId)}/viewed`,
+  );
+  return data;
+}

--- a/frontend/lib/query/hooks/use-inquiries.ts
+++ b/frontend/lib/query/hooks/use-inquiries.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/authStore';
+import {
+  listIncomingInquiries,
+  listOutgoingInquiries,
+  markInquiryViewed,
+  type InquiryRecord,
+} from '@/lib/inquiries/api';
+
+export type { InquiryRecord };
+
+const INCOMING_INQUIRIES_QUERY_KEY = ['incoming-inquiries'] as const;
+const OUTGOING_INQUIRIES_QUERY_KEY = ['outgoing-inquiries'] as const;
+
+export function useIncomingInquiries() {
+  const userId = useAuthStore((state) => state.user?.id);
+
+  return useQuery({
+    queryKey: [...INCOMING_INQUIRIES_QUERY_KEY, userId],
+    enabled: Boolean(userId),
+    queryFn: listIncomingInquiries,
+    staleTime: 5_000,
+  });
+}
+
+export function useOutgoingInquiries() {
+  const userId = useAuthStore((state) => state.user?.id);
+
+  return useQuery({
+    queryKey: [...OUTGOING_INQUIRIES_QUERY_KEY, userId],
+    enabled: Boolean(userId),
+    queryFn: listOutgoingInquiries,
+    staleTime: 5_000,
+  });
+}
+
+export function useMarkInquiryViewed() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (inquiryId: string) => markInquiryViewed(inquiryId),
+    onSuccess: (updated) => {
+      queryClient.setQueriesData<InquiryRecord[]>(
+        { queryKey: INCOMING_INQUIRIES_QUERY_KEY },
+        (records) =>
+          records?.map((record) =>
+            record.id === updated.id ? updated : record,
+          ),
+      );
+    },
+  });
+}


### PR DESCRIPTION


Property inquiries could be submitted (`POST /inquiries`) but were never surfaced to either party afterwards — the landlord who received one had no page to read it, and the guest who sent one had no way to check its status. The only visible trace was an aggregate count on the analytics dashboard. This PR adds a full inquiries inbox on the frontend, consuming the `GET /inquiries/incoming`, `GET /inquiries/outgoing`, and `PATCH /inquiries/:id/viewed` endpoints that already existed on the backend.

Closes the reported issue: *"Property inquiries can be submitted but there is no inbox UI to view or respond to them."*

## Problem

closes #1333 

- A guest could submit an inquiry via `PropertyInquiryModal` → `POST /inquiries`, and it was genuinely persisted.
- There was no page anywhere in the frontend reading `/inquiries/incoming` or `/inquiries/outgoing`. A search for `useIncomingInquiries`, `IncomingInquir*`, etc. returned zero matches.
- The only UI trace of inquiries was a hardcoded/aggregate "Total Inquiries" stat on `app/user/analytics/page.tsx` and a dashboard stat card — both just numbers, with no link to the underlying messages.
- Net effect: inquiries disappeared into a black hole from the landlord's perspective, and guests had no way to track what they'd sent.

## What changed

### Backend (`backend/src/modules/inquiries/`)

The API already existed, but `listIncoming`/`listOutgoing` only returned raw `PropertyInquiry` rows (`propertyId`, `fromUserId`, `toUserId` as bare UUIDs). That's unusable for a real inbox UI — the frontend would have shown property IDs instead of titles and no landlord contact details. Enriched the service layer instead of pushing that work to the client:

- **`inquiries.service.ts`**
  - Added `InquiryPropertySummary` (`id`, `title`, `address`, `city`, `coverImageUrl`) and `InquiryCounterparty` (`id`, `name`, `email`, `phone`) types, and a `PropertyInquiryWithDetails` type that layers both onto a `PropertyInquiry`.
  - `listIncoming`: attaches the property summary, and builds `counterparty` directly from the sender fields already stored on the inquiry (`senderName`/`senderEmail`/`senderPhone`) — no extra user lookup needed since that data is captured at submission time.
  - `listOutgoing`: attaches the property summary and looks up the landlord (`toUserId`) via a batched `User` query to build `counterparty`.
  - Added private `loadProperties()` / `loadUsers()` helpers that de-duplicate IDs and issue a single `In(...)` query each — avoids N+1 queries when listing many inquiries.
  - Cover image resolution prefers the property's primary image, falling back to the first image, then `null`.
- **`inquiries.module.ts`**: registered the `User` repository (`TypeOrmModule.forFeature([PropertyInquiry, Property, User])`) so the service can look up landlord contact info.
- **`inquiries.service.spec.ts`**: updated existing tests for the new constructor dependency, and added two new tests asserting the enrichment shape for both incoming and outgoing lists.

This is additive — `createInquiry` and `markViewed` are unchanged, and existing consumers of the raw shape aren't affected since nothing else in the codebase called `listIncoming`/`listOutgoing` before this PR.

### Frontend

**API + data layer**
- `lib/inquiries/api.ts` — typed `listIncomingInquiries()`, `listOutgoingInquiries()`, `markInquiryViewed()` wrapping `apiClient`, typed against the enriched backend response.
- `lib/query/hooks/use-inquiries.ts` — `useIncomingInquiries()`, `useOutgoingInquiries()`, `useMarkInquiryViewed()`, following the existing `use-tenant-disputes.ts` / `use-tenant-dispute.ts` conventions (React Query, keyed by user id, mutation patches the incoming-list cache in place on success).

**UI**
- `components/user/InquiriesList.tsx` — reusable list for both directions (`direction: 'incoming' | 'outgoing'`):
  - Search (by property title/address, counterparty name, message text) and status filter (pending/viewed).
  - Card per inquiry: property thumbnail, title, counterparty name, relative timestamp, message preview.
  - Click to expand: shows full message plus `mailto:`/`tel:` links for the counterparty and the property address. Expanding an unread incoming inquiry fires `markInquiryViewed` automatically.
  - Loading, error (with retry), and empty states.
- `app/user/inquiries/page.tsx` — new route with **Incoming** / **Sent** tabs (both available to any authenticated user, since landlord/guest isn't a distinct role in this app — the same account can own properties and also inquire about others').

**Wiring into existing navigation** (per the issue's proposed fix #2)
- `data/user-nav-items.ts` — added an "Inquiries" entry to the sidebar, linking to `/user/inquiries`.
- `app/user/page.tsx` — the dashboard's "Inquiries" stat card is now a `Link` to `/user/inquiries` instead of a dead-end number.
- `app/user/analytics/page.tsx` — `MetricCard` gained an optional `href`; the "Total Inquiries" metric now links to `/user/inquiries` too.

## Explicitly out of scope

The issue's proposed fix asked to *"consider whether inquiry responses should route into the existing messages/messaging module... worth a product decision before implementation."* I did not wire replies into messaging:

- The codebase currently has two distinct messaging surfaces (`MessagingController` at `/messaging/rooms/...` and a separate `messagingApi` hitting `/messages` + `/conversations`), and reconciling which one "reply to an inquiry" should target is a product/architecture decision, not something to guess at silently.
- Instead, each inquiry card surfaces the counterparty's email/phone (already collected at submission time, or looked up from the landlord's profile) via `mailto:`/`tel:` links, so there's an immediate way to respond without building a bespoke reply mechanism that might conflict with a future messaging integration.

## Testing

- Backend: `pnpm exec jest` — full suite passes, **1796 passed**, 0 failed (162/164 suites; 2 pre-existing skips unrelated to this change). New enrichment tests included.
- Backend: `npx tsc --noEmit`, `nest build`, and `eslint` on the module — all clean.
- Frontend: `next build` succeeds; `/user/inquiries` compiles and is statically prerendered.
- Frontend: `eslint .` — 0 errors (pre-existing warnings elsewhere untouched by this change, confirmed via `git stash` diff).
- Frontend: `prettier --check` — clean on all new/changed files (2 unrelated pre-existing formatting issues elsewhere, confirmed untouched by this change).

## Manual verification steps

1. As guest A, submit a property inquiry via the contact modal on a property owned by user B.
2. Log in as user B → sidebar → **Inquiries** (or dashboard/analytics "Inquiries" card) → **Incoming** tab: the inquiry appears with property, sender name, message, and contact links; clicking to expand marks it as viewed.
3. Log in as guest A → **Inquiries** → **Sent** tab: the inquiry appears with status reflecting the `viewed` update from step 2, along with the landlord's contact info.

## Files changed

```
backend/src/modules/inquiries/inquiries.module.ts        |   3 +-
backend/src/modules/inquiries/inquiries.service.spec.ts   | 102 ++++++++
backend/src/modules/inquiries/inquiries.service.ts        | 117 ++++++++-
frontend/app/user/analytics/page.tsx                      |  18 +-
frontend/app/user/inquiries/page.tsx                       |  79 ++++++ (new)
frontend/app/user/page.tsx                                 |   7 +-
frontend/components/user/InquiriesList.tsx                 | 282 +++++++++++ (new)
frontend/data/user-nav-items.ts                             |   6 +
frontend/lib/inquiries/api.ts                                |  54 ++++ (new)
frontend/lib/query/hooks/use-inquiries.ts                    |  54 ++++ (new)
```


closes #1333