### PR TITLE
Fix/1337 admin kyc endpoints

### DIFF
--- a/backend/src/migrations/1900400000000-AddReasonToKyc.ts
+++ b/backend/src/migrations/1900400000000-AddReasonToKyc.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReasonToKyc1900400000000 implements MigrationInterface {
+  name = 'AddReasonToKyc1900400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$ BEGIN
+        ALTER TABLE "kyc" ADD COLUMN IF NOT EXISTS "reason" text;
+      EXCEPTION WHEN duplicate_column THEN null;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "kyc" DROP COLUMN IF EXISTS "reason"`);
+  }
+}

--- a/backend/src/modules/kyc/__tests__/kyc-encryption.integration.spec.ts
+++ b/backend/src/modules/kyc/__tests__/kyc-encryption.integration.spec.ts
@@ -10,6 +10,7 @@ import { SubmitKycDto } from '../kyc.dto';
 import { UserKycStatusService } from '../../users/user-kyc-status.service';
 import { AuditService } from '../../audit/audit.service';
 import { NotificationsService } from '../../notifications/notifications.service';
+import { User } from '../../users/entities/user.entity';
 
 /**
  * Integration tests for KYC encryption with the KYC service
@@ -50,6 +51,10 @@ describe('KYC Encryption - Integration Tests', () => {
         EncryptionService,
         { provide: ConfigService, useValue: mockConfigService },
         { provide: getRepositoryToken(Kyc), useValue: mockKycRepository },
+        {
+          provide: getRepositoryToken(User),
+          useValue: { find: jest.fn(), findOne: jest.fn() },
+        },
         {
           provide: UserKycStatusService,
           useValue: mockUserKycStatusService,

--- a/backend/src/modules/kyc/admin-kyc.controller.spec.ts
+++ b/backend/src/modules/kyc/admin-kyc.controller.spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import { AdminKycController } from './admin-kyc.controller';
+import { KycService } from './kyc.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
+import { KycStatus } from './kyc-status.enum';
+import { UserRole } from '../users/entities/user.entity';
+
+describe('AdminKycController', () => {
+  let app: INestApplication;
+  let kycService: {
+    findPendingForAdmin: jest.Mock;
+    findRejectedForAdmin: jest.Mock;
+    findByIdForAdmin: jest.Mock;
+    approveKyc: jest.Mock;
+    rejectKyc: jest.Mock;
+  };
+  let currentUser: { id: string; role: UserRole };
+
+  const buildApp = async () => {
+    const mock = {
+      findPendingForAdmin: jest.fn(),
+      findRejectedForAdmin: jest.fn(),
+      findByIdForAdmin: jest.fn(),
+      approveKyc: jest.fn(),
+      rejectKyc: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [AdminKycController],
+      providers: [{ provide: KycService, useValue: mock }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate(context: ExecutionContext) {
+          const req = context.switchToHttp().getRequest();
+          req.user = currentUser;
+          return true;
+        },
+      })
+      .overrideInterceptor(AuditLogInterceptor)
+      .useValue({
+        intercept(_ctx: ExecutionContext, next: CallHandler) {
+          return next.handle();
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    kycService = moduleRef.get(KycService);
+  };
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  describe('as a non-admin user', () => {
+    beforeEach(async () => {
+      currentUser = { id: 'user-1', role: UserRole.USER };
+      await buildApp();
+    });
+
+    it('denies listing pending verifications', async () => {
+      await request(app.getHttpServer()).get('/admin/kyc/pending').expect(403);
+      expect(kycService.findPendingForAdmin).not.toHaveBeenCalled();
+    });
+
+    it('denies listing rejected verifications', async () => {
+      await request(app.getHttpServer()).get('/admin/kyc/rejected').expect(403);
+      expect(kycService.findRejectedForAdmin).not.toHaveBeenCalled();
+    });
+
+    it('denies approve action', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/kyc/kyc-1/approve')
+        .send({})
+        .expect(403);
+      expect(kycService.approveKyc).not.toHaveBeenCalled();
+    });
+
+    it('denies reject action', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/kyc/kyc-1/reject')
+        .send({ reason: 'nope' })
+        .expect(403);
+      expect(kycService.rejectKyc).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('as an admin user', () => {
+    beforeEach(async () => {
+      currentUser = { id: 'admin-1', role: UserRole.ADMIN };
+      await buildApp();
+    });
+
+    it('lists pending verifications', async () => {
+      kycService.findPendingForAdmin.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/admin/kyc/pending')
+        .expect(200);
+
+      expect(res.body.total).toBe(0);
+      expect(kycService.findPendingForAdmin).toHaveBeenCalled();
+    });
+
+    it('lists rejected verifications', async () => {
+      kycService.findRejectedForAdmin.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
+
+      await request(app.getHttpServer()).get('/admin/kyc/rejected').expect(200);
+
+      expect(kycService.findRejectedForAdmin).toHaveBeenCalled();
+    });
+
+    it('approves a verification', async () => {
+      kycService.approveKyc.mockResolvedValue({
+        id: 'kyc-1',
+        status: KycStatus.APPROVED,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/kyc/kyc-1/approve')
+        .send({})
+        .expect(201);
+
+      expect(res.body.status).toBe(KycStatus.APPROVED);
+      expect(kycService.approveKyc).toHaveBeenCalledWith(
+        'kyc-1',
+        'admin-1',
+        undefined,
+      );
+    });
+
+    it('rejects a verification with a reason', async () => {
+      kycService.rejectKyc.mockResolvedValue({
+        id: 'kyc-1',
+        status: KycStatus.REJECTED,
+        reason: 'Blurry document',
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/kyc/kyc-1/reject')
+        .send({ reason: 'Blurry document' })
+        .expect(201);
+
+      expect(res.body.status).toBe(KycStatus.REJECTED);
+      expect(kycService.rejectKyc).toHaveBeenCalledWith(
+        'kyc-1',
+        'admin-1',
+        'Blurry document',
+      );
+    });
+
+    it('gets a verification detail', async () => {
+      kycService.findByIdForAdmin.mockResolvedValue({
+        id: 'kyc-1',
+        status: KycStatus.PENDING,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/admin/kyc/kyc-1')
+        .expect(200);
+
+      expect(res.body.id).toBe('kyc-1');
+      expect(kycService.findByIdForAdmin).toHaveBeenCalledWith('kyc-1');
+    });
+  });
+});

--- a/backend/src/modules/kyc/admin-kyc.controller.ts
+++ b/backend/src/modules/kyc/admin-kyc.controller.ts
@@ -1,0 +1,98 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { KycService } from './kyc.service';
+import { AdminKycQueryDto, KycDecisionDto } from './kyc.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../users/entities/user.entity';
+import { AuditLog } from '../audit/decorators/audit-log.decorator';
+import { AuditAction, AuditLevel } from '../audit/entities/audit-log.entity';
+import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
+
+@ApiTags('Admin KYC')
+@ApiBearerAuth('JWT-auth')
+@Controller('admin/kyc')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+@UseInterceptors(AuditLogInterceptor)
+export class AdminKycController {
+  constructor(private readonly kycService: KycService) {}
+
+  @Get('pending')
+  @ApiOperation({ summary: 'List pending KYC verifications' })
+  @ApiResponse({ status: 200, description: 'Paginated pending verifications' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  async listPending(@Query() query: AdminKycQueryDto) {
+    return this.kycService.findPendingForAdmin(query);
+  }
+
+  @Get('rejected')
+  @ApiOperation({ summary: 'List rejected KYC verifications' })
+  @ApiResponse({ status: 200, description: 'Paginated rejected verifications' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  async listRejected(@Query() query: AdminKycQueryDto) {
+    return this.kycService.findRejectedForAdmin(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get KYC verification detail' })
+  @ApiResponse({ status: 200, description: 'KYC verification detail' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async getDetail(@Param('id') id: string) {
+    return this.kycService.findByIdForAdmin(id);
+  }
+
+  @Post(':id/approve')
+  @ApiOperation({ summary: 'Approve a KYC verification' })
+  @ApiResponse({ status: 200, description: 'KYC verification approved' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @AuditLog({
+    action: AuditAction.KYC_APPROVED,
+    entityType: 'Kyc',
+    level: AuditLevel.SECURITY,
+    includeNewValues: true,
+    sensitive: true,
+  })
+  async approve(
+    @Param('id') id: string,
+    @Body() dto: KycDecisionDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.kycService.approveKyc(id, req.user.id, dto.reason);
+  }
+
+  @Post(':id/reject')
+  @ApiOperation({ summary: 'Reject a KYC verification' })
+  @ApiResponse({ status: 200, description: 'KYC verification rejected' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @AuditLog({
+    action: AuditAction.KYC_REJECTED,
+    entityType: 'Kyc',
+    level: AuditLevel.SECURITY,
+    includeNewValues: true,
+    sensitive: true,
+  })
+  async reject(
+    @Param('id') id: string,
+    @Body() dto: KycDecisionDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.kycService.rejectKyc(id, req.user.id, dto.reason);
+  }
+}

--- a/backend/src/modules/kyc/kyc.dto.ts
+++ b/backend/src/modules/kyc/kyc.dto.ts
@@ -1,10 +1,15 @@
 import {
   IsEnum,
+  IsIn,
+  IsInt,
   IsNotEmpty,
   IsObject,
   IsOptional,
   IsString,
+  Max,
+  Min,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { KycStatus } from './kyc-status.enum';
 
@@ -39,6 +44,47 @@ export class KycWebhookDto {
   status: KycStatus;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+
+export class AdminKycQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiPropertyOptional({
+    description: 'Search by user id, email, or name',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ enum: ['createdAt', 'updatedAt', 'status'] })
+  @IsOptional()
+  @IsIn(['createdAt', 'updatedAt', 'status'])
+  sortBy?: 'createdAt' | 'updatedAt' | 'status' = 'createdAt';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}
+
+export class KycDecisionDto {
+  @ApiPropertyOptional({ description: 'Reviewer note or rejection reason' })
   @IsOptional()
   @IsString()
   reason?: string;

--- a/backend/src/modules/kyc/kyc.entity.ts
+++ b/backend/src/modules/kyc/kyc.entity.ts
@@ -30,6 +30,9 @@ export class Kyc {
   @Column({ type: 'text', nullable: true })
   providerReference: string | null;
 
+  @Column({ type: 'text', nullable: true })
+  reason: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/modules/kyc/kyc.module.ts
+++ b/backend/src/modules/kyc/kyc.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Kyc } from './kyc.entity';
+import { User } from '../users/entities/user.entity';
 import { KycService } from './kyc.service';
 import { KycController } from './kyc.controller';
+import { AdminKycController } from './admin-kyc.controller';
 import { UsersModule } from '../users/users.module';
 import { SecurityModule } from '../security/security.module';
 import { AuditModule } from '../audit/audit.module';
@@ -11,7 +13,7 @@ import { WebhooksModule } from '../webhooks/webhooks.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Kyc]),
+    TypeOrmModule.forFeature([Kyc, User]),
     UsersModule,
     SecurityModule,
     AuditModule,
@@ -19,7 +21,7 @@ import { WebhooksModule } from '../webhooks/webhooks.module';
     WebhooksModule,
   ],
   providers: [KycService],
-  controllers: [KycController],
+  controllers: [KycController, AdminKycController],
   exports: [KycService],
 })
 export class KycModule {}

--- a/backend/src/modules/kyc/kyc.service.spec.ts
+++ b/backend/src/modules/kyc/kyc.service.spec.ts
@@ -9,6 +9,7 @@ import { SubmitKycDto, KycWebhookDto } from './kyc.dto';
 import { UserKycStatusService } from '../users/user-kyc-status.service';
 import { AuditService } from '../audit/audit.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { User } from '../users/entities/user.entity';
 
 describe('KycService', () => {
   let service: KycService;
@@ -20,6 +21,11 @@ describe('KycService', () => {
     create: jest.fn(),
     save: jest.fn(),
     findOne: jest.fn(),
+  };
+
+  const mockUserRepository = {
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
   };
 
   const mockUserKycStatusService = {
@@ -56,6 +62,10 @@ describe('KycService', () => {
         {
           provide: getRepositoryToken(Kyc),
           useValue: mockKycRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
         },
         {
           provide: UserKycStatusService,
@@ -100,6 +110,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.PENDING,
         providerReference: null,
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -149,6 +160,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.PENDING,
         providerReference: null,
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -180,6 +192,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.APPROVED,
         providerReference: 'ref-123',
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -216,6 +229,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.APPROVED,
         providerReference: null,
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -247,6 +261,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.PENDING,
         providerReference: 'ref-123',
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -289,6 +304,7 @@ describe('KycService', () => {
         providers: [
           KycService,
           { provide: getRepositoryToken(Kyc), useValue: mockKycRepository },
+          { provide: getRepositoryToken(User), useValue: mockUserRepository },
           { provide: UserKycStatusService, useValue: mockUserKycStatusService },
           { provide: EncryptionService, useValue: mockEncryptionService },
           { provide: AuditService, useValue: mockAuditService },
@@ -304,6 +320,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.PENDING,
         providerReference: 'ref-rej',
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -332,6 +349,7 @@ describe('KycService', () => {
         providers: [
           KycService,
           { provide: getRepositoryToken(Kyc), useValue: mockKycRepository },
+          { provide: getRepositoryToken(User), useValue: mockUserRepository },
           { provide: UserKycStatusService, useValue: mockUserKycStatusService },
           { provide: EncryptionService, useValue: mockEncryptionService },
           { provide: AuditService, useValue: mockAuditService },
@@ -347,6 +365,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.PENDING,
         providerReference: 'ref-info',
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -386,6 +405,10 @@ describe('KycService', () => {
             useValue: mockKycRepository,
           },
           {
+            provide: getRepositoryToken(User),
+            useValue: mockUserRepository,
+          },
+          {
             provide: UserKycStatusService,
             useValue: mockUserKycStatusService,
           },
@@ -421,6 +444,7 @@ describe('KycService', () => {
         encryptionVersion: 1,
         status: KycStatus.PENDING,
         providerReference: null,
+        reason: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -443,6 +467,111 @@ describe('KycService', () => {
       expect(retrieved?.encryptedKycData.first_name).toBe('Alice');
       expect(retrieved?.encryptedKycData.last_name).toBe('Smith');
       expect(retrieved?.encryptedKycData.id_number).toBe('ID987654');
+    });
+  });
+
+  describe('admin approve/reject', () => {
+    const adminId = 'admin-1';
+
+    const pendingKyc: Kyc = {
+      id: 'kyc-admin-1',
+      userId: mockUserId,
+      encryptedKycData: {},
+      encryptionVersion: 1,
+      status: KycStatus.PENDING,
+      providerReference: null,
+      reason: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('approves a pending verification and notifies the user', async () => {
+      mockKycRepository.findOne.mockResolvedValue({ ...pendingKyc });
+      mockKycRepository.save.mockImplementation((kyc) => Promise.resolve(kyc));
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.approveKyc(pendingKyc.id, adminId);
+
+      expect(result.status).toBe(KycStatus.APPROVED);
+      expect(mockUserKycStatusService.setStatus).toHaveBeenCalledWith(
+        mockUserId,
+        KycStatus.APPROVED,
+      );
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'KYC_APPROVED',
+          performedBy: adminId,
+        }),
+      );
+    });
+
+    it('rejects a pending verification with a reason and notifies the user', async () => {
+      mockKycRepository.findOne.mockResolvedValue({ ...pendingKyc });
+      mockKycRepository.save.mockImplementation((kyc) => Promise.resolve(kyc));
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.rejectKyc(
+        pendingKyc.id,
+        adminId,
+        'Blurry document',
+      );
+
+      expect(result.status).toBe(KycStatus.REJECTED);
+      expect(result.reason).toBe('Blurry document');
+      expect(mockUserKycStatusService.setStatus).toHaveBeenCalledWith(
+        mockUserId,
+        KycStatus.REJECTED,
+      );
+    });
+
+    it('throws when the KYC verification does not exist', async () => {
+      mockKycRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.approveKyc('missing-id', adminId)).rejects.toThrow(
+        'KYC verification not found',
+      );
+    });
+
+    it('is idempotent when re-approving an already-approved record', async () => {
+      const approvedKyc: Kyc = {
+        ...pendingKyc,
+        status: KycStatus.APPROVED,
+      };
+      mockKycRepository.findOne.mockResolvedValue({ ...approvedKyc });
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.approveKyc(pendingKyc.id, adminId);
+
+      expect(result.status).toBe(KycStatus.APPROVED);
+      expect(mockKycRepository.save).not.toHaveBeenCalled();
+      expect(mockUserKycStatusService.setStatus).not.toHaveBeenCalled();
+      expect(mockAuditService.log).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'KYC_APPROVED' }),
+      );
+    });
+
+    it('is idempotent when re-rejecting an already-rejected record', async () => {
+      const rejectedKyc: Kyc = {
+        ...pendingKyc,
+        status: KycStatus.REJECTED,
+        reason: 'Original reason',
+      };
+      mockKycRepository.findOne.mockResolvedValue({ ...rejectedKyc });
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.rejectKyc(
+        pendingKyc.id,
+        adminId,
+        'A new reason',
+      );
+
+      expect(result.status).toBe(KycStatus.REJECTED);
+      expect(result.reason).toBe('Original reason');
+      expect(mockKycRepository.save).not.toHaveBeenCalled();
+      expect(mockUserKycStatusService.setStatus).not.toHaveBeenCalled();
+      expect(mockAuditService.log).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'KYC_REJECTED' }),
+      );
     });
   });
 });

--- a/backend/src/modules/kyc/kyc.service.ts
+++ b/backend/src/modules/kyc/kyc.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Kyc } from './kyc.entity';
-import { SubmitKycDto, KycWebhookDto } from './kyc.dto';
+import { SubmitKycDto, KycWebhookDto, AdminKycQueryDto } from './kyc.dto';
 import { EncryptionService } from '../security/encryption.service';
 import { AuditService } from '../audit/audit.service';
 import {
@@ -17,6 +17,36 @@ import {
 import { UserKycStatusService } from '../users/user-kyc-status.service';
 import { KycStatus } from './kyc-status.enum';
 import { NotificationsService } from '../notifications/notifications.service';
+import { User } from '../users/entities/user.entity';
+
+export interface AdminKycUserView {
+  id: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  role?: string;
+}
+
+export interface AdminKycView {
+  id: string;
+  userId: string;
+  status: KycStatus;
+  reason?: string;
+  providerReference?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user?: AdminKycUserView;
+  kycData?: Record<string, unknown>;
+  documents: [];
+}
+
+export interface PaginatedAdminKycResult {
+  data: AdminKycView[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
 
 @Injectable()
 export class KycService {
@@ -25,6 +55,8 @@ export class KycService {
   constructor(
     @InjectRepository(Kyc)
     private readonly kycRepository: Repository<Kyc>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     private readonly userKycStatusService: UserKycStatusService,
     private readonly encryptionService: EncryptionService,
     private readonly auditService: AuditService,
@@ -124,6 +156,211 @@ export class KycService {
       `Your KYC status is now ${dto.status}.`,
       'KYC_UPDATED',
     );
+  }
+
+  async findPendingForAdmin(
+    query: AdminKycQueryDto,
+  ): Promise<PaginatedAdminKycResult> {
+    return this.findByStatusForAdmin(KycStatus.PENDING, query);
+  }
+
+  async findRejectedForAdmin(
+    query: AdminKycQueryDto,
+  ): Promise<PaginatedAdminKycResult> {
+    return this.findByStatusForAdmin(KycStatus.REJECTED, query);
+  }
+
+  async findByIdForAdmin(id: string): Promise<AdminKycView> {
+    const kyc = await this.kycRepository.findOne({ where: { id } });
+    if (!kyc) {
+      throw new NotFoundException('KYC verification not found');
+    }
+    const user = await this.userRepository.findOne({
+      where: { id: kyc.userId },
+    });
+    return this.toAdminView(kyc, user ?? undefined);
+  }
+
+  async approveKyc(
+    id: string,
+    adminId: string,
+    reason?: string,
+  ): Promise<AdminKycView> {
+    const kyc = await this.kycRepository.findOne({ where: { id } });
+    if (!kyc) {
+      throw new NotFoundException('KYC verification not found');
+    }
+
+    if (kyc.status === KycStatus.APPROVED) {
+      const user = await this.userRepository.findOne({
+        where: { id: kyc.userId },
+      });
+      return this.toAdminView(kyc, user ?? undefined);
+    }
+
+    const previousStatus = kyc.status;
+    kyc.status = KycStatus.APPROVED;
+    kyc.reason = reason ?? null;
+    const saved = await this.kycRepository.save(kyc);
+
+    await this.userKycStatusService.setStatus(kyc.userId, KycStatus.APPROVED);
+
+    await this.auditService.log({
+      action: AuditAction.KYC_APPROVED,
+      entityType: 'Kyc',
+      entityId: saved.id,
+      performedBy: adminId,
+      status: AuditStatus.SUCCESS,
+      level: AuditLevel.SECURITY,
+      oldValues: { status: previousStatus },
+      newValues: { status: KycStatus.APPROVED },
+      metadata: { userId: kyc.userId },
+    });
+
+    await this.notificationsService.notify(
+      kyc.userId,
+      'KYC approved',
+      'Your identity verification has been approved.',
+      'KYC_APPROVED',
+    );
+
+    const user = await this.userRepository.findOne({
+      where: { id: kyc.userId },
+    });
+    return this.toAdminView(saved, user ?? undefined);
+  }
+
+  async rejectKyc(
+    id: string,
+    adminId: string,
+    reason?: string,
+  ): Promise<AdminKycView> {
+    const kyc = await this.kycRepository.findOne({ where: { id } });
+    if (!kyc) {
+      throw new NotFoundException('KYC verification not found');
+    }
+
+    if (kyc.status === KycStatus.REJECTED) {
+      const user = await this.userRepository.findOne({
+        where: { id: kyc.userId },
+      });
+      return this.toAdminView(kyc, user ?? undefined);
+    }
+
+    const previousStatus = kyc.status;
+    kyc.status = KycStatus.REJECTED;
+    kyc.reason = reason ?? null;
+    const saved = await this.kycRepository.save(kyc);
+
+    await this.userKycStatusService.setStatus(kyc.userId, KycStatus.REJECTED);
+
+    await this.auditService.log({
+      action: AuditAction.KYC_REJECTED,
+      entityType: 'Kyc',
+      entityId: saved.id,
+      performedBy: adminId,
+      status: AuditStatus.SUCCESS,
+      level: AuditLevel.SECURITY,
+      oldValues: { status: previousStatus },
+      newValues: { status: KycStatus.REJECTED, reason: saved.reason },
+      metadata: { userId: kyc.userId },
+    });
+
+    await this.notificationsService.notify(
+      kyc.userId,
+      'KYC rejected',
+      reason
+        ? `Your verification was rejected: ${reason}`
+        : 'Your verification was rejected. Please review and resubmit.',
+      'KYC_REJECTED',
+    );
+
+    const user = await this.userRepository.findOne({
+      where: { id: kyc.userId },
+    });
+    return this.toAdminView(saved, user ?? undefined);
+  }
+
+  private async findByStatusForAdmin(
+    status: KycStatus,
+    query: AdminKycQueryDto,
+  ): Promise<PaginatedAdminKycResult> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+    const sortBy = query.sortBy ?? 'createdAt';
+    const sortOrder = (query.sortOrder ?? 'desc').toUpperCase() as
+      | 'ASC'
+      | 'DESC';
+
+    const qb = this.kycRepository
+      .createQueryBuilder('kyc')
+      .leftJoin(User, 'user', 'user.id = kyc.userId')
+      .where('kyc.status = :status', { status });
+
+    if (query.search) {
+      qb.andWhere(
+        '(user.email ILIKE :search OR user.firstName ILIKE :search OR user.lastName ILIKE :search OR CAST(kyc.userId AS TEXT) ILIKE :search)',
+        { search: `%${query.search}%` },
+      );
+    }
+
+    qb.orderBy(`kyc.${sortBy}`, sortOrder)
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [rows, total] = await qb.getManyAndCount();
+    const data = await this.toAdminViewList(rows);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.max(Math.ceil(total / limit), 1),
+    };
+  }
+
+  private async toAdminViewList(rows: Kyc[]): Promise<AdminKycView[]> {
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const userIds = [...new Set(rows.map((row) => row.userId))];
+    const users = await this.userRepository.find({
+      where: { id: In(userIds) },
+    });
+    const usersById = new Map(users.map((user) => [user.id, user]));
+
+    return rows.map((row) => this.toAdminView(row, usersById.get(row.userId)));
+  }
+
+  private toAdminView(kyc: Kyc, user?: User): AdminKycView {
+    const kycData = kyc.encryptedKycData
+      ? this.decryptKycData(kyc.userId, kyc.encryptedKycData)
+      : undefined;
+
+    return {
+      id: kyc.id,
+      userId: kyc.userId,
+      status: kyc.status,
+      reason: kyc.reason ?? undefined,
+      providerReference: kyc.providerReference ?? undefined,
+      createdAt: kyc.createdAt,
+      updatedAt: kyc.updatedAt,
+      user: user
+        ? {
+            id: user.id,
+            name:
+              [user.firstName, user.lastName].filter(Boolean).join(' ') ||
+              undefined,
+            email: user.email ?? undefined,
+            phone: user.phoneNumber ?? undefined,
+            role: user.role,
+          }
+        : undefined,
+      kycData,
+      documents: [],
+    };
   }
 
   private encryptKycData(

--- a/backend/test/kyc-verification.e2e-spec.ts
+++ b/backend/test/kyc-verification.e2e-spec.ts
@@ -7,6 +7,7 @@ import { EncryptionService } from '../src/modules/security/encryption.service';
 import { UserKycStatusService } from '../src/modules/users/user-kyc-status.service';
 import { AuditService } from '../src/modules/audit/audit.service';
 import { NotificationsService } from '../src/modules/notifications/notifications.service';
+import { User } from '../src/modules/users/entities/user.entity';
 
 describe('KYC Verification Integration', () => {
   let service: KycService;
@@ -50,6 +51,10 @@ describe('KYC Verification Integration', () => {
       providers: [
         KycService,
         { provide: getRepositoryToken(Kyc), useValue: mockKycRepository },
+        {
+          provide: getRepositoryToken(User),
+          useValue: { find: jest.fn(), findOne: jest.fn() },
+        },
         { provide: EncryptionService, useValue: mockEncryptionService },
         { provide: UserKycStatusService, useValue: mockUserKycStatusService },
         { provide: AuditService, useValue: mockAuditService },


### PR DESCRIPTION
## Summary
- Adds a `reason` column on `kyc` (migration) to persist rejection/review notes
- Adds `AdminKycController` (`/admin/kyc/pending`, `/admin/kyc/rejected`, `/admin/kyc/:id`, `/admin/kyc/:id/approve`, `/admin/kyc/:id/reject`) matching the frontend's expected routes, guarded by JWT + admin roles
- Adds `KycService` admin methods: paginated listing by status, detail lookup, and approve/reject with idempotent no-ops when already in the target status
- Wires audit logging and user notifications on approve/reject decisions

## Test plan
- [x] `npx jest src/modules/kyc` — 7 suites, 104 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/modules/kyc` — clean
- [x] New `admin-kyc.controller.spec.ts` covers 403 access control for non-admins and idempotency of repeated approve/reject calls

closes #1337