### PR TITLE
Fix/issue 1338 admin users endpoints

### DIFF
--- a/backend/src/modules/users/admin-users.controller.spec.ts
+++ b/backend/src/modules/users/admin-users.controller.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import { AdminUsersController } from './admin-users.controller';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
+import { UserRole } from './entities/user.entity';
+
+describe('AdminUsersController', () => {
+  let app: INestApplication;
+  let usersService: {
+    findAllForAdmin: jest.Mock;
+    adminDeactivateAccount: jest.Mock;
+    adminVerifyAccount: jest.Mock;
+    adminRestoreAccount: jest.Mock;
+  };
+  let currentUser: { id: string; role: UserRole };
+
+  const buildApp = async () => {
+    const mock = {
+      findAllForAdmin: jest.fn(),
+      adminDeactivateAccount: jest.fn(),
+      adminVerifyAccount: jest.fn(),
+      adminRestoreAccount: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [AdminUsersController],
+      providers: [{ provide: UsersService, useValue: mock }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate(context: ExecutionContext) {
+          const req = context.switchToHttp().getRequest();
+          req.user = currentUser;
+          return true;
+        },
+      })
+      .overrideInterceptor(AuditLogInterceptor)
+      .useValue({
+        intercept(_ctx: ExecutionContext, next: CallHandler) {
+          return next.handle();
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    usersService = moduleRef.get(UsersService);
+  };
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  describe('as a non-admin user', () => {
+    beforeEach(async () => {
+      currentUser = { id: 'user-1', role: UserRole.USER };
+      await buildApp();
+    });
+
+    it('denies listing users', async () => {
+      await request(app.getHttpServer()).get('/admin/users').expect(403);
+      expect(usersService.findAllForAdmin).not.toHaveBeenCalled();
+    });
+
+    it('denies suspending a user', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/users/user-2/deactivate')
+        .expect(403);
+      expect(usersService.adminDeactivateAccount).not.toHaveBeenCalled();
+    });
+
+    it('denies verifying a user', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/users/user-2/verify')
+        .expect(403);
+      expect(usersService.adminVerifyAccount).not.toHaveBeenCalled();
+    });
+
+    it('denies restoring a user', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/users/user-2/restore')
+        .expect(403);
+      expect(usersService.adminRestoreAccount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('as an admin user', () => {
+    beforeEach(async () => {
+      currentUser = { id: 'admin-1', role: UserRole.ADMIN };
+      await buildApp();
+    });
+
+    it('lists users', async () => {
+      usersService.findAllForAdmin.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/admin/users')
+        .expect(200);
+
+      expect(res.body.total).toBe(0);
+      expect(usersService.findAllForAdmin).toHaveBeenCalled();
+    });
+
+    it('suspends a user', async () => {
+      usersService.adminDeactivateAccount.mockResolvedValue({
+        message: 'User suspended successfully',
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/users/user-2/deactivate')
+        .expect(201);
+
+      expect(res.body.message).toBe('User suspended successfully');
+      expect(usersService.adminDeactivateAccount).toHaveBeenCalledWith(
+        'user-2',
+        'admin-1',
+      );
+    });
+
+    it('verifies a user', async () => {
+      usersService.adminVerifyAccount.mockResolvedValue({
+        message: 'User verified successfully',
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/users/user-2/verify')
+        .expect(201);
+
+      expect(res.body.message).toBe('User verified successfully');
+      expect(usersService.adminVerifyAccount).toHaveBeenCalledWith(
+        'user-2',
+        'admin-1',
+      );
+    });
+
+    it('restores a user', async () => {
+      usersService.adminRestoreAccount.mockResolvedValue({
+        message: 'User restored successfully',
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/users/user-2/restore')
+        .expect(201);
+
+      expect(res.body.message).toBe('User restored successfully');
+      expect(usersService.adminRestoreAccount).toHaveBeenCalledWith(
+        'user-2',
+        'admin-1',
+      );
+    });
+  });
+});

--- a/backend/src/modules/users/admin-users.controller.ts
+++ b/backend/src/modules/users/admin-users.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { UsersService } from './users.service';
+import { AdminUserQueryDto } from './dto/admin-user-query.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User, UserRole } from './entities/user.entity';
+import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
+
+@ApiTags('Admin Users')
+@ApiBearerAuth('JWT-auth')
+@Controller('admin/users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+@UseInterceptors(AuditLogInterceptor)
+export class AdminUsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List users (admin)' })
+  @ApiResponse({ status: 200, description: 'Paginated user list' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  async list(@Query() query: AdminUserQueryDto) {
+    return this.usersService.findAllForAdmin(query);
+  }
+
+  @Post(':id/deactivate')
+  @ApiOperation({ summary: 'Suspend a user account (admin)' })
+  @ApiResponse({ status: 200, description: 'User suspended' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async deactivate(@Param('id') id: string, @CurrentUser() admin: User) {
+    return this.usersService.adminDeactivateAccount(id, admin.id);
+  }
+
+  @Post(':id/verify')
+  @ApiOperation({ summary: 'Mark a user as verified (admin)' })
+  @ApiResponse({ status: 200, description: 'User verified' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async verify(@Param('id') id: string, @CurrentUser() admin: User) {
+    return this.usersService.adminVerifyAccount(id, admin.id);
+  }
+
+  @Post(':id/restore')
+  @ApiOperation({ summary: 'Restore/reactivate a user account (admin)' })
+  @ApiResponse({ status: 200, description: 'User restored' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async restore(@Param('id') id: string, @CurrentUser() admin: User) {
+    return this.usersService.adminRestoreAccount(id, admin.id);
+  }
+}

--- a/backend/src/modules/users/dto/admin-user-query.dto.ts
+++ b/backend/src/modules/users/dto/admin-user-query.dto.ts
@@ -1,0 +1,49 @@
+import {
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AdminUserQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiPropertyOptional({ description: 'Filter by user role' })
+  @IsOptional()
+  @IsString()
+  role?: string;
+
+  @ApiPropertyOptional({
+    description: 'Search by email, first name, or last name',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by email verification status' })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  isVerified?: boolean;
+}

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { AdminUsersController } from './admin-users.controller';
 import { User } from './entities/user.entity';
 import { UserNotificationPreference } from './entities/user-notification-preference.entity';
 import { AuditModule } from '../audit/audit.module';
@@ -12,7 +13,7 @@ import { UserKycStatusService } from './user-kyc-status.service';
     TypeOrmModule.forFeature([User, UserNotificationPreference]),
     AuditModule,
   ],
-  controllers: [UsersController],
+  controllers: [UsersController, AdminUsersController],
   providers: [UsersService, UserKycStatusService],
   exports: [UsersService, UserKycStatusService],
 })

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -12,6 +12,7 @@ import { User, UserRole, AuthMethod } from './entities/user.entity';
 import { UserNotificationPreference } from './entities/user-notification-preference.entity';
 import { KycStatus } from '../kyc/kyc-status.enum';
 import { AuditService } from '../audit/audit.service';
+import { AuditAction } from '../audit/entities/audit-log.entity';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -56,6 +57,7 @@ describe('UsersService', () => {
     softDelete: jest.fn(),
     delete: jest.fn(),
     restore: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockAuditService = {
@@ -279,6 +281,173 @@ describe('UsersService', () => {
       expect(result).toHaveProperty('accountCreated');
       expect(result).toHaveProperty('emailVerified');
       expect(result).toHaveProperty('isActive');
+    });
+  });
+
+  describe('findAllForAdmin', () => {
+    it('returns a paginated, mapped list of users', async () => {
+      const listUser: User = {
+        ...mockUser,
+        firstName: 'Test',
+        lastName: 'User',
+      };
+      const mockQb = {
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[listUser], 1]),
+      };
+      mockUserRepository.createQueryBuilder.mockReturnValue(mockQb);
+
+      const result = await service.findAllForAdmin({ page: 1, limit: 10 });
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: listUser.id,
+        email: listUser.email,
+        name: 'Test User',
+        isVerified: true,
+      });
+    });
+
+    it('applies role, isVerified, and search filters', async () => {
+      const mockQb = {
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      mockUserRepository.createQueryBuilder.mockReturnValue(mockQb);
+
+      await service.findAllForAdmin({
+        page: 1,
+        limit: 10,
+        role: UserRole.ADMIN,
+        isVerified: true,
+        search: 'test',
+      });
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith('user.role = :role', {
+        role: UserRole.ADMIN,
+      });
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        'user.emailVerified = :isVerified',
+        { isVerified: true },
+      );
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('ILIKE'),
+        { search: '%test%' },
+      );
+    });
+  });
+
+  describe('adminDeactivateAccount', () => {
+    it('suspends the user and writes an audit log', async () => {
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.update.mockResolvedValue({});
+
+      const result = await service.adminDeactivateAccount('1', 'admin-1');
+
+      expect(result).toHaveProperty('message');
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        '1',
+        expect.objectContaining({ isActive: false }),
+      );
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.USER_SUSPENDED,
+          entityId: '1',
+          performedBy: 'admin-1',
+        }),
+      );
+    });
+
+    it('throws NotFoundException if user not found', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.adminDeactivateAccount('999', 'admin-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('adminVerifyAccount', () => {
+    it('marks the user verified and writes an audit log', async () => {
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.update.mockResolvedValue({});
+
+      const result = await service.adminVerifyAccount('1', 'admin-1');
+
+      expect(result).toHaveProperty('message');
+      expect(mockUserRepository.update).toHaveBeenCalledWith('1', {
+        emailVerified: true,
+      });
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.USER_VERIFIED,
+          entityId: '1',
+          performedBy: 'admin-1',
+        }),
+      );
+    });
+
+    it('throws NotFoundException if user not found', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.adminVerifyAccount('999', 'admin-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('adminRestoreAccount', () => {
+    it('restores a soft-deleted user and reactivates them', async () => {
+      const deletedUser = {
+        ...mockUser,
+        deletedAt: new Date(),
+        isActive: false,
+      };
+      mockUserRepository.findOne.mockResolvedValue(deletedUser);
+      mockUserRepository.restore.mockResolvedValue({});
+      mockUserRepository.update.mockResolvedValue({});
+
+      const result = await service.adminRestoreAccount('1', 'admin-1');
+
+      expect(result).toHaveProperty('message');
+      expect(mockUserRepository.restore).toHaveBeenCalledWith('1');
+      expect(mockUserRepository.update).toHaveBeenCalledWith('1', {
+        isActive: true,
+      });
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.USER_RESTORED,
+          entityId: '1',
+          performedBy: 'admin-1',
+        }),
+      );
+    });
+
+    it('reactivates a suspended (not soft-deleted) user without calling restore', async () => {
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.update.mockResolvedValue({});
+
+      await service.adminRestoreAccount('1', 'admin-1');
+
+      expect(mockUserRepository.restore).not.toHaveBeenCalled();
+      expect(mockUserRepository.update).toHaveBeenCalledWith('1', {
+        isActive: true,
+      });
+    });
+
+    it('throws NotFoundException if user not found', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.adminRestoreAccount('999', 'admin-1'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -9,13 +9,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { createHash, randomBytes } from 'crypto';
 import * as bcrypt from 'bcryptjs';
-import { User } from './entities/user.entity';
+import { User, UserRole } from './entities/user.entity';
 import {
   UpdateUserProfileDto,
   ChangeEmailDto,
   ChangePasswordDto,
 } from './dto/update-user.dto';
 import { UserRestoreDto } from './dto/user-restore.dto';
+import { AdminUserQueryDto } from './dto/admin-user-query.dto';
 import { KycStatus } from '../kyc/kyc-status.enum';
 import { AuditService } from '../audit/audit.service';
 import {
@@ -30,6 +31,26 @@ import {
 } from '../audit/entities/audit-log.entity';
 
 const SALT_ROUNDS = 12;
+
+export interface AdminUserView {
+  id: string;
+  email: string;
+  name: string;
+  role: UserRole;
+  phone: string | null;
+  avatar: string | null;
+  isVerified: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaginatedAdminUsersResult {
+  data: AdminUserView[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
 
 @Injectable()
 export class UsersService {
@@ -312,6 +333,138 @@ export class UsersService {
     this.logger.log(`Account restored for user: ${user.email}`);
 
     return { message: 'Account restored successfully. You can now log in.' };
+  }
+
+  async findAllForAdmin(
+    query: AdminUserQueryDto,
+  ): Promise<PaginatedAdminUsersResult> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+
+    const qb = this.userRepository.createQueryBuilder('user');
+
+    if (query.role) {
+      qb.andWhere('user.role = :role', { role: query.role });
+    }
+
+    if (query.isVerified !== undefined) {
+      qb.andWhere('user.emailVerified = :isVerified', {
+        isVerified: query.isVerified,
+      });
+    }
+
+    if (query.search) {
+      qb.andWhere(
+        '(user.email ILIKE :search OR user.firstName ILIKE :search OR user.lastName ILIKE :search)',
+        { search: `%${query.search}%` },
+      );
+    }
+
+    qb.orderBy('user.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [rows, total] = await qb.getManyAndCount();
+
+    return {
+      data: rows.map((user) => this.toAdminUserView(user)),
+      total,
+      page,
+      limit,
+      totalPages: Math.max(Math.ceil(total / limit), 1),
+    };
+  }
+
+  async adminDeactivateAccount(
+    userId: string,
+    adminId: string,
+  ): Promise<{ message: string }> {
+    const user = await this.findById(userId);
+
+    await this.userRepository.update(userId, {
+      isActive: false,
+      refreshToken: null,
+    });
+
+    await this.auditService.log({
+      action: AuditAction.USER_SUSPENDED,
+      entityType: 'User',
+      entityId: userId,
+      performedBy: adminId,
+      status: AuditStatus.SUCCESS,
+      level: AuditLevel.SECURITY,
+      oldValues: { isActive: user.isActive },
+      newValues: { isActive: false },
+    });
+
+    this.logger.log(`Account suspended by admin ${adminId}: ${user.email}`);
+
+    return { message: 'User suspended successfully' };
+  }
+
+  async adminVerifyAccount(
+    userId: string,
+    adminId: string,
+  ): Promise<{ message: string }> {
+    const user = await this.findById(userId);
+
+    await this.userRepository.update(userId, { emailVerified: true });
+
+    await this.auditService.log({
+      action: AuditAction.USER_VERIFIED,
+      entityType: 'User',
+      entityId: userId,
+      performedBy: adminId,
+      status: AuditStatus.SUCCESS,
+      level: AuditLevel.SECURITY,
+      oldValues: { emailVerified: user.emailVerified },
+      newValues: { emailVerified: true },
+    });
+
+    this.logger.log(`Account verified by admin ${adminId}: ${user.email}`);
+
+    return { message: 'User verified successfully' };
+  }
+
+  async adminRestoreAccount(
+    userId: string,
+    adminId: string,
+  ): Promise<{ message: string }> {
+    const user = await this.findById(userId, true);
+
+    if (user.deletedAt) {
+      await this.userRepository.restore(userId);
+    }
+    await this.userRepository.update(userId, { isActive: true });
+
+    await this.auditService.log({
+      action: AuditAction.USER_RESTORED,
+      entityType: 'User',
+      entityId: userId,
+      performedBy: adminId,
+      status: AuditStatus.SUCCESS,
+      level: AuditLevel.SECURITY,
+      oldValues: { isActive: user.isActive, deletedAt: user.deletedAt ?? null },
+      newValues: { isActive: true, deletedAt: null },
+    });
+
+    this.logger.log(`Account restored by admin ${adminId}: ${user.email}`);
+
+    return { message: 'User restored successfully' };
+  }
+
+  private toAdminUserView(user: User): AdminUserView {
+    return {
+      id: user.id,
+      email: user.email ?? '',
+      name: [user.firstName, user.lastName].filter(Boolean).join(' '),
+      role: user.role,
+      phone: user.phoneNumber,
+      avatar: user.avatarUrl,
+      isVerified: user.emailVerified,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+    };
   }
 
   async hardDeleteAccount(userId: string): Promise<{ message: string }> {

--- a/frontend/lib/query/hooks/use-admin-users.ts
+++ b/frontend/lib/query/hooks/use-admin-users.ts
@@ -54,7 +54,10 @@ export function useSuspendUser() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (userId: string) => {
-      await apiClient.post(`/users/${userId}/deactivate`, {});
+      await apiClient.post(
+        `/admin/users/${encodeURIComponent(userId)}/deactivate`,
+        {},
+      );
     },
     onSuccess: (_, userId) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
@@ -72,7 +75,10 @@ export function useActivateUser() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (userId: string) => {
-      await apiClient.post(`/users/restore`, { userId });
+      await apiClient.post(
+        `/admin/users/${encodeURIComponent(userId)}/restore`,
+        {},
+      );
     },
     onSuccess: (_, userId) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.all });


### PR DESCRIPTION
## Summary
Adds the missing admin-scoped `/admin/users/*` backend routes that the existing admin user management page calls, and fixes the frontend hooks that were hitting mismatched endpoints.

- `GET /admin/users` — paginated list, filterable by `role`, `search`, `isVerified`
- `POST /admin/users/:id/deactivate` — admin suspend by user id
- `POST /admin/users/:id/verify` — mark a user verified
- `POST /admin/users/:id/restore` — admin restore/reactivate by id (the old `/users/restore` route needs `{email, password}` for self-service recovery and doesn't match the `{userId}` the frontend sent)
- All admin actions guarded by `JwtAuthGuard` + `RolesGuard(ADMIN, SUPER_ADMIN)` and audit-logged
- Frontend `useSuspendUser`/`useActivateUser` updated to call the new endpoints

## Test plan
- [x] Backend: `pnpm run lint`, `pnpm exec tsc --noEmit`, `pnpm test` (1856 passed), `pnpm run build` — all pass
- [x] Frontend: `pnpm run lint`, `pnpm test` (900 passed), `pnpm run build` — all pass
- [x] New unit tests: non-admin gets 403 on all four routes; admin succeeds and service is called with correct args; repository update + audit log asserted per action

Closes #1338
