### PR TITLE
fix/1424-xss-error-display-sanitization

### DIFF
--- a/frontend/__tests__/components/error/ErrorFallback.test.tsx
+++ b/frontend/__tests__/components/error/ErrorFallback.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ErrorFallback from '@/components/error/ErrorFallback';
+
+// Regression coverage for issue #1424 ("XSS Vulnerability in Error Display
+// Components"): the dev-only error detail (`error.message`) is rendered via
+// plain JSX text interpolation ({error.message}) inside a <pre>, which React
+// auto-escapes — never dangerouslySetInnerHTML or a raw DOM API. These tests
+// lock that in so a future refactor can't silently reintroduce an actual
+// injection path.
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('ErrorFallback', () => {
+  it('renders the description as plain text', () => {
+    render(<ErrorFallback description="A safe description" />);
+    expect(screen.getByText('A safe description')).toBeDefined();
+  });
+
+  it('renders a malicious error message as inert text in development mode', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const payload = '<img src=x onerror=alert(1)>';
+    const { container } = render(
+      <ErrorFallback error={new Error(payload)} />,
+    );
+
+    expect(screen.getByText(payload)).toBeDefined();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders a script-tag payload as inert text, not an executable script', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const payload = '<script>alert(document.cookie)</script>';
+    const { container } = render(
+      <ErrorFallback error={new Error(payload)} />,
+    );
+
+    expect(screen.getByText(payload)).toBeDefined();
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('does not render error details outside development mode', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const payload = '<img src=x onerror=alert(1)>';
+    render(<ErrorFallback error={new Error(payload)} />);
+
+    expect(screen.queryByText(payload)).toBeNull();
+  });
+});

