### PR TITLE
Connect frontend rent payment components to backend payment API

### DIFF
--- a/frontend/__tests__/lib/use-payments.test.ts
+++ b/frontend/__tests__/lib/use-payments.test.ts
@@ -1,0 +1,832 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  usePayments,
+  usePayment,
+  usePaymentsByAgreement,
+  useCreatePayment,
+  usePaymentMethods,
+  useCreatePaymentMethod,
+  useDeletePaymentMethod,
+  useRentPaymentSchedule,
+  useRentPaymentHistory,
+  useSubmitRentPayment,
+  useDownloadPaymentReceipt,
+  useCalculateLateFee,
+  usePaymentSchedules,
+  useCreatePaymentSchedule,
+  useUpdatePaymentSchedule,
+  useRunPaymentSchedule,
+  readDepositDeductions,
+  useDeposits,
+  useDepositStatus,
+  useDepositDeductions,
+} from '@/lib/query/hooks/use-payments';
+import { apiClient } from '@/lib/api-client';
+import type { PaginatedResponse, Payment, PaymentScheduleEntry } from '@/types';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: vi.fn(),
+    }),
+  };
+});
+
+function createMockPaginatedResponse<T>(items: T[]): PaginatedResponse<T> {
+  return {
+    data: items,
+    total: items.length,
+    page: 1,
+    limit: 10,
+    totalPages: 1,
+  };
+}
+
+function createMockPayment(overrides: Partial<Payment> = {}): Payment {
+  return {
+    id: 'pay-1',
+    agreementId: 'agreement-1',
+    amount: 2500,
+    currency: 'USDC',
+    status: 'completed',
+    paymentMethod: 'card',
+    dueDate: '2025-06-01',
+    paidAt: '2025-06-01T12:00:00Z',
+    referenceNumber: 'REF-001',
+    createdAt: '2025-06-01T12:00:00Z',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// Helper to create a wrapper for React Query hooks
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+describe('usePayments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches paginated payments list', async () => {
+    const mockResponse = createMockPaginatedResponse([createMockPayment()]);
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockResponse,
+    });
+
+    const { result } = renderHook(() => usePayments({ page: 1, limit: 10 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+    expect(apiClient.get).toHaveBeenCalledWith('/payments?page=1&limit=10');
+  });
+
+  it('builds query string with all filters', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: createMockPaginatedResponse([]),
+    });
+
+    renderHook(
+      () =>
+        usePayments({
+          page: 2,
+          limit: 5,
+          status: 'pending',
+          agreementId: 'agr-1',
+          startDate: '2025-01-01',
+          endDate: '2025-12-31',
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/payments?page=2&limit=5&status=pending&agreementId=agr-1&startDate=2025-01-01&endDate=2025-12-31',
+      );
+    });
+  });
+
+  it('handles empty params gracefully', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: createMockPaginatedResponse([]),
+    });
+
+    renderHook(() => usePayments(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith('/payments');
+    });
+  });
+});
+
+describe('usePayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches a single payment by ID', async () => {
+    const mockPayment = createMockPayment({ id: 'pay-1' });
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockPayment,
+    });
+
+    const { result } = renderHook(() => usePayment('pay-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockPayment);
+    expect(apiClient.get).toHaveBeenCalledWith('/payments/pay-1');
+  });
+
+  it('does not fetch when id is null', async () => {
+    const { result } = renderHook(() => usePayment(null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});
+
+describe('usePaymentsByAgreement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches payments by agreement', async () => {
+    const mockPayments = [createMockPayment()];
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockPayments,
+    });
+
+    const { result } = renderHook(() => usePaymentsByAgreement('agreement-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockPayments);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/payments?agreementId=agreement-1',
+    );
+  });
+});
+
+describe('useCreatePayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a payment and invalidates caches', async () => {
+    const createdPayment = createMockPayment({ id: 'pay-new' });
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: createdPayment,
+    });
+
+    const { result } = renderHook(() => useCreatePayment(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      agreementId: 'agreement-1',
+      amount: 2500,
+      currency: 'USDC',
+      paymentMethod: 'card',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(createdPayment);
+    expect(apiClient.post).toHaveBeenCalledWith('/payments', {
+      agreementId: 'agreement-1',
+      amount: 2500,
+      currency: 'USDC',
+      paymentMethod: 'card',
+    });
+  });
+});
+
+describe('usePaymentMethods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches payment methods', async () => {
+    const mockMethods = [
+      {
+        id: 1,
+        userId: 'user-1',
+        paymentType: 'CREDIT_CARD',
+        lastFour: '1234',
+        isDefault: true,
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ];
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockMethods,
+    });
+
+    const { result } = renderHook(() => usePaymentMethods(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockMethods);
+    expect(apiClient.get).toHaveBeenCalledWith('/payment-methods');
+  });
+
+  it('passes isDefault filter when provided', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [],
+    });
+
+    renderHook(() => usePaymentMethods({ isDefault: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/payment-methods?isDefault=true',
+      );
+    });
+  });
+});
+
+describe('useCreatePaymentMethod', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a payment method', async () => {
+    const createdMethod = {
+      id: 2,
+      userId: 'user-1',
+      paymentType: 'BANK_TRANSFER',
+      lastFour: '5678',
+      isDefault: true,
+      createdAt: '2025-06-01T00:00:00Z',
+      updatedAt: '2025-06-01T00:00:00Z',
+    };
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: createdMethod,
+    });
+
+    const { result } = renderHook(() => useCreatePaymentMethod(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      paymentType: 'BANK_TRANSFER',
+      lastFour: '5678',
+      isDefault: true,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(createdMethod);
+  });
+});
+
+describe('useDeletePaymentMethod', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deletes a payment method', async () => {
+    (apiClient.delete as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { success: true },
+    });
+
+    const { result } = renderHook(() => useDeletePaymentMethod(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(1);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.delete).toHaveBeenCalledWith('/payment-methods/1');
+  });
+});
+
+describe('useRentPaymentSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches rent payment schedule for an agreement', async () => {
+    const mockSchedule: PaymentScheduleEntry[] = [
+      {
+        paymentNumber: 1,
+        dueDate: new Date(Date.now() + 30 * 86400000).toISOString(),
+        amount: 2500,
+        agreementId: 'agreement-1',
+      },
+    ];
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockSchedule,
+    });
+
+    const { result } = renderHook(() => useRentPaymentSchedule('agreement-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockSchedule);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/rent/agreements/agreement-1/schedule',
+    );
+  });
+
+  it('does not fetch when agreementId is null', async () => {
+    const { result } = renderHook(() => useRentPaymentSchedule(null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});
+
+describe('useRentPaymentHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches rent payment history for an agreement', async () => {
+    const mockHistory = [createMockPayment({ id: 'pay-hist-1' })];
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockHistory,
+    });
+
+    const { result } = renderHook(() => useRentPaymentHistory('agreement-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockHistory);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/rent/agreements/agreement-1/history',
+    );
+  });
+});
+
+describe('useSubmitRentPayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits a stellar rent payment', async () => {
+    const createdPayment = createMockPayment({ id: 'pay-stellar-1' });
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: createdPayment,
+    });
+
+    const { result } = renderHook(() => useSubmitRentPayment(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userAddress: 'GABC123...',
+      userSecret: 'SABC123...',
+      agreementId: 'agreement-1',
+      amount: '2500',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(createdPayment);
+    expect(apiClient.post).toHaveBeenCalledWith('/payments/stellar/rent', {
+      userAddress: 'GABC123...',
+      userSecret: 'SABC123...',
+      agreementId: 'agreement-1',
+      amount: '2500',
+    });
+  });
+});
+
+describe('useDownloadPaymentReceipt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('downloads a payment receipt', async () => {
+    const mockReceipt = {
+      receipt: { paymentId: 'pay-1', amount: 2500 },
+      fileName: 'receipt-pay-1.txt',
+      data: btoa('test receipt content'),
+    };
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockReceipt,
+    });
+
+    const { result } = renderHook(() => useDownloadPaymentReceipt(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate('pay-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockReceipt);
+    expect(apiClient.get).toHaveBeenCalledWith('/payments/pay-1/receipt');
+  });
+});
+
+describe('useCalculateLateFee', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calculates late fee', async () => {
+    const mockResult = { lateFee: 125 };
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockResult,
+    });
+
+    const { result } = renderHook(() => useCalculateLateFee(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      monthlyRent: 2500,
+      daysLate: 10,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResult);
+    expect(apiClient.post).toHaveBeenCalledWith('/rent/calculate/late-fee', {
+      monthlyRent: 2500,
+      daysLate: 10,
+    });
+  });
+
+  it('passes optional grace period and rate', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { lateFee: 200 },
+    });
+
+    const { result } = renderHook(() => useCalculateLateFee(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      monthlyRent: 2500,
+      daysLate: 15,
+      gracePeriodDays: 7,
+      lateFeeRate: 0.1,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.post).toHaveBeenCalledWith('/rent/calculate/late-fee', {
+      monthlyRent: 2500,
+      daysLate: 15,
+      gracePeriodDays: 7,
+      lateFeeRate: 0.1,
+    });
+  });
+});
+
+describe('usePaymentSchedules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches payment schedules', async () => {
+    const mockSchedules = [
+      {
+        id: 'sched-1',
+        userId: 'user-1',
+        agreementId: 'agreement-1',
+        paymentMethod: null,
+        paymentMethodId: 1,
+        amount: 2500,
+        currency: 'USDC',
+        interval: 'monthly' as const,
+        nextRunAt: new Date(Date.now() + 30 * 86400000).toISOString(),
+        status: 'active' as const,
+        retries: 0,
+        maxRetries: 3,
+        lastError: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockSchedules,
+    });
+
+    const { result } = renderHook(
+      () => usePaymentSchedules({ agreementId: 'agreement-1' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockSchedules);
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/payments/schedules?agreementId=agreement-1',
+    );
+  });
+
+  it('filters by status', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [],
+    });
+
+    renderHook(() => usePaymentSchedules({ status: 'active' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/payments/schedules?status=active',
+      );
+    });
+  });
+
+  it('fetches all schedules with no filters', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [],
+    });
+
+    renderHook(() => usePaymentSchedules(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith('/payments/schedules');
+    });
+  });
+});
+
+describe('useCreatePaymentSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a payment schedule', async () => {
+    const created = {
+      id: 'sched-new',
+      userId: 'user-1',
+      agreementId: 'agreement-1',
+      paymentMethod: null,
+      paymentMethodId: 1,
+      amount: 2500,
+      currency: 'USDC',
+      interval: 'monthly' as const,
+      nextRunAt: new Date(Date.now() + 30 * 86400000).toISOString(),
+      status: 'active' as const,
+      retries: 0,
+      maxRetries: 3,
+      lastError: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: created,
+    });
+
+    const { result } = renderHook(() => useCreatePaymentSchedule(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      amount: 2500,
+      paymentMethodId: '1',
+      interval: 'monthly',
+      agreementId: 'agreement-1',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(created);
+    expect(apiClient.post).toHaveBeenCalledWith('/payments/schedules', {
+      amount: 2500,
+      paymentMethodId: '1',
+      interval: 'monthly',
+      agreementId: 'agreement-1',
+    });
+  });
+});
+
+describe('useUpdatePaymentSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates a payment schedule (pause)', async () => {
+    const updated = {
+      id: 'sched-1',
+      status: 'paused' as const,
+    };
+    (apiClient.patch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: updated,
+    });
+
+    const { result } = renderHook(() => useUpdatePaymentSchedule(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: 'sched-1', status: 'paused' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(updated);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/payments/schedules/sched-1',
+      {
+        status: 'paused',
+      },
+    );
+  });
+
+  it('updates nextRunAt and maxRetries', async () => {
+    (apiClient.patch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'sched-1' },
+    });
+
+    const { result } = renderHook(() => useUpdatePaymentSchedule(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      id: 'sched-1',
+      nextRunAt: '2025-07-01T00:00:00Z',
+      maxRetries: 5,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/payments/schedules/sched-1',
+      {
+        nextRunAt: '2025-07-01T00:00:00Z',
+        maxRetries: 5,
+      },
+    );
+  });
+});
+
+describe('useRunPaymentSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs a payment schedule', async () => {
+    const mockPayment = createMockPayment({ id: 'pay-from-schedule' });
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockPayment,
+    });
+
+    const { result } = renderHook(() => useRunPaymentSchedule(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate('sched-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockPayment);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/payments/schedules/sched-1/run',
+    );
+  });
+});
+
+describe('readDepositDeductions', () => {
+  it('returns empty array when deductions is missing or not an array', () => {
+    expect(readDepositDeductions({ metadata: {} } as any)).toEqual([]);
+    expect(
+      readDepositDeductions({ metadata: { deductions: 'not-array' } } as any),
+    ).toEqual([]);
+  });
+
+  it('correctly maps and filters valid deductions', () => {
+    const mockPayment = {
+      id: 'pay-1',
+      metadata: {
+        deductions: [
+          {
+            id: 'd-1',
+            label: 'Cleaning',
+            amount: 150,
+            reason: 'Dirty kitchen',
+            createdAt: '2025-05-01',
+          },
+          { label: 'Repairs', amount: 250 },
+          { label: 'Free', amount: 0 },
+          { label: 'Invalid', amount: 'abc' },
+          null,
+        ],
+      },
+    } as any;
+
+    const results = readDepositDeductions(mockPayment);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      id: 'd-1',
+      label: 'Cleaning',
+      amount: 150,
+      reason: 'Dirty kitchen',
+      createdAt: '2025-05-01',
+    });
+    expect(results[1]).toEqual({
+      id: 'pay-1-deduction-1',
+      label: 'Repairs',
+      amount: 250,
+      reason: undefined,
+      createdAt: undefined,
+    });
+  });
+});
+
+describe('useDeposits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches and filters deposits', async () => {
+    const nonDepositPayment = createMockPayment({
+      id: 'pay-regular',
+      metadata: {},
+    });
+    const depositPayment = createMockPayment({
+      id: 'pay-deposit',
+      metadata: { flow: 'deposit', type: 'security_deposit' },
+    });
+
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: createMockPaginatedResponse([nonDepositPayment, depositPayment]),
+    });
+
+    const { result } = renderHook(() => useDeposits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+    expect(result.current.data?.data[0].id).toBe('pay-deposit');
+  });
+});
+
+describe('useDepositStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches deposit status', async () => {
+    const mockPayment = createMockPayment({ id: 'pay-deposit' });
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockPayment,
+    });
+
+    const { result } = renderHook(() => useDepositStatus('pay-deposit'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockPayment);
+  });
+});
+
+describe('useDepositDeductions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches deposit deductions', async () => {
+    const mockPayment = {
+      id: 'pay-deposit',
+      metadata: {
+        deductions: [{ id: 'd-1', label: 'Cleaning', amount: 150 }],
+      },
+    };
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockPayment,
+    });
+
+    const { result } = renderHook(() => useDepositDeductions('pay-deposit'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].label).toBe('Cleaning');
+  });
+});

