### PR TITLE
fix: image cache, localStorage cache, N+1 query, and as any cleanup

### DIFF
--- a/backend/src/common/errors/error-factory.ts
+++ b/backend/src/common/errors/error-factory.ts
@@ -104,7 +104,8 @@ export class ErrorFactory {
       const message =
         typeof response === 'string'
           ? response
-          : (response as any).message || error.message;
+          : ((response as Record<string, unknown>).message as string) ||
+            error.message;
 
       return new BaseAppError(
         this.httpStatusToErrorCode(status),

--- a/backend/src/common/filters/all-exceptions.filter.ts
+++ b/backend/src/common/filters/all-exceptions.filter.ts
@@ -14,6 +14,19 @@ import { ErrorCode } from '../errors/error-codes';
 import { RateLimitError } from '../errors/domain-errors';
 import { ErrorResponseDto } from '../dto/error-response.dto';
 
+/** Express Request extended with fields added by NestJS/Passport middleware. */
+interface AuthenticatedRequest extends Request {
+  requestId?: string;
+  user?: { id: string };
+}
+
+/** Shape of a NestJS ValidationPipe exception response body. */
+interface ValidationExceptionResponse {
+  message: string | string[];
+  error?: string;
+  statusCode?: number;
+}
+
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
   private readonly logger = new Logger(AllExceptionsFilter.name);
@@ -21,18 +34,18 @@ export class AllExceptionsFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
-    const request = ctx.getRequest<Request>();
+    const request = ctx.getRequest<AuthenticatedRequest>();
 
     const { status, body } = this.resolve(exception, request);
 
     // Log error with request context
     const requestId =
-      (request as any).requestId || request.headers['x-request-id'];
+      request.requestId ?? (request.headers['x-request-id'] as string);
     const logContext = {
       requestId,
       path: request.url,
       method: request.method,
-      userId: (request as any).user?.id,
+      userId: request.user?.id,
       statusCode: status,
     };
 
@@ -46,9 +59,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       // Report to Sentry if it's a server error
       Sentry.captureException(exception, {
         extra: logContext,
-        user: (request as any).user
-          ? { id: (request as any).user.id }
-          : undefined,
+        user: request.user ? { id: request.user.id } : undefined,
       });
     } else {
       this.logger.warn(
@@ -61,13 +72,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
   private resolve(
     exception: unknown,
-    request: Request,
+    request: AuthenticatedRequest,
   ): {
     status: number;
     body: ErrorResponseDto;
   } {
     const requestId =
-      (request as any).requestId || request.headers['x-request-id'];
+      request.requestId ?? (request.headers['x-request-id'] as string);
     const path = request.url;
     const timestamp = new Date().toISOString();
 
@@ -128,7 +139,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         status === (HttpStatus.BAD_REQUEST as number) &&
         typeof exceptionResponse === 'object'
       ) {
-        const res = exceptionResponse as any;
+        const res = exceptionResponse as ValidationExceptionResponse;
         if (Array.isArray(res.message)) {
           return {
             status,
@@ -147,7 +158,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         typeof exceptionResponse === 'object'
           ? ({
               ...baseResponse,
-              ...(exceptionResponse as any),
+              ...(exceptionResponse as Record<string, unknown>),
             } as ErrorResponseDto)
           : ({
               ...baseResponse,

--- a/backend/src/common/filters/throttler-exception.filter.ts
+++ b/backend/src/common/filters/throttler-exception.filter.ts
@@ -19,7 +19,8 @@ export class ThrottlerExceptionFilter implements ExceptionFilter {
       const message =
         typeof exceptionResponse === 'string'
           ? exceptionResponse
-          : (exceptionResponse as any).message || 'Too Many Requests';
+          : ((exceptionResponse as Record<string, unknown>).message as string) ||
+            'Too Many Requests';
 
       response.status(status).json({
         statusCode: status,

--- a/backend/src/common/logger/logging.decorator.ts
+++ b/backend/src/common/logger/logging.decorator.ts
@@ -1,21 +1,28 @@
 import { LoggerService, LogContext } from './logger.service';
 
+/** Minimal interface covering both NestJS and custom logger shapes. */
+interface LoggerLike {
+  info?: (message: string, metadata: Record<string, unknown>) => void;
+  log?: (message: string, metadata: Record<string, unknown>) => void;
+  error: (message: string, error: unknown, metadata?: Record<string, unknown>) => void;
+}
+
 export function Logging(contextInfo: Partial<LogContext> = {}) {
   return function (
-    target: any,
+    target: { constructor: { name: string } },
     propertyKey: string,
     descriptor: PropertyDescriptor,
   ) {
-    const originalMethod = descriptor.value;
-    descriptor.value = async function (...args: any[]) {
-      const logger: LoggerService = this.logger || new LoggerService();
+    const originalMethod = descriptor.value as (...args: unknown[]) => Promise<unknown>;
+    descriptor.value = async function (this: { logger?: LoggerLike }, ...args: unknown[]) {
+      const logger: LoggerLike = this.logger ?? new LoggerService();
       const logInfo = (message: string, metadata: Record<string, unknown>) => {
-        if (typeof (logger as any).info === 'function') {
-          (logger as any).info(message, metadata);
+        if (typeof logger.info === 'function') {
+          logger.info(message, metadata);
           return;
         }
-        if (typeof (logger as any).log === 'function') {
-          (logger as any).log(message, metadata);
+        if (typeof logger.log === 'function') {
+          logger.log(message, metadata);
         }
       };
       const method = propertyKey;

--- a/backend/src/common/middleware/compression.middleware.ts
+++ b/backend/src/common/middleware/compression.middleware.ts
@@ -19,7 +19,7 @@ export class CompressionMiddleware implements NestMiddleware {
 
     const originalEnd = res.end.bind(res);
 
-    (res as any).end = (
+    (res as unknown as { end: typeof originalEnd }).end = (
       chunk?: Buffer | string,
       encodingOrCb?: BufferEncoding | (() => void),
       cb?: () => void,

--- a/backend/src/common/middleware/request-id.middleware.ts
+++ b/backend/src/common/middleware/request-id.middleware.ts
@@ -2,12 +2,17 @@ import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 
+/** Express Request extended with the requestId set by this middleware. */
+interface RequestWithId extends Request {
+  requestId?: string;
+}
+
 @Injectable()
 export class RequestIdMiddleware implements NestMiddleware {
-  use(req: Request, res: Response, next: NextFunction) {
+  use(req: RequestWithId, res: Response, next: NextFunction) {
     const requestId = (req.headers['x-request-id'] as string) || randomUUID();
 
-    (req as any).requestId = requestId;
+    req.requestId = requestId;
     res.setHeader('x-request-id', requestId);
 
     next();

--- a/backend/src/common/middleware/threat-detection.middleware.ts
+++ b/backend/src/common/middleware/threat-detection.middleware.ts
@@ -2,6 +2,11 @@ import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { ThreatDetectionService } from '../../modules/security/threat-detection.service';
 
+/** Express Request extended with the user object populated by Passport/JWT. */
+interface AuthenticatedRequest extends Request {
+  user?: { id: string };
+}
+
 /**
  * Middleware that runs every inbound request through the threat detection engine.
  * Non-blocking: failures are logged and the request is allowed through.
@@ -12,9 +17,9 @@ export class ThreatDetectionMiddleware implements NestMiddleware {
 
   constructor(private readonly threatDetection: ThreatDetectionService) {}
 
-  async use(req: Request, _res: Response, next: NextFunction): Promise<void> {
+  async use(req: AuthenticatedRequest, _res: Response, next: NextFunction): Promise<void> {
     try {
-      const userId = (req as any).user?.id as string | undefined;
+      const userId = req.user?.id;
       const decision = await this.threatDetection.analyzeRequest(req, userId);
 
       if (decision === 'block') {

--- a/backend/src/modules/agreements/agreements.service.ts
+++ b/backend/src/modules/agreements/agreements.service.ts
@@ -311,7 +311,11 @@ export class AgreementsService {
   }
 
   async getPayments(id: string) {
-    return await this.paymentRepository.find({ where: { agreementId: id } });
+    return await this.paymentRepository.find({
+      where: { agreementId: id },
+      relations: ['user', 'paymentMethodRelation'],
+      order: { createdAt: 'DESC' },
+    });
   }
 
   /**

--- a/backend/src/modules/properties/availability.controller.ts
+++ b/backend/src/modules/properties/availability.controller.ts
@@ -23,6 +23,11 @@ import { BlockDatesDto } from './dto/block-dates.dto';
 import { SetPriceDto } from './dto/set-price.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
+/** Express Request extended with the user object populated by Passport/JWT. */
+interface AuthenticatedRequest extends Request {
+  user: { id: string };
+}
+
 @ApiTags('Property Availability')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -50,12 +55,12 @@ export class AvailabilityController {
   async updateAvailability(
     @Param('propertyId') propertyId: string,
     @Body() dto: UpdateAvailabilityDto,
-    @Req() req: Request,
+    @Req() req: AuthenticatedRequest,
   ) {
     return this.availabilityService.updateAvailability(
       propertyId,
       dto,
-      (req.user as any).id,
+      req.user.id,
     );
   }
 
@@ -65,13 +70,9 @@ export class AvailabilityController {
   async blockDates(
     @Param('propertyId') propertyId: string,
     @Body() dto: BlockDatesDto,
-    @Req() req: Request,
+    @Req() req: AuthenticatedRequest,
   ) {
-    await this.availabilityService.blockDates(
-      propertyId,
-      dto,
-      (req.user as any).id,
-    );
+    await this.availabilityService.blockDates(propertyId, dto, req.user.id);
     return { success: true };
   }
 
@@ -81,13 +82,9 @@ export class AvailabilityController {
   async unblockDates(
     @Param('propertyId') propertyId: string,
     @Body() dto: BlockDatesDto,
-    @Req() req: Request,
+    @Req() req: AuthenticatedRequest,
   ) {
-    await this.availabilityService.unblockDates(
-      propertyId,
-      dto,
-      (req.user as any).id,
-    );
+    await this.availabilityService.unblockDates(propertyId, dto, req.user.id);
     return { success: true };
   }
 
@@ -97,12 +94,8 @@ export class AvailabilityController {
   async setPrice(
     @Param('propertyId') propertyId: string,
     @Body() dto: SetPriceDto,
-    @Req() req: Request,
+    @Req() req: AuthenticatedRequest,
   ) {
-    return this.availabilityService.setPrice(
-      propertyId,
-      dto,
-      (req.user as any).id,
-    );
+    return this.availabilityService.setPrice(propertyId, dto, req.user.id);
   }
 }

--- a/backend/src/modules/storage/image-processing.service.ts
+++ b/backend/src/modules/storage/image-processing.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import * as crypto from 'crypto';
 import * as sharp from 'sharp';
 
 export interface ImageVariant {
@@ -15,9 +16,111 @@ export interface ProcessImageResult {
   webp: ImageVariant;
 }
 
+/** Metrics snapshot returned by getCacheMetrics(). */
+export interface ImageCacheMetrics {
+  hits: number;
+  misses: number;
+  size: number;
+  maxSize: number;
+}
+
+/**
+ * Simple LRU node used by the in-process variant cache.
+ */
+interface LruNode {
+  hash: string;
+  result: ProcessImageResult;
+  prev: LruNode | null;
+  next: LruNode | null;
+}
+
+/**
+ * In-process LRU cache keyed by SHA-256 hash of the raw image buffer.
+ * Avoids re-running sharp transforms for duplicate uploads within the
+ * same process lifetime (e.g. retried multipart requests or reused assets).
+ *
+ * The default capacity of 128 entries fits comfortably within typical Node.js
+ * heap budgets while still covering burst duplicate-upload scenarios.
+ */
+class ImageVariantLruCache {
+  private readonly map = new Map<string, LruNode>();
+  private head: LruNode | null = null; // most-recently used
+  private tail: LruNode | null = null; // least-recently used
+  private hits = 0;
+  private misses = 0;
+
+  constructor(private readonly maxSize: number) {}
+
+  get(hash: string): ProcessImageResult | undefined {
+    const node = this.map.get(hash);
+    if (!node) {
+      this.misses++;
+      return undefined;
+    }
+    this.hits++;
+    this.moveToHead(node);
+    return node.result;
+  }
+
+  set(hash: string, result: ProcessImageResult): void {
+    if (this.map.has(hash)) {
+      const node = this.map.get(hash)!;
+      node.result = result;
+      this.moveToHead(node);
+      return;
+    }
+
+    const node: LruNode = { hash, result, prev: null, next: this.head };
+    if (this.head) this.head.prev = node;
+    this.head = node;
+    if (!this.tail) this.tail = node;
+    this.map.set(hash, node);
+
+    if (this.map.size > this.maxSize) {
+      this.evictTail();
+    }
+  }
+
+  getMetrics(): ImageCacheMetrics {
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      size: this.map.size,
+      maxSize: this.maxSize,
+    };
+  }
+
+  private moveToHead(node: LruNode): void {
+    if (node === this.head) return;
+    if (node.prev) node.prev.next = node.next;
+    if (node.next) node.next.prev = node.prev;
+    if (node === this.tail) this.tail = node.prev;
+    node.prev = null;
+    node.next = this.head;
+    if (this.head) this.head.prev = node;
+    this.head = node;
+  }
+
+  private evictTail(): void {
+    if (!this.tail) return;
+    this.map.delete(this.tail.hash);
+    if (this.tail.prev) this.tail.prev.next = null;
+    this.tail = this.tail.prev;
+    if (!this.tail) this.head = null;
+  }
+}
+
 @Injectable()
 export class ImageProcessingService {
   private readonly logger = new Logger(ImageProcessingService.name);
+
+  /**
+   * LRU cache: SHA-256(buffer) → processed variants.
+   * Capacity: 128 entries (override via IMAGE_CACHE_MAX_SIZE env var).
+   */
+  private readonly cache = new ImageVariantLruCache(
+    parseInt(process.env.IMAGE_CACHE_MAX_SIZE ?? '128', 10),
+  );
 
   async processImage(
     buffer: Buffer,
@@ -32,6 +135,24 @@ export class ImageProcessingService {
       throw new Error('Not an image file');
     }
 
+    // --- Cache lookup by content hash -----------------------------------
+    // The cache key is derived from the raw pixel data, not the filename,
+    // so duplicate uploads (same bytes, different keys) get a cache hit.
+    const hash = crypto.createHash('sha256').update(buffer).digest('hex');
+
+    const cached = this.cache.get(hash);
+    if (cached) {
+      this.logger.debug(`Image cache hit for hash ${hash.slice(0, 12)}…`);
+      // Re-stamp keys for the new upload path so S3 targets are correct.
+      return {
+        original: { ...cached.original, key: originalKey },
+        thumbnail: { ...cached.thumbnail, key: `${baseKey}_thumb.jpg` },
+        medium: { ...cached.medium, key: `${baseKey}_medium.jpg` },
+        webp: { ...cached.webp, key: `${baseKey}.webp` },
+      };
+    }
+
+    // --- Cache miss: run sharp transforms --------------------------------
     const [thumbnailBuffer, mediumBuffer, webpBuffer] = await Promise.all([
       // 150x150 thumbnail
       sharp(buffer)
@@ -51,10 +172,10 @@ export class ImageProcessingService {
     ]);
 
     this.logger.log(
-      `Processed image: thumbnail=${thumbnailBuffer.length}B, medium=${mediumBuffer.length}B, webp=${webpBuffer.length}B`,
+      `Processed image (cache miss): thumbnail=${thumbnailBuffer.length}B, medium=${mediumBuffer.length}B, webp=${webpBuffer.length}B`,
     );
 
-    return {
+    const result: ProcessImageResult = {
       original: {
         key: originalKey,
         buffer,
@@ -80,6 +201,9 @@ export class ImageProcessingService {
         size: webpBuffer.length,
       },
     };
+
+    this.cache.set(hash, result);
+    return result;
   }
 
   async getImageMetadata(
@@ -91,5 +215,10 @@ export class ImageProcessingService {
       height: metadata.height ?? 0,
       format: metadata.format ?? 'unknown',
     };
+  }
+
+  /** Returns cache hit/miss metrics for observability endpoints. */
+  getCacheMetrics(): ImageCacheMetrics {
+    return this.cache.getMetrics();
   }
 }

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -53,6 +53,24 @@ function getApiBaseUrl(): string {
   );
 }
 
+/**
+ * Module-level token cache so getAuthToken() does not hit localStorage on
+ * every HTTP request. Populated by setApiClientToken() which is called by
+ * the authStore whenever tokens change (login, refresh, logout).
+ *
+ * Falls back to localStorage on the first call (e.g. page reload before the
+ * store has had a chance to call setApiClientToken).
+ */
+let _cachedToken: string | null | undefined = undefined;
+
+/**
+ * Updates the api-client's in-memory token cache.
+ * Call this from the authStore on login, token refresh, and logout.
+ */
+export function setApiClientToken(token: string | null): void {
+  _cachedToken = token;
+}
+
 class ApiClient {
   private baseURL: string;
   private defaultHeaders: Record<string, string>;
@@ -67,10 +85,16 @@ class ApiClient {
   private getAuthToken(): string | null {
     if (typeof window === 'undefined') return null;
 
-    return (
+    // Use in-memory cache if already populated (avoids synchronous localStorage
+    // I/O on every request — localStorage reads block the main thread).
+    if (_cachedToken !== undefined) return _cachedToken;
+
+    // Cold-start fallback: read from localStorage once and cache the result.
+    const token =
       localStorage.getItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN) ||
-      localStorage.getItem(AUTH_STORAGE_KEYS.LEGACY_ACCESS_TOKEN)
-    );
+      localStorage.getItem(AUTH_STORAGE_KEYS.LEGACY_ACCESS_TOKEN);
+    _cachedToken = token;
+    return token;
   }
 
   private async parseResponse<T>(response: Response): Promise<T> {
@@ -87,6 +111,7 @@ class ApiClient {
 
     localStorage.removeItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN);
     localStorage.removeItem(AUTH_STORAGE_KEYS.LEGACY_ACCESS_TOKEN);
+    _cachedToken = null;
   }
 
   private async request<T>(

--- a/frontend/store/authStore.ts
+++ b/frontend/store/authStore.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { AppError } from '@/lib/errors';
-import { apiClient } from '@/lib/api-client';
+import { apiClient, setApiClientToken } from '@/lib/api-client';
 import { create } from 'zustand';
 import { withMiddleware } from './middleware';
 
@@ -123,7 +123,30 @@ function removeAuthCookie() {
 
 // --- Storage Helpers ---------------------------------------------------------
 
+/**
+ * Module-level closure cache for localStorage auth values.
+ * Populated once by readStoredAuth() / persistAuth(), cleared by clearStorage().
+ * Avoids synchronous localStorage I/O on every store access and every HTTP
+ * request (api-client reads the token on each fetch).
+ */
+let _cache: (Omit<AuthState, 'loading'> & { hydrated: boolean }) | null = null;
+
+function invalidateCache(): void {
+  _cache = null;
+}
+
 function readStoredAuth(): Omit<AuthState, 'loading'> {
+  // Return in-memory cache when already hydrated (avoids repeated localStorage reads)
+  if (_cache?.hydrated) {
+    return {
+      user: _cache.user,
+      accessToken: _cache.accessToken,
+      refreshToken: _cache.refreshToken,
+      isAuthenticated: _cache.isAuthenticated,
+      walletAddress: _cache.walletAddress,
+    };
+  }
+
   if (typeof window === 'undefined') {
     return {
       user: null,
@@ -147,13 +170,15 @@ function readStoredAuth(): Omit<AuthState, 'loading'> {
     );
 
     if (storedAccessToken && storedUser) {
-      return {
+      const result: Omit<AuthState, 'loading'> = {
         user: JSON.parse(storedUser) as User,
         accessToken: storedAccessToken,
         refreshToken: storedRefreshToken,
         isAuthenticated: true,
         walletAddress: storedWalletAddress,
       };
+      _cache = { ...result, hydrated: true };
+      return result;
     }
   } catch {
     localStorage.removeItem(AUTH_STORAGE_KEYS.ACCESS_TOKEN);
@@ -163,13 +188,15 @@ function readStoredAuth(): Omit<AuthState, 'loading'> {
     removeAuthCookie();
   }
 
-  return {
+  const empty: Omit<AuthState, 'loading'> = {
     user: null,
     accessToken: null,
     refreshToken: null,
     isAuthenticated: false,
     walletAddress: null,
   };
+  _cache = { ...empty, hydrated: true };
+  return empty;
 }
 
 function clearStorage() {
@@ -180,6 +207,7 @@ function clearStorage() {
   localStorage.removeItem(AUTH_STORAGE_KEYS.USER);
   localStorage.removeItem(AUTH_STORAGE_KEYS.WALLET_ADDRESS);
   removeAuthCookie();
+  invalidateCache();
 }
 
 function persistAuth(
@@ -197,6 +225,16 @@ function persistAuth(
 
   localStorage.setItem(AUTH_STORAGE_KEYS.USER, JSON.stringify(user));
   setAuthCookie(accessToken);
+
+  // Keep the closure cache in sync so subsequent reads skip localStorage
+  _cache = {
+    user,
+    accessToken,
+    refreshToken,
+    isAuthenticated: true,
+    walletAddress: _cache?.walletAddress ?? null,
+    hydrated: true,
+  };
 }
 
 function normalizeUser(user: AuthApiUser): User {
@@ -257,6 +295,7 @@ export const useAuthStore = create<AuthStore>()(
         user: User,
       ) => {
         persistAuth(accessToken, refreshToken, user);
+        setApiClientToken(accessToken);
         set((state) => {
           state.user = user;
           state.accessToken = accessToken;
@@ -271,6 +310,11 @@ export const useAuthStore = create<AuthStore>()(
           localStorage.setItem(AUTH_STORAGE_KEYS.WALLET_ADDRESS, address);
         } else {
           localStorage.removeItem(AUTH_STORAGE_KEYS.WALLET_ADDRESS);
+        }
+
+        // Keep closure cache in sync
+        if (_cache) {
+          _cache = { ..._cache, walletAddress: address };
         }
 
         set((state) => {
@@ -429,6 +473,7 @@ export const useAuthStore = create<AuthStore>()(
         }
 
         clearStorage();
+        setApiClientToken(null);
 
         set((state) => {
           state.user = null;


### PR DESCRIPTION
# fix: image cache, localStorage cache, N+1 query, and `as any` cleanup

## Summary

This PR closes four performance and type-safety issues. It adds hash-based
caching to image processing, eliminates redundant localStorage I/O in the
auth store and API client, fixes an N+1 query in agreement payment listing,
and removes all `as any` type assertions from production source files.

---

## Issues Closed

Closes #1427
Closes #1423
Closes #1419
Closes #1417

---

## Changes

### #1427 — Image Processing Not Cached

**Problem:** `ImageProcessingService.processImage()` ran all three `sharp`
transforms (thumbnail, medium, WebP) on every upload, including duplicate
uploads of the same file.

**Fix:**
- Added a SHA-256-keyed **LRU cache** inside `ImageProcessingService`.
- On each call the raw buffer is hashed (`crypto.createHash('sha256')`).
  A cache hit returns the stored variant buffers immediately, skipping all
  `sharp` work.
- Cache capacity defaults to 128 entries and is overridable via the
  `IMAGE_CACHE_MAX_SIZE` environment variable.
- On a cache hit, variant keys are re-stamped with the new upload path so
  S3 targets remain correct even when the same image is stored under a
  different filename.
- `getCacheMetrics()` exposes `hits`, `misses`, `size`, and `maxSize` for
  observability dashboards.
- `ImageCacheMetrics` interface exported for consumers.

**Files changed:**
- `backend/src/modules/storage/image-processing.service.ts`

---

### #1423 — localStorage I/O Not Cached in AuthStore

**Problem:** `readStoredAuth()` called `localStorage.getItem` four times on
every `hydrate()` invocation. `ApiClient.getAuthToken()` hit localStorage on
every HTTP request. Both are synchronous operations that block the main
thread.

**Fix — authStore:**
- Added a **module-level closure cache** (`_cache`) populated by
  `readStoredAuth()` on first call.
- Subsequent calls return the in-memory value without touching localStorage.
- `persistAuth()` writes to localStorage and updates the cache atomically.
- `clearStorage()` invalidates the cache on logout.
- `setWalletAddress()` updates the `walletAddress` field in the cache.
- Imported and called `setApiClientToken()` on `setTokens()` and `logout()`
  to keep the api-client cache in sync.

**Fix — api-client:**
- Added `_cachedToken` module variable; `getAuthToken()` returns the cached
  value on every request after the first cold-start read.
- Exported `setApiClientToken(token)` so the auth store can push token
  changes without requiring a localStorage read.
- `clearAuthAndRedirectIfNeeded()` sets `_cachedToken = null` on 401 so
  stale tokens are not reused.

**Files changed:**
- `frontend/store/authStore.ts`
- `frontend/lib/api-client.ts`

---

### #1419 — N+1 Query Problem in Payment Listing

**Problem:** `AgreementsService.getPayments()` used a plain
`paymentRepository.find({ where: { agreementId: id } })` with no `relations`
option. Each call to access `payment.user` or `payment.paymentMethodRelation`
triggered a separate lazy-load query — 100 payments produced 100+ queries.

**Fix:**
- Added `relations: ['user', 'paymentMethodRelation']` so TypeORM emits a
  single JOIN query that fetches all related data up front.
- Added `order: { createdAt: 'DESC' }` for consistent result ordering.

**Files changed:**
- `backend/src/modules/agreements/agreements.service.ts`

---

### #1417 — Remove All Type Safety Bypasses (`as any`)

**Problem:** 20+ `as any` assertions in production source files bypassed
TypeScript's type checker, hiding potential runtime errors and making
refactoring unsafe.

**Fix:** Replaced every `as any` in production (non-spec) files with proper
typed interfaces or narrower casts:

| File | Change |
|------|--------|
| `all-exceptions.filter.ts` | Added `AuthenticatedRequest` (typed `requestId` + `user`) and `ValidationExceptionResponse` interfaces — removed 7 casts |
| `availability.controller.ts` | Added local `AuthenticatedRequest` interface — removed 4 casts |
| `throttler-exception.filter.ts` | Replaced with `Record<string, unknown>` cast |
| `error-factory.ts` | Replaced with `Record<string, unknown>` cast |
| `request-id.middleware.ts` | Added `RequestWithId` interface extending `Request` |
| `threat-detection.middleware.ts` | Added `AuthenticatedRequest` interface |
| `compression.middleware.ts` | Replaced with `as unknown as { end: ... }` typed override |
| `logging.decorator.ts` | Added `LoggerLike` interface — removed 4 casts; tightened decorator parameter types |

**Files changed:**
- `backend/src/common/filters/all-exceptions.filter.ts`
- `backend/src/modules/properties/availability.controller.ts`
- `backend/src/common/filters/throttler-exception.filter.ts`
- `backend/src/common/errors/error-factory.ts`
- `backend/src/common/middleware/request-id.middleware.ts`
- `backend/src/common/middleware/threat-detection.middleware.ts`
- `backend/src/common/middleware/compression.middleware.ts`
- `backend/src/common/logger/logging.decorator.ts`

---

## Testing

- All 12 changed files pass diagnostics with no errors or warnings.
- No new `as any` assertions introduced in any changed file.

## Notes

- `IMAGE_CACHE_MAX_SIZE` can be set in the environment to tune the image
  variant cache capacity (default: 128). Set lower in memory-constrained
  deployments.
- The LRU cache is in-process only — it does not persist across restarts or
  share state across multiple instances. In a multi-replica deployment,
  each instance maintains its own cache (still beneficial for within-instance
  duplicate uploads and retries).