--- a/frontend/__tests__/components/error/ErrorToast.test.tsx
+++ b/frontend/__tests__/components/error/ErrorToast.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ErrorToast } from '@/components/error/ErrorToast';
+import type { GlobalError } from '@/store/errorStore';
+
+// Regression coverage for issue #1424 ("XSS Vulnerability in Error Display
+// Components"): error.message is rendered via plain JSX text interpolation
+// ({error.message}), which React auto-escapes — it is never passed through
+// dangerouslySetInnerHTML or a raw DOM API. These tests lock that in so a
+// future refactor can't silently reintroduce an actual injection path.
+
+function makeError(overrides: Partial<GlobalError> = {}): GlobalError {
+  return {
+    id: 'err-1',
+    message: 'Something went wrong',
+    category: 'unknown',
+    severity: 'error',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('ErrorToast', () => {
+  it('renders a plain error message as text', () => {
+    render(<ErrorToast error={makeError()} onRemove={vi.fn()} />);
+    expect(screen.getByText('Something went wrong')).toBeDefined();
+  });
+
+  it('renders a malicious error message as inert text, not markup', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const { container } = render(
+      <ErrorToast error={makeError({ message: payload })} onRemove={vi.fn()} />,
+    );
+
+    // The payload must appear as literal text content...
+    expect(screen.getByText(payload)).toBeDefined();
+    // ...and must never have been parsed into a real <img> element.
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders a script-tag payload as inert text, not an executable script', () => {
+    const payload = '<script>alert(document.cookie)</script>';
+    const { container } = render(
+      <ErrorToast error={makeError({ message: payload })} onRemove={vi.fn()} />,
+    );
+
+    expect(screen.getByText(payload)).toBeDefined();
+    expect(container.querySelector('script')).toBeNull();
+  });
+});

--- a/frontend/__tests__/components/forms/FormErrorAlert.test.tsx
+++ b/frontend/__tests__/components/forms/FormErrorAlert.test.tsx
@@ -57,7 +57,31 @@ describe('FormErrorAlert', () => {
   });
 
   it('renders special characters in the message safely', () => {
-    render(<FormErrorAlert message="Error: invalid <input> & value" />);
+    const { container } = render(
+      <FormErrorAlert message="Error: invalid <input> & value" />,
+    );
     expect(screen.getByText('Error: invalid <input> & value')).toBeDefined();
+    // The message must appear as literal text, not be parsed as markup.
+    expect(container.querySelector('input')).toBeNull();
+  });
+
+  // Regression coverage for issue #1424 ("XSS Vulnerability in Error Display
+  // Components"): `message` is rendered via plain JSX text interpolation
+  // ({message}), which React auto-escapes — never dangerouslySetInnerHTML or
+  // a raw DOM API. These lock that in against a future regression.
+  it('renders a malicious message as inert text, not markup', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const { container } = render(<FormErrorAlert message={payload} />);
+
+    expect(screen.getByText(payload)).toBeDefined();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders a script-tag payload as inert text, not an executable script', () => {
+    const payload = '<script>alert(document.cookie)</script>';
+    const { container } = render(<FormErrorAlert message={payload} />);
+
+    expect(screen.getByText(payload)).toBeDefined();
+    expect(container.querySelector('script')).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #1371 
Closes #1426 
Closes #1425 
Closes #1424 

# Summary


What I found: A GIN tsvector index (search_vector, migration 1783000000000-AddPropertySearchIndexes) already existed and was already used by SearchService. But the main property listing endpoint's search — PropertyQueryBuilder.applySearchFilter() — still used LOWER(title) LIKE LOWER('%...%'), which can't use any index (leading wildcard forces a sequential scan). Several other paths (SearchService's city/state/address ILIKE filters, and its autocomplete executeSuggest()) were also unindexed substring/prefix matches.

Changes:

[1900600000000-AddPropertyTrigramSearchIndexes.ts](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/backend/src/migrations/1900600000000-AddPropertyTrigramSearchIndexes.ts) — new migration adding pg_trgm extension + GIN trigram indexes on title, address, city, state. Trigram indexes are the correct complement to tsvector — they accelerate substring/prefix LIKE/ILIKE matches that word-based full-text search can't cover. This alone speeds up SearchService's existing ILIKE filters with zero code changes, since that code already avoids the LOWER()-wrapping anti-pattern that defeats the index.
[property-query-builder.ts](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/backend/src/modules/properties/property-query-builder.ts) — applySearchFilter() now queries search_vector @@ plainto_tsquery(...) OR'd with plain ILIKE on title/address, matching the indexed pattern SearchService already used, instead of the unindexed LOWER(...) LIKE LOWER(...).
[properties.pagination.spec.ts](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/backend/src/modules/properties/__tests__/properties.pagination.spec.ts) — updated the one test that asserted the old LIKE string, to assert the new indexed query instead.
[benchmark-property-search.ts](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/backend/scripts/benchmark-property-search.ts) + db:benchmark-search npm script — runs EXPLAIN (ANALYZE, BUFFERS) for the old vs. new query side by side against the real database, reporting scan type and execution time (I didn't fabricate benchmark numbers since no DB is running this session — this gives you a real, repeatable measurement to run yourself).
[PERFORMANCE_INDEXES.md](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/backend/docs/database/PERFORMANCE_INDEXES.md) — new "Properties Full-Text & Substring Search" section documenting both index types, why each exists, the query patterns they optimize, and how to run the benchmark.
"dangerouslySetInnerHTML" across the whole frontend → zero hits) — every error-display component (ErrorToast.tsx:60, ErrorFallback.tsx:86, FormErrorAlert.tsx:15, and ~30 other call sites) renders error.message via plain JSX {expression} interpolation, which React auto-escapes by design. That's not exploitable for XSS. (Separately, ContractDetailsModal.tsx and lib/export-transactions.ts use document.write() to build PDF/print HTML without escaping — a real pattern worth hardening, but it doesn't touch error messages and isn't what #1424 describes, so per your scope choice it's out of this PR.)



[ErrorToast.test.tsx](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/frontend/__tests__/components/error/ErrorToast.test.tsx) — new, asserts <img onerror> and <script> payloads render as literal text, never as parsed DOM elements.
[ErrorFallback.test.tsx](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/frontend/__tests__/components/error/ErrorFallback.test.tsx) — new, same assertions for the dev-mode error detail <pre> block, plus confirms it's hidden entirely outside development.
[FormErrorAlert.test.tsx](vscode-webview://0opf9gl0pmbqqtcnvbgfc9g3qjhl8um6qvtublcccc33l1u1h2fi/frontend/__tests__/components/forms/FormErrorAlert.test.tsx) — extended the existing "special characters" test and added two new payload cases (<img>, <script>), each asserting no matching element was created in the DOM.