--- a/frontend/lib/mock-api.ts
+++ b/frontend/lib/mock-api.ts
@@ -344,6 +344,109 @@ const dynamicPatterns: Array<{
       limit: 10,
     }),
   },
+  // ─── Rent Payment Schedule ─────────────────────────────────────────────────
+  {
+    pattern: /^\/rent\/agreements\/([^/]+)\/schedule$/,
+    handler: (match) => [
+      {
+        paymentNumber: 1,
+        dueDate: new Date(Date.now() + 30 * 86400000).toISOString(),
+        amount: 2500,
+        agreementId: match[1],
+      },
+      {
+        paymentNumber: 2,
+        dueDate: new Date(Date.now() + 60 * 86400000).toISOString(),
+        amount: 2500,
+        agreementId: match[1],
+      },
+      {
+        paymentNumber: 3,
+        dueDate: new Date(Date.now() + 90 * 86400000).toISOString(),
+        amount: 2500,
+        agreementId: match[1],
+      },
+    ],
+  },
+  // ─── Rent Payment History ──────────────────────────────────────────────────
+  {
+    pattern: /^\/rent\/agreements\/([^/]+)\/history$/,
+    handler: (match) => [
+      {
+        id: 'pay-hist-001',
+        agreementId: match[1],
+        amount: 2500,
+        currency: 'USDC',
+        status: 'completed',
+        paymentMethod: 'card',
+        dueDate: new Date(Date.now() - 30 * 86400000).toISOString(),
+        paidAt: new Date(Date.now() - 28 * 86400000).toISOString(),
+        referenceNumber: 'REF-001',
+        createdAt: new Date(Date.now() - 28 * 86400000).toISOString(),
+      },
+      {
+        id: 'pay-hist-002',
+        agreementId: match[1],
+        amount: 2500,
+        currency: 'USDC',
+        status: 'completed',
+        paymentMethod: 'bank_transfer',
+        dueDate: new Date(Date.now() - 60 * 86400000).toISOString(),
+        paidAt: new Date(Date.now() - 58 * 86400000).toISOString(),
+        referenceNumber: 'REF-002',
+        createdAt: new Date(Date.now() - 58 * 86400000).toISOString(),
+      },
+    ],
+  },
+  // ─── Late Fee Calculation ──────────────────────────────────────────────────
+  {
+    pattern: /^\/rent\/calculate\/late-fee$/,
+    handler: () => ({ lateFee: 125 }),
+  },
+  // ─── Payment Schedules ─────────────────────────────────────────────────────
+  {
+    pattern: /^\/payments\/schedules$/,
+    handler: () => [
+      {
+        id: 'sched-001',
+        userId: 'user_1',
+        agreementId: 'agreement_1',
+        paymentMethod: null,
+        paymentMethodId: 1,
+        amount: 2500,
+        currency: 'USDC',
+        interval: 'monthly',
+        nextRunAt: new Date(Date.now() + 30 * 86400000).toISOString(),
+        status: 'active',
+        retries: 0,
+        maxRetries: 3,
+        lastError: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ],
+  },
+  // ─── Payment Schedule Detail ───────────────────────────────────────────────
+  {
+    pattern: /^\/payments\/schedules\/([^/]+)$/,
+    handler: (match) => ({
+      id: match[1],
+      userId: 'user_1',
+      agreementId: 'agreement_1',
+      paymentMethod: null,
+      paymentMethodId: 1,
+      amount: 2500,
+      currency: 'USDC',
+      interval: 'monthly',
+      nextRunAt: new Date(Date.now() + 30 * 86400000).toISOString(),
+      status: 'active',
+      retries: 0,
+      maxRetries: 3,
+      lastError: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  },
 ];
 
 export function getMockData(endpoint: string): unknown {

--- a/frontend/lib/query/hooks/use-payments.ts
+++ b/frontend/lib/query/hooks/use-payments.ts
@@ -3,7 +3,15 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import { queryKeys } from '../keys';
-import type { Payment, PaginatedResponse, PaymentMethod } from '@/types';
+import type {
+  Payment,
+  PaginatedResponse,
+  PaymentMethod,
+  PaymentSchedule,
+  PaymentScheduleEntry,
+  PaymentScheduleStatus,
+  LateFeeCalculation,
+} from '@/types';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -111,6 +119,284 @@ export function usePaymentsByAgreement(agreementId: string | null) {
       return data;
     },
     enabled: Boolean(agreementId),
+  });
+}
+
+// ─── Rent Payment Schedule ─────────────────────────────────────────────────
+
+/**
+ * Fetch the rent payment schedule for an agreement.
+ * GET /rent/agreements/:id/schedule
+ */
+export function useRentPaymentSchedule(agreementId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.payments.rentSchedule(agreementId ?? ''),
+    queryFn: async () => {
+      const { data } = await apiClient.get<PaymentScheduleEntry[]>(
+        `/rent/agreements/${agreementId}/schedule`,
+      );
+      return data;
+    },
+    enabled: Boolean(agreementId),
+  });
+}
+
+/**
+ * Fetch the rent payment history for an agreement.
+ * GET /rent/agreements/:id/history
+ */
+export function useRentPaymentHistory(agreementId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.payments.rentHistory(agreementId ?? ''),
+    queryFn: async () => {
+      const { data } = await apiClient.get<Payment[]>(
+        `/rent/agreements/${agreementId}/history`,
+      );
+      return data;
+    },
+    enabled: Boolean(agreementId),
+  });
+}
+
+// ─── Submit Stellar Rent Payment ───────────────────────────────────────────────
+
+export interface SubmitRentPaymentPayload {
+  userAddress: string;
+  userSecret: string;
+  agreementId: string;
+  amount: string;
+  idempotencyKey?: string;
+}
+
+/**
+ * Submit a rent payment via Stellar blockchain.
+ * POST /payments/stellar/rent
+ */
+export function useSubmitRentPayment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: SubmitRentPaymentPayload) => {
+      const { data } = await apiClient.post<Payment>(
+        '/payments/stellar/rent',
+        payload,
+      );
+      return data;
+    },
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.payments.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.transactions.all });
+      if (created.agreementId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.payments.rentHistory(created.agreementId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.payments.rentSchedule(created.agreementId),
+        });
+      }
+    },
+  });
+}
+
+// ─── Download Payment Receipt ──────────────────────────────────────────────────
+
+export interface DownloadReceiptPayload {
+  paymentId: string;
+}
+
+/**
+ * Download a receipt for any completed payment.
+ * GET /payments/:id/receipt
+ */
+export function useDownloadPaymentReceipt() {
+  return useMutation({
+    mutationFn: async (paymentId: string) => {
+      const { data } = await apiClient.get<{
+        receipt: unknown;
+        fileName?: string;
+        data?: string;
+      }>(`/payments/${paymentId}/receipt`);
+      downloadPaymentReceiptFile(paymentId, data);
+      return data;
+    },
+  });
+}
+
+function downloadPaymentReceiptFile(
+  paymentId: string,
+  receipt: { receipt?: unknown; fileName?: string; data?: string },
+) {
+  if (typeof window === 'undefined') return;
+
+  const fileName =
+    typeof receipt.fileName === 'string'
+      ? receipt.fileName
+      : `receipt-${paymentId}.txt`;
+
+  if (receipt.data && typeof receipt.data === 'string') {
+    const binaryStr = atob(receipt.data);
+    const bytes = new Uint8Array(binaryStr.length);
+    for (let i = 0; i < binaryStr.length; i++) {
+      bytes[i] = binaryStr.charCodeAt(i);
+    }
+    const blob = new Blob([bytes], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  } else {
+    const blob = new Blob(
+      [JSON.stringify(receipt.receipt ?? receipt, null, 2)],
+      { type: 'application/json' },
+    );
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+}
+
+// ─── Handle Late Payments ──────────────────────────────────────────────────────
+
+export interface CalculateLateFeePayload {
+  monthlyRent: number;
+  daysLate: number;
+  gracePeriodDays?: number;
+  lateFeeRate?: number;
+}
+
+/**
+ * Calculate a late fee for overdue payments.
+ * POST /rent/calculate/late-fee
+ */
+export function useCalculateLateFee() {
+  return useMutation({
+    mutationFn: async (payload: CalculateLateFeePayload) => {
+      const { data } = await apiClient.post<LateFeeCalculation>(
+        '/rent/calculate/late-fee',
+        payload,
+      );
+      return data;
+    },
+  });
+}
+
+// ─── Automatic Payments (Payment Schedules) ────────────────────────────────────
+
+export interface PaymentScheduleListParams {
+  agreementId?: string;
+  status?: PaymentScheduleStatus;
+}
+
+export interface CreatePaymentSchedulePayload {
+  agreementId?: string;
+  amount: number;
+  paymentMethodId: string;
+  currency?: string;
+  interval: 'weekly' | 'monthly' | 'quarterly' | 'yearly';
+  startDate?: string;
+  maxRetries?: number;
+}
+
+export interface UpdatePaymentSchedulePayload {
+  status?: PaymentScheduleStatus;
+  nextRunAt?: string;
+  maxRetries?: number;
+}
+
+/**
+ * Fetch payment schedules with optional filters.
+ * GET /payments/schedules
+ */
+export function usePaymentSchedules(filters: PaymentScheduleListParams = {}) {
+  return useQuery({
+    queryKey: queryKeys.payments.schedules.list(filters),
+    queryFn: async () => {
+      const qs = new URLSearchParams();
+      if (filters.agreementId) qs.append('agreementId', filters.agreementId);
+      if (filters.status) qs.append('status', filters.status);
+      const str = qs.toString();
+      const { data } = await apiClient.get<PaymentSchedule[]>(
+        `/payments/schedules${str ? `?${str}` : ''}`,
+      );
+      return data;
+    },
+  });
+}
+
+/**
+ * Create a new automatic payment schedule.
+ * POST /payments/schedules
+ */
+export function useCreatePaymentSchedule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: CreatePaymentSchedulePayload) => {
+      const { data } = await apiClient.post<PaymentSchedule>(
+        '/payments/schedules',
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.payments.schedules.all,
+      });
+    },
+  });
+}
+
+/**
+ * Update an existing payment schedule (pause, cancel, modify).
+ * PATCH /payments/schedules/:id
+ */
+export function useUpdatePaymentSchedule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      ...payload
+    }: UpdatePaymentSchedulePayload & { id: string }) => {
+      const { data } = await apiClient.patch<PaymentSchedule>(
+        `/payments/schedules/${id}`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.payments.schedules.all,
+      });
+    },
+  });
+}
+
+/**
+ * Manually trigger a payment schedule run.
+ * POST /payments/schedules/:id/run
+ */
+export function useRunPaymentSchedule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data } = await apiClient.post<Payment>(
+        `/payments/schedules/${id}/run`,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.payments.schedules.all,
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.payments.all });
+    },
   });
 }
 

