### PR TITLE
fixed all issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -11,8 +11,9 @@ assignees: ""
 **Do NOT disclose security vulnerabilities publicly!**
 
 - Email security@chioma.dev instead
-- Or use GitHub's private vulnerability reporting
-- See SECURITY.md for responsible disclosure
+- Or use GitHub's private vulnerability reporting (Security tab → "Report a vulnerability")
+- See [SECURITY.md](../../SECURITY.md) for full scope, response timelines, and responsible
+  disclosure guidelines
 
 ## 📝 Description
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ We welcome:
 
 ---
 
+## Security
+
+If you discover a security vulnerability, **please do not open a public issue.**
+
+Report it privately through one of the channels described in [SECURITY.md](./SECURITY.md):
+
+- **GitHub private vulnerability reporting** — Security tab → "Report a vulnerability"
+- **Email** — security@chioma.dev
+
+We follow a coordinated disclosure model and aim to acknowledge reports within 48 hours. See
+[SECURITY.md](./SECURITY.md) for full details on scope, response timelines, and responsible
+disclosure.
+
+---
+
 ## You Should Know
 
 Chioma is not just a rental app.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,116 @@
+# Security Policy
+
+## Supported Versions
+
+We actively maintain and patch security vulnerabilities in the following branches:
+
+| Branch / Version | Supported            |
+| ---------------- | -------------------- |
+| `main`           | ✅ Yes               |
+| `develop`        | ✅ Yes (pre-release) |
+| Older branches   | ❌ No                |
+
+If you are running a fork or a pinned version that is no longer on a supported branch, please
+upgrade to `main` before reporting.
+
+---
+
+## Scope
+
+The following components are in scope for security reports:
+
+| Component              | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| **Smart Contracts**    | Soroban contracts in `contract/` (escrow, payments, etc.) |
+| **Backend API**        | NestJS application in `backend/`                          |
+| **Frontend**           | Next.js application in `frontend/`                        |
+| **Authentication**     | Stellar-based auth, JWT handling, KYC flows               |
+| **Payment flows**      | Rent payments, deposit escrow, agent commissions          |
+| **PII / data storage** | Encrypted fields, database access controls                |
+
+Out of scope: third-party services (Stellar network itself, anchor operators, GitHub
+infrastructure), social engineering, physical attacks.
+
+---
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.** Public disclosure
+before a fix is available puts all users at risk.
+
+### Option 1 — GitHub Private Vulnerability Reporting (preferred)
+
+Use GitHub's built-in private reporting:
+
+1. Go to the **Security** tab of this repository.
+2. Click **"Report a vulnerability"**.
+3. Fill in the details. Only maintainers can see the report.
+
+GitHub documentation:
+[Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+
+### Option 2 — Email
+
+Send a report to **security@chioma.dev** with:
+
+- A clear description of the vulnerability
+- Affected component and version/branch
+- Step-by-step reproduction instructions
+- Potential impact and severity (Low / Medium / High / Critical)
+- Any proof-of-concept code (optional but helpful)
+- Your suggested fix, if you have one
+
+PGP encryption is not required but is welcome if you need it — reach out first and we will
+exchange keys.
+
+---
+
+## What to Expect
+
+| Timeline        | Action                                                       |
+| --------------- | ------------------------------------------------------------ |
+| **Within 48 h** | Acknowledgement of your report                               |
+| **Within 7 d**  | Initial triage: confirmed, needs-info, or out-of-scope       |
+| **Within 30 d** | Patch available for confirmed High/Critical issues           |
+| **Within 90 d** | Patch available for confirmed Medium/Low issues              |
+| After patch     | Coordinated public disclosure and CVE filing (if applicable) |
+
+We will keep you updated at each stage. If you do not hear back within 48 hours, please follow
+up — your email may have been caught by spam filters.
+
+---
+
+## Responsible Disclosure
+
+We follow a **coordinated disclosure** model:
+
+- We ask that you give us a reasonable amount of time (see timelines above) to fix the issue
+  before publishing your findings.
+- We will credit you in the security advisory unless you prefer to remain anonymous.
+- We will not pursue legal action against researchers who act in good faith and follow this
+  policy.
+
+---
+
+## Bug Bounty
+
+We do not currently operate a formal bug bounty programme. We are deeply grateful for
+responsible disclosures and will credit all reporters publicly in our security advisories.
+
+---
+
+## Security Contacts
+
+| Channel                  | Address / Link                          |
+| ------------------------ | --------------------------------------- |
+| GitHub private reporting | Security tab → "Report a vulnerability" |
+| Email                    | security@chioma.dev                     |
+| Telegram (community)     | https://t.me/chiomagroup                |
+
+---
+
+## Previous Security Advisories
+
+Security advisories will be published under the
+[Security Advisories](../../security/advisories) tab of this repository after coordinated
+disclosure.


### PR DESCRIPTION
closes #1318 
closes #1322 


What was done
  
  SECURITY.md — created at repo root
  
  The file covers everything reporters (and reviewers) need:
  
  - Supported versions/branches table
  - In-scope components: Smart Contracts, Backend API, Frontend, Auth, Payments,
  PII/data
  - Two reporting channels: GitHub private vulnerability reporting (preferred)
  and security@chioma.dev email
  - Expected response timeline (48 h ack → 7 d triage → 30/90 d patch)
  - Responsible disclosure and bug bounty stance
  - Security contacts table
  
  README.md — Security section cross-linked
  
  Added a ## Security section between "Open Source First" and "You Should Know"
  with links to SECURITY.md and both reporting channels. This is exactly what
  the existing README already contained (it was already there from the context —
  the task was to ensure it points to the real file).
  
  .github/ISSUE_TEMPLATE/security.md — broken reference fixed
  
  Changed the plain-text "See SECURITY.md for responsible disclosure" to a
  proper Markdown link [SECURITY.md](../../SECURITY.md) and made the GitHub
  private reporting bullet more descriptive with the navigation path.
  
  Formatting
  
  All three files pass npx prettier --check cleanly.
  
  ──────────────────────────────────────────────────────────────────────────────
  
  One thing you'll need to do manually in the GitHub UI
  
  The issue ticket also asks to enable "Private vulnerability reporting" in
  Settings → Security & analysis → Private vulnerability reporting. This is a
  repository settings toggle that cannot be changed via files or the GitHub CLI
  without admin credentials — you'll need to flip it on in the browser. Once
  enabled, the "Report a vulnerability" button described in SECURITY.md will be
  live for reporters.