### PR TITLE
fix: validate chargeId before processing payment refunds (#1354)

### DIFF
--- a/backend/src/modules/payments/payment.service.comprehensive.spec.ts
+++ b/backend/src/modules/payments/payment.service.comprehensive.spec.ts
@@ -313,6 +313,73 @@ describe('PaymentService – edge cases & isolation', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it('rejects refund with a descriptive error when metadata has no chargeId', async () => {
+      entityManager.findOne.mockResolvedValue({
+        id: 'pay-1',
+        userId: 'user-1',
+        status: PaymentStatus.COMPLETED,
+        amount: 100,
+        refundAmount: 0,
+        metadata: { gateway: 'paystack' },
+      } as unknown as Payment);
+
+      await expect(
+        service.processRefund(
+          'pay-1',
+          { amount: 50, reason: 'no charge' } as ProcessRefundDto,
+          'user-1',
+        ),
+      ).rejects.toThrow(
+        /payment pay-1 has no gateway charge ID recorded in its metadata/,
+      );
+
+      // Refund must be rejected before it ever reaches the gateway.
+      expect(mockGateway.processRefund).not.toHaveBeenCalled();
+      expect(entityManager.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects refund when metadata is entirely null', async () => {
+      entityManager.findOne.mockResolvedValue({
+        id: 'pay-2',
+        userId: 'user-1',
+        status: PaymentStatus.COMPLETED,
+        amount: 100,
+        refundAmount: 0,
+        metadata: null,
+      } as unknown as Payment);
+
+      await expect(
+        service.processRefund(
+          'pay-2',
+          { amount: 50, reason: 'null meta' } as ProcessRefundDto,
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockGateway.processRefund).not.toHaveBeenCalled();
+    });
+
+    it('rejects refund when chargeId is blank/whitespace', async () => {
+      entityManager.findOne.mockResolvedValue({
+        id: 'pay-3',
+        userId: 'user-1',
+        status: PaymentStatus.COMPLETED,
+        amount: 100,
+        refundAmount: 0,
+        metadata: { chargeId: '   ' },
+      } as unknown as Payment);
+
+      await expect(
+        service.processRefund(
+          'pay-3',
+          { amount: 50, reason: 'blank' } as ProcessRefundDto,
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockGateway.processRefund).not.toHaveBeenCalled();
+    });
+
     it('sends notification after successful refund', async () => {
       entityManager.findOne.mockResolvedValue({
         id: 'pay-1',

--- a/backend/src/modules/payments/payment.service.ts
+++ b/backend/src/modules/payments/payment.service.ts
@@ -231,13 +231,19 @@ export class PaymentService {
         );
       }
 
-      if (dto.amount > payment.amount - payment.refundAmount) {
-        throw new BadRequestException('Refund amount exceeds available amount');
+      // Assert the gateway charge reference exists before any refund work.
+      // Without it we cannot tell the gateway which charge to reverse, and
+      // proceeding with an undefined chargeId risks crashing the gateway call
+      // or refunding against the wrong charge.
+      const chargeId = payment.metadata?.chargeId?.trim();
+      if (!chargeId) {
+        throw new BadRequestException(
+          `Cannot process refund: payment ${paymentId} has no gateway charge ID recorded in its metadata`,
+        );
       }
 
-      const chargeId = payment.metadata?.chargeId;
-      if (!chargeId) {
-        throw new BadRequestException('No charge ID found for refund');
+      if (dto.amount > payment.amount - payment.refundAmount) {
+        throw new BadRequestException('Refund amount exceeds available amount');
       }
 
       const refundResult = await Promise.resolve(


### PR DESCRIPTION
## Summary

Fixes #1354 — a refund could reach the payment gateway with an undefined `chargeId`.

`Payment.metadata` is `PaymentMetadata | null` and `chargeId` is optional, so `payment.metadata?.chargeId` is genuinely reachable as `undefined`. Passing that to `paymentGateway.processRefund(chargeId, amount)` can crash the gateway call or reverse the wrong charge.

## Changes

**`payment.service.ts` (`processRefund`)**
- Moved the `chargeId` assertion to the **start of the refund flow** (right after the status check, before any amount math), so a structurally-broken payment is rejected before any refund work.
- Descriptive error naming the payment and what's missing:
  > `Cannot process refund: payment {id} has no gateway charge ID recorded in its metadata`
- Hardened against whitespace-only values via `?.trim()`.

**`payment.service.comprehensive.spec.ts`**
- 3 new tests: `chargeId` absent, `metadata: null`, and blank/whitespace `chargeId` — each asserting the descriptive rejection **and** that `gateway.processRefund` / `save` are never called (proves it's rejected safely before any external call).

> Note: the pre-existing guard used a generic message and ran after the amount check with no test coverage; this tightens ordering, messaging, and adds the missing tests.

## Acceptance criteria

- [x] Refunds with missing `chargeId` are rejected
- [x] Error message explains what's missing
- [x] Tests verify validation works

## Verification

- `pnpm run build` — passes
- `pnpm jest src/modules/payments/payment.service*.spec.ts` — 41 passed (incl. 3 new)

Closes #1354