### PR TITLE
fixed issues

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -84,7 +84,9 @@
   --color-slate-100: #ece9e0;
   --color-slate-200: #d9d5c9;
   --color-slate-300: #b9b3a4;
-  --color-slate-400: #8e897c;
+  /* slate-400 darkened #8e897c → #6b6760 for WCAG AA compliance:
+     5.62:1 on white · 5.20:1 on slate-50 · 4.63:1 on slate-100 */
+  --color-slate-400: #6b6760;
   --color-slate-500: #646056;
   --color-slate-600: #45423c;
   --color-slate-700: #2c2b28;
@@ -97,7 +99,9 @@
   --color-neutral-100: #ece9e0;
   --color-neutral-200: #d9d5c9;
   --color-neutral-300: #b9b3a4;
-  --color-neutral-400: #8e897c;
+  /* neutral-400 darkened #8e897c → #6b6760 for WCAG AA compliance:
+     5.62:1 on white · 5.20:1 on neutral-50 · 4.63:1 on neutral-100 */
+  --color-neutral-400: #6b6760;
   --color-neutral-500: #646056;
   --color-neutral-600: #45423c;
   --color-neutral-700: #2c2b28;

--- a/frontend/components/files/FileIcon.tsx
+++ b/frontend/components/files/FileIcon.tsx
@@ -45,7 +45,7 @@ export const FileIcon: React.FC<Props> = ({
     fileType.includes('word') ||
     fileType.includes('officedocument.wordprocessingml')
   )
-    return <FileText size={size} className={className || 'text-blue-600'} />;
+    return <FileText size={size} className={className || 'text-blue-800'} />;
 
   if (fileType.includes('presentation') || fileType.includes('powerpoint'))
     return (

--- a/frontend/components/leases/LeaseDetailsModal.tsx
+++ b/frontend/components/leases/LeaseDetailsModal.tsx
@@ -84,9 +84,8 @@ export function LeaseDetailsModal({
     // Counter previous pending offers
     setOffers((prev: NegotiationOffer[]) =>
       prev
-        .map(
-          (o: NegotiationOffer): NegotiationOffer =>
-            o.status === 'PENDING' ? { ...o, status: 'COUNTERED' } : o,
+        .map((o: NegotiationOffer): NegotiationOffer =>
+          o.status === 'PENDING' ? { ...o, status: 'COUNTERED' } : o,
         )
         .concat(newOffer),
     );
@@ -256,7 +255,7 @@ export function LeaseDetailsModal({
             {lease.status === 'PENDING' && (
               <button
                 onClick={() => setIsNegotiating(true)}
-                className="px-6 py-2.5 rounded-xl font-bold text-blue-600 bg-blue-50 hover:bg-blue-100 border border-blue-200 transition-colors flex items-center gap-2"
+                className="px-6 py-2.5 rounded-xl font-bold text-blue-800 bg-blue-50 hover:bg-blue-100 border border-blue-200 transition-colors flex items-center gap-2"
               >
                 <MessageSquare className="w-4 h-4" />
                 Negotiate

--- a/frontend/components/leases/NegotiationSidebar.tsx
+++ b/frontend/components/leases/NegotiationSidebar.tsx
@@ -155,7 +155,7 @@ export function NegotiationSidebar({
             onClick={() => setActiveTab('chat')}
             className={`flex-1 flex items-center justify-center gap-2 py-2 text-sm font-medium rounded-lg transition-all ${
               activeTab === 'chat'
-                ? 'bg-white text-blue-600 shadow-sm'
+                ? 'bg-white text-blue-800 shadow-sm'
                 : 'text-neutral-500 hover:text-neutral-700'
             }`}
           >
@@ -166,14 +166,14 @@ export function NegotiationSidebar({
             onClick={() => setActiveTab('offers')}
             className={`flex-1 flex items-center justify-center gap-2 py-2 text-sm font-medium rounded-lg transition-all ${
               activeTab === 'offers'
-                ? 'bg-white text-blue-600 shadow-sm'
+                ? 'bg-white text-blue-800 shadow-sm'
                 : 'text-neutral-500 hover:text-neutral-700'
             }`}
           >
             <History size={16} />
             Offers
             {offers.length > 0 && (
-              <span className="ml-1 w-5 h-5 rounded-full bg-blue-100 text-blue-600 text-[10px] flex items-center justify-center font-bold">
+              <span className="ml-1 w-5 h-5 rounded-full bg-blue-100 text-blue-800 text-[10px] flex items-center justify-center font-bold">
                 {offers.length}
               </span>
             )}
@@ -320,7 +320,7 @@ export function NegotiationSidebar({
                     <Button
                       variant="outline"
                       onClick={() => setIsProposing(false)}
-                      className="flex-1 h-9 rounded-lg border-blue-200 bg-white text-blue-600 hover:bg-blue-100"
+                      className="flex-1 h-9 rounded-lg border-blue-200 bg-white text-blue-800 hover:bg-blue-100"
                     >
                       Cancel
                     </Button>
@@ -335,7 +335,7 @@ export function NegotiationSidebar({
               ) : (
                 <Button
                   onClick={() => setIsProposing(true)}
-                  className="w-full py-6 rounded-2xl border-2 border-dashed border-neutral-200 hover:border-blue-400 hover:bg-blue-50 text-neutral-500 hover:text-blue-600 transition-all bg-transparent font-semibold flex items-center gap-2"
+                  className="w-full py-6 rounded-2xl border-2 border-dashed border-neutral-200 hover:border-blue-400 hover:bg-blue-50 text-neutral-500 hover:text-blue-800 transition-all bg-transparent font-semibold flex items-center gap-2"
                 >
                   <ArrowRight size={18} />
                   Make a Counter-Offer
@@ -386,7 +386,7 @@ export function NegotiationSidebar({
                               <div
                                 className={`p-1.5 rounded-lg ${
                                   offer.proposerRole === userRole
-                                    ? 'bg-blue-100 text-blue-600'
+                                    ? 'bg-blue-100 text-blue-800'
                                     : 'bg-neutral-100 text-neutral-600'
                                 }`}
                               >

--- a/frontend/components/messaging/ChatSidebar.tsx
+++ b/frontend/components/messaging/ChatSidebar.tsx
@@ -141,7 +141,7 @@ export function ChatSidebar({
                   <div className="flex items-center justify-between mb-0.5">
                     <span
                       className={`text-sm font-semibold truncate ${
-                        isActive ? 'text-blue-700' : 'text-neutral-900'
+                        isActive ? 'text-blue-900' : 'text-neutral-900'
                       }`}
                     >
                       {other
@@ -174,8 +174,8 @@ export function ChatSidebar({
                     <span
                       className={`inline-block mt-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full capitalize ${
                         other.role === 'admin'
-                          ? 'bg-red-50 text-red-600'
-                          : 'bg-blue-50 text-blue-600'
+                          ? 'bg-red-50 text-red-700'
+                          : 'bg-blue-50 text-blue-800'
                       }`}
                     >
                       {other.role}

--- a/frontend/components/messaging/MessagingHub.tsx
+++ b/frontend/components/messaging/MessagingHub.tsx
@@ -137,7 +137,7 @@ export function MessagingHub() {
             <div className="flex-1 flex flex-col items-center justify-center bg-neutral-50 p-8">
               <button
                 onClick={() => setShowSidebar(true)}
-                className="md:hidden mb-6 text-sm text-blue-600 font-medium hover:underline"
+                className="md:hidden mb-6 text-sm text-blue-800 font-medium hover:underline"
               >
                 Back to conversations
               </button>

--- a/frontend/components/modals/DisputeDetailModal.tsx
+++ b/frontend/components/modals/DisputeDetailModal.tsx
@@ -70,7 +70,7 @@ function buildTimeline(dispute: DashboardDispute): TimelineEvent[] {
       label: 'Dispute filed',
       date: dispute.createdAt,
       icon: <Scale size={14} />,
-      color: 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
+      color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
     },
   ];
 
@@ -236,7 +236,7 @@ export const DisputeDetailModal: React.FC<DisputeDetailModalProps> = ({
             <div className="w-9 h-9 rounded-xl bg-blue-100 dark:bg-blue-900/20 flex items-center justify-center">
               <MessageSquareText
                 size={16}
-                className="text-blue-600 dark:text-blue-400"
+                className="text-blue-800 dark:text-blue-400"
               />
             </div>
             <div>

--- a/frontend/components/modals/EvidenceUploadModal.tsx
+++ b/frontend/components/modals/EvidenceUploadModal.tsx
@@ -143,7 +143,7 @@ export const EvidenceUploadModal: React.FC<EvidenceUploadModalProps> = ({
       >
         {/* Info Banner */}
         <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/30 rounded-2xl p-4 flex items-start gap-3">
-          <Info className="text-blue-600 shrink-0 mt-0.5" size={18} />
+          <Info className="text-blue-800 shrink-0 mt-0.5" size={18} />
           <p className="text-sm text-blue-900 dark:text-blue-100">
             Upload photos, receipts, or documents that support your case. All
             parties will be able to view submitted evidence.

--- a/frontend/components/properties/PropertySummaryCard.tsx
+++ b/frontend/components/properties/PropertySummaryCard.tsx
@@ -93,14 +93,14 @@ export default function PropertySummaryCard({
       {/* Content */}
       <div className="p-4">
         {/* Price */}
-        <p className="text-blue-600 font-bold text-xl mb-2">
+        <p className="text-blue-800 font-bold text-xl mb-2">
           {property.price}{' '}
           <span className="text-gray-500 font-normal text-sm">/yr</span>
         </p>
 
         {/* Title */}
         <Link href={`/properties/${property.id}`}>
-          <h3 className="font-bold text-gray-900 mb-2 text-base hover:text-blue-600 transition">
+          <h3 className="font-bold text-gray-900 mb-2 text-base hover:text-blue-800 transition">
             {property.title}
           </h3>
         </Link>

--- a/frontend/components/sections/StepsCard.tsx
+++ b/frontend/components/sections/StepsCard.tsx
@@ -8,7 +8,7 @@ const steps = [
     description: 'Find verified listings and book smart-lock tours instantly.',
     icon: <MapPin className="w-8 h-8" strokeWidth={1.5} />,
     iconBg: 'bg-blue-50',
-    iconColor: 'text-blue-600',
+    iconColor: 'text-blue-800',
   },
   {
     id: 2,
@@ -16,7 +16,7 @@ const steps = [
     description: 'Execute a tamper-proof lease on the blockchain in seconds.',
     icon: <FileText className="w-8 h-8" strokeWidth={1.5} />,
     iconBg: 'bg-blue-50',
-    iconColor: 'text-blue-600',
+    iconColor: 'text-blue-800',
   },
   {
     id: 3,
@@ -24,7 +24,7 @@ const steps = [
     description: 'Get keys instantly and earn rewards for on-time payments.',
     icon: <Home className="w-8 h-8" strokeWidth={1.5} />,
     iconBg: 'bg-blue-50',
-    iconColor: 'text-blue-600',
+    iconColor: 'text-blue-800',
   },
 ];
 


### PR DESCRIPTION
closes #1263 
closes #1274
closes #1275 
closes #1277 

  WCAG AA Contrast Audit — Changes Made
  
  Design Token Fix (frontend/app/globals.css)
  
  neutral-400 and slate-400 were darkened from #8e897c (3.49:1 on
  white — fails) to #6b6760:
  
  ┌──────────────────────┬───────────┬──────────────────────────┐
  │ Surface              │ Before    │ After                    │
  ├──────────────────────┼───────────┼──────────────────────────┤
  │ on white             │ 3.49:1 ❌ │ 5.62:1 ✅                │
  ├──────────────────────┼───────────┼──────────────────────────┤
  │ on neutral-50        │ 3.23:1 ❌ │ 5.20:1 ✅                │
  ├──────────────────────┼───────────┼──────────────────────────┤
  │ on neutral-100       │ 2.87:1 ❌ │ 4.63:1 ✅                │
  ├──────────────────────┼───────────┼──────────────────────────┤
  │ on ink-900 (dark bg) │ 5.53:1 ✅ │ 3.43:1 ✅ (UI/large min) │
  └──────────────────────┴───────────┴──────────────────────────┘
  
  Component Fixes — text-blue-600 → text-blue-800 on light
  backgrounds
  
  blue-600 (#b8771c) is designed for dark ink backgrounds (5.23:1
  on ink-900 ✅) but only 3.51:1 on light blue and 3.69:1 on
  white. blue-800 (#764b18) was substituted in all light-surface
  usages, achieving 6.58–7.53:1.
  
  ┌─────────────────────────┬────────────────────────────────────
  ─────────────┐
  │ File                    │ Fix
                                               │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ LeaseDetailsModal.tsx   │ Negotiate button text-blue-600 →
  text-blue-800  │
  │                         │ on bg-blue-50
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ NegotiationSidebar.tsx  │ Tabs, counter-offer badge, proposal
  form cancel │
  │                         │ btn, hover icon
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ MessagingHub.tsx        │ "Back to conversations" link text
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ ChatSidebar.tsx         │ Active room name, role badge text
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ PropertySummaryCard.tsx │ Price display, title hover color
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ DisputeDetailModal.tsx  │ Status badge config, comments icon
  on           │
  │                         │ bg-blue-100
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ EvidenceUploadModal.tsx │ Info box icon on bg-blue-50
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ StepsCard.tsx           │ All three step icons on bg-blue-50
  │
  ├─────────────────────────┼────────────────────────────────────
  ─────────────┤
  │ FileIcon.tsx            │ Word document icon default color
  │
  └─────────────────────────┴────────────────────────────────────
  ─────────────┘
  
  Items confirmed already compliant (no changes needed)
  
  - Primary text (cream #f7f4ec on all ink surfaces):
  12.88–18.12:1 ✅
  - Secondary text (cream-dim #b9b3a4 on ink): 7.88–9.23:1 ✅  
  - Focus ring (brass-400 #e0a84a on ink-900): 9.07:1 ✅
  - Brand button hover state (white on brand-blue-dark): 5.27:1
  - All brass accent text on dark surfaces: 5.23–11.33:1 ✅
  
  CI results: 972 tests passed · format check clean · build
  clean.