--- a/frontend/lib/query/keys.ts
+++ b/frontend/lib/query/keys.ts
@@ -28,6 +28,19 @@ export const queryKeys = {
       [...queryKeys.payments.deposits(), 'detail', id] as const,
     depositDeductions: (id: string) =>
       [...queryKeys.payments.deposit(id), 'deductions'] as const,
+    rentSchedule: (agreementId: string) =>
+      [...queryKeys.payments.all, 'rentSchedule', agreementId] as const,
+    rentHistory: (agreementId: string) =>
+      [...queryKeys.payments.all, 'rentHistory', agreementId] as const,
+    schedules: {
+      all: ['payment-schedules'] as const,
+      lists: () => [...queryKeys.payments.schedules.all, 'list'] as const,
+      list: (filters: object) =>
+        [...queryKeys.payments.schedules.lists(), filters] as const,
+      detail: (id: string) =>
+        [...queryKeys.payments.schedules.all, 'detail', id] as const,
+    },
+    lateFee: () => [...queryKeys.payments.all, 'lateFee'] as const,
   },
 
   paymentMethods: {

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -40,7 +40,11 @@ export interface UserActivity {
 
 // Property Types — aligned with backend entity (ListingStatus / PropertyType enums)
 export type PropertyType =
-  'apartment' | 'house' | 'commercial' | 'land' | 'other';
+  | 'apartment'
+  | 'house'
+  | 'commercial'
+  | 'land'
+  | 'other';
 export type ListingStatus = 'draft' | 'published' | 'rented' | 'archived';
 
 export interface Property {
@@ -309,7 +313,11 @@ export interface Transaction {
 
 export type AnchorTransactionType = 'deposit' | 'withdrawal';
 export type AnchorTransactionStatus =
-  'pending' | 'processing' | 'completed' | 'failed' | 'refunded';
+  | 'pending'
+  | 'processing'
+  | 'completed'
+  | 'failed'
+  | 'refunded';
 
 export interface AnchorTransaction {
   id: string;
@@ -340,10 +348,15 @@ export interface AnchorTransactionStats {
 }
 
 export type IndexedTransactionStatus =
-  'pending' | 'indexed' | 'confirmed' | 'failed';
+  | 'pending'
+  | 'indexed'
+  | 'confirmed'
+  | 'failed';
 
 export type IndexedTransactionBlockchainConfirmation =
-  'confirmed' | 'unconfirmed' | 'failed';
+  | 'confirmed'
+  | 'unconfirmed'
+  | 'failed';
 
 export interface IndexedTransaction {
   id: string;
@@ -548,7 +561,12 @@ export interface ApiError {
 // Document Types
 export type DocumentType = 'pdf' | 'image' | 'docx' | 'xlsx' | 'txt';
 export type DocumentCategory =
-  'lease' | 'identity' | 'payment' | 'maintenance' | 'inspection' | 'other';
+  | 'lease'
+  | 'identity'
+  | 'payment'
+  | 'maintenance'
+  | 'inspection'
+  | 'other';
 
 export interface Document {
   id: string;

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -40,11 +40,7 @@ export interface UserActivity {
 
 // Property Types — aligned with backend entity (ListingStatus / PropertyType enums)
 export type PropertyType =
-  | 'apartment'
-  | 'house'
-  | 'commercial'
-  | 'land'
-  | 'other';
+  'apartment' | 'house' | 'commercial' | 'land' | 'other';
 export type ListingStatus = 'draft' | 'published' | 'rented' | 'archived';
 
 export interface Property {
@@ -174,6 +170,40 @@ export interface PaymentMethod {
   updatedAt: string;
 }
 
+export type PaymentInterval = 'weekly' | 'monthly' | 'quarterly' | 'yearly';
+
+export type PaymentScheduleStatus = 'active' | 'paused' | 'canceled' | 'failed';
+
+export interface PaymentSchedule {
+  id: string;
+  userId: string;
+  agreementId: string | null;
+  paymentMethod: PaymentMethod | null;
+  paymentMethodId: number | null;
+  amount: number;
+  currency: string;
+  interval: PaymentInterval;
+  nextRunAt: string;
+  status: PaymentScheduleStatus;
+  retries: number;
+  maxRetries: number;
+  lastError: string | null;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaymentScheduleEntry {
+  paymentNumber: number;
+  dueDate: string;
+  amount: number;
+  agreementId: string;
+}
+
+export interface LateFeeCalculation {
+  lateFee: number;
+}
+
 // Maintenance Types
 export interface MaintenanceRequest {
   id: string;
@@ -279,11 +309,7 @@ export interface Transaction {
 
 export type AnchorTransactionType = 'deposit' | 'withdrawal';
 export type AnchorTransactionStatus =
-  | 'pending'
-  | 'processing'
-  | 'completed'
-  | 'failed'
-  | 'refunded';
+  'pending' | 'processing' | 'completed' | 'failed' | 'refunded';
 
 export interface AnchorTransaction {
   id: string;
@@ -314,15 +340,10 @@ export interface AnchorTransactionStats {
 }
 
 export type IndexedTransactionStatus =
-  | 'pending'
-  | 'indexed'
-  | 'confirmed'
-  | 'failed';
+  'pending' | 'indexed' | 'confirmed' | 'failed';
 
 export type IndexedTransactionBlockchainConfirmation =
-  | 'confirmed'
-  | 'unconfirmed'
-  | 'failed';
+  'confirmed' | 'unconfirmed' | 'failed';
 
 export interface IndexedTransaction {
   id: string;
@@ -527,12 +548,7 @@ export interface ApiError {
 // Document Types
 export type DocumentType = 'pdf' | 'image' | 'docx' | 'xlsx' | 'txt';
 export type DocumentCategory =
-  | 'lease'
-  | 'identity'
-  | 'payment'
-  | 'maintenance'
-  | 'inspection'
-  | 'other';
+  'lease' | 'identity' | 'payment' | 'maintenance' | 'inspection' | 'other';
 
 export interface Document {
   id: string;


### PR DESCRIPTION
## Description

This PR connects all frontend rent payment components to the backend payment API, covering the full scope of rent payment operations: fetching schedules, submitting payments, viewing history, downloading receipts, handling late fees, and managing automatic payment schedules.

Closes #1174

## Changes Made

### New Types (`frontend/types/index.ts`)
- Added `PaymentSchedule` interface matching backend `PaymentSchedule` entity
- Added `PaymentScheduleEntry` interface for generated schedule entries
- Added `LateFeeCalculation` interface for late fee API responses
- Added `PaymentInterval` and `PaymentScheduleStatus` type aliases

### New Query Keys (`frontend/lib/query/keys.ts`)
- `payments.rentSchedule(agreementId)`
- `payments.rentHistory(agreementId)`
- `payments.schedules` — full hierarchy (`all`, `lists`, `list`, `detail`)
- `payments.lateFee`

### New React Query Hooks (`frontend/lib/query/hooks/use-payments.ts`)
| Hook | Endpoint | Description |
|------|----------|-------------|
| `useRentPaymentSchedule` | `GET /rent/agreements/:id/schedule` | Fetch payment schedule for an agreement |
| `useRentPaymentHistory` | `GET /rent/agreements/:id/history` | Fetch payment history for an agreement |
| `useSubmitRentPayment` | `POST /payments/stellar/rent` | Submit rent payment via Stellar |
| `useDownloadPaymentReceipt` | `GET /payments/:id/receipt` | Download payment receipt (generalized) |
| `useCalculateLateFee` | `POST /rent/calculate/late-fee` | Calculate late fee for overdue payments |
| `usePaymentSchedules` | `GET /payments/schedules` | List automatic payment schedules |
| `useCreatePaymentSchedule` | `POST /payments/schedules` | Create automatic payment schedule |
| `useUpdatePaymentSchedule` | `PATCH /payments/schedules/:id` | Update schedule (pause/cancel/modify) |
| `useRunPaymentSchedule` | `POST /payments/schedules/:id/run` | Manually trigger a schedule |

### Mock API Data (`frontend/lib/mock-api.ts`)
Added mock responses for all new endpoints:
- `/rent/agreements/:id/schedule` — returns 3-month schedule
- `/rent/agreements/:id/history` — returns past payment records
- `/rent/calculate/late-fee` — returns calculated fee
- `/payments/schedules` — returns schedule list
- `/payments/schedules/:id` — returns schedule detail

### Testing
- Added `frontend/__tests__/lib/use-payments.test.ts` with 30 tests covering all hooks (new + existing)
- `readDepositDeductions` tests migrated from the smaller test file

## Verification
- All 87 frontend test files pass (930 tests)
- All 164 backend test suites pass (1839 tests)
- Coverage thresholds maintained
- All existing test files unchanged

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] All tests pass
- [x] No breaking changes