### PR TITLE
Fix/api keys persistence

### DIFF
--- a/backend/migrations/1900100000000-AddApiKeyPermissionsAndDescription.ts
+++ b/backend/migrations/1900100000000-AddApiKeyPermissionsAndDescription.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddApiKeyPermissionsAndDescription1900100000000
+    implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'api_keys',
+            new TableColumn({
+                name: 'description',
+                type: 'varchar',
+                length: '255',
+                isNullable: true,
+                default: null,
+            }),
+        );
+
+        await queryRunner.addColumn(
+            'api_keys',
+            new TableColumn({
+                name: 'permissions',
+                type: 'text',
+                isNullable: false,
+                default: "''",
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('api_keys', 'permissions');
+        await queryRunner.dropColumn('api_keys', 'description');
+    }
+}

--- a/backend/src/modules/developer/developer.controller.ts
+++ b/backend/src/modules/developer/developer.controller.ts
@@ -52,7 +52,12 @@ export class DeveloperController {
     @Req() req: { user: { id: string } },
     @Body() dto: CreateApiKeyDto,
   ) {
-    return this.developerService.createKey(req.user.id, dto.name);
+    return this.developerService.createKey(
+      req.user.id,
+      dto.name,
+      dto.description,
+      dto.permissions,
+    );
   }
 
   @Get('api-keys')
@@ -90,7 +95,9 @@ export class DeveloperController {
     return {
       id: key.id,
       name: key.name,
-      prefix: key.keyPrefix ?? 'chioma_sk_...',
+      description: key.description,
+      keyPrefix: key.keyPrefix ?? 'chioma_sk_...',
+      permissions: key.permissions || [],
       lastUsedAt: key.lastUsedAt,
       createdAt: key.createdAt,
       expiresAt: key.expiresAt,
@@ -105,7 +112,8 @@ export class DeveloperController {
   @Patch('api-keys/:id')
   @ApiOperation({
     summary: 'Update API key',
-    description: 'Update API key name and/or expiration date.',
+    description:
+      'Update API key name, description, permissions and/or expiration date.',
   })
   @ApiParam({ name: 'id', description: 'API key ID' })
   @ApiResponse({ status: 200, description: 'API key updated' })
@@ -115,14 +123,27 @@ export class DeveloperController {
     @Param('id') id: string,
     @Body() dto: UpdateApiKeyDto,
   ) {
-    const updates: { name?: string; expiresAt?: Date } = {};
+    const updates: {
+      name?: string;
+      description?: string;
+      expiresAt?: Date;
+      permissions?: string[];
+    } = {};
 
     if (dto.name) {
       updates.name = dto.name;
     }
 
+    if (dto.description !== undefined) {
+      updates.description = dto.description;
+    }
+
     if (dto.expiresAt) {
       updates.expiresAt = new Date(dto.expiresAt);
+    }
+
+    if (dto.permissions) {
+      updates.permissions = dto.permissions;
     }
 
     const key = await this.developerService.updateKey(req.user.id, id, updates);

--- a/backend/src/modules/developer/developer.service.ts
+++ b/backend/src/modules/developer/developer.service.ts
@@ -41,6 +41,8 @@ export class DeveloperService {
   async createKey(
     userId: string,
     name: string,
+    description?: string,
+    permissions?: string[],
     expiresAt?: Date,
   ): Promise<{ id: string; key: string; name: string; expiresAt: Date }> {
     const rawKey = PREFIX + generateKey();
@@ -51,8 +53,10 @@ export class DeveloperService {
     const apiKey = this.apiKeyRepo.create({
       userId,
       name,
+      description: description || null,
       keyHash,
       keyPrefix,
+      permissions: permissions || [],
       expiresAt: expirationDate,
       status: ApiKeyStatus.ACTIVE,
     });
@@ -70,7 +74,9 @@ export class DeveloperService {
     {
       id: string;
       name: string;
-      prefix: string;
+      description: string | null;
+      keyPrefix: string;
+      permissions: string[];
       lastUsedAt: Date | null;
       createdAt: Date;
       expiresAt: Date | null;
@@ -88,7 +94,9 @@ export class DeveloperService {
     return keys.map((k) => ({
       id: k.id,
       name: k.name,
-      prefix: k.keyPrefix ?? 'chioma_sk_...',
+      description: k.description,
+      keyPrefix: k.keyPrefix ?? 'chioma_sk_...',
+      permissions: k.permissions || [],
       lastUsedAt: k.lastUsedAt,
       createdAt: k.createdAt,
       expiresAt: k.expiresAt,
@@ -114,7 +122,12 @@ export class DeveloperService {
   async updateKey(
     userId: string,
     keyId: string,
-    updates: { name?: string; expiresAt?: Date },
+    updates: {
+      name?: string;
+      description?: string;
+      expiresAt?: Date;
+      permissions?: string[];
+    },
   ): Promise<ApiKey> {
     const key = await this.getKey(userId, keyId);
 
@@ -122,8 +135,16 @@ export class DeveloperService {
       key.name = updates.name;
     }
 
+    if (updates.description !== undefined) {
+      key.description = updates.description || null;
+    }
+
     if (updates.expiresAt) {
       key.expiresAt = updates.expiresAt;
+    }
+
+    if (updates.permissions) {
+      key.permissions = updates.permissions;
     }
 
     return this.apiKeyRepo.save(key);

--- a/backend/src/modules/developer/dto/create-api-key.dto.ts
+++ b/backend/src/modules/developer/dto/create-api-key.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsString,
+  MaxLength,
+  MinLength,
+  IsArray,
+  IsOptional,
+} from 'class-validator';
 
 export class CreateApiKeyDto {
   @ApiProperty({ example: 'My integration', minLength: 1, maxLength: 80 })
@@ -7,4 +13,23 @@ export class CreateApiKeyDto {
   @MinLength(1)
   @MaxLength(80)
   name: string;
+
+  @ApiProperty({
+    example: 'Integration for external service',
+    required: false,
+    maxLength: 255,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  description?: string;
+
+  @ApiProperty({
+    example: ['properties:read', 'properties:write'],
+    description: 'List of permissions/scopes for this key',
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  permissions?: string[];
 }

--- a/backend/src/modules/developer/dto/update-api-key.dto.ts
+++ b/backend/src/modules/developer/dto/update-api-key.dto.ts
@@ -5,6 +5,7 @@ import {
   IsDateString,
   MaxLength,
   MinLength,
+  IsArray,
 } from 'class-validator';
 
 export class UpdateApiKeyDto {
@@ -20,12 +21,29 @@ export class UpdateApiKeyDto {
   name?: string;
 
   @ApiPropertyOptional({
+    example: 'Updated description',
+    maxLength: 255,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  description?: string;
+
+  @ApiPropertyOptional({
     description: 'Expiration date in ISO 8601 format',
     example: '2026-06-25T12:00:00Z',
   })
   @IsOptional()
   @IsDateString()
   expiresAt?: string;
+
+  @ApiPropertyOptional({
+    example: ['properties:read', 'properties:write'],
+    description: 'List of permissions/scopes for this key',
+  })
+  @IsOptional()
+  @IsArray()
+  permissions?: string[];
 }
 
 export class RotateApiKeyDto {

--- a/backend/src/modules/developer/entities/api-key.entity.ts
+++ b/backend/src/modules/developer/entities/api-key.entity.ts
@@ -23,11 +23,17 @@ export class ApiKey {
   @Column({ type: 'varchar', length: 100 })
   name: string;
 
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  description: string | null;
+
   @Column({ type: 'varchar', length: 64 })
   keyHash: string;
 
   @Column({ type: 'varchar', length: 20, nullable: true })
   keyPrefix: string | null;
+
+  @Column({ type: 'simple-array', default: '' })
+  permissions: string[];
 
   @Column({ type: 'varchar', length: 30, nullable: true })
   lastUsedAt: Date | null;

--- a/frontend/components/developer/ApiKeyDetails.tsx
+++ b/frontend/components/developer/ApiKeyDetails.tsx
@@ -15,12 +15,14 @@ interface ApiKeyDetailsProps {
   apiKey: ApiKey;
   onRevoke: (id: string) => void;
   onRotate: (id: string) => void;
+  isLoading?: boolean;
 }
 
 export function ApiKeyDetails({
   apiKey,
   onRevoke,
   onRotate,
+  isLoading = false,
 }: ApiKeyDetailsProps) {
   const copyPrefix = () => {
     navigator.clipboard.writeText(apiKey.keyPrefix);
@@ -141,14 +143,16 @@ export function ApiKeyDetails({
         <div className="pt-4 border-t border-white/10 flex gap-3">
           <button
             onClick={() => onRotate(apiKey.id)}
-            className="flex-1 px-4 py-2.5 bg-blue-600/20 hover:bg-blue-600/30 border border-blue-500/30 text-blue-300 rounded-xl font-semibold text-sm flex items-center justify-center gap-2 transition-all"
+            disabled={isLoading}
+            className="flex-1 px-4 py-2.5 bg-blue-600/20 hover:bg-blue-600/30 disabled:opacity-60 disabled:cursor-not-allowed border border-blue-500/30 text-blue-300 rounded-xl font-semibold text-sm flex items-center justify-center gap-2 transition-all"
           >
             <RotateCw size={15} />
             Rotate Key
           </button>
           <button
             onClick={() => onRevoke(apiKey.id)}
-            className="flex-1 px-4 py-2.5 bg-rose-500/10 hover:bg-rose-500/20 border border-rose-500/30 text-rose-400 rounded-xl font-semibold text-sm flex items-center justify-center gap-2 transition-all"
+            disabled={isLoading}
+            className="flex-1 px-4 py-2.5 bg-rose-500/10 hover:bg-rose-500/20 disabled:opacity-60 disabled:cursor-not-allowed border border-rose-500/30 text-rose-400 rounded-xl font-semibold text-sm flex items-center justify-center gap-2 transition-all"
           >
             <Trash2 size={15} />
             Revoke Key

--- a/frontend/components/developer/ApiKeysList.tsx
+++ b/frontend/components/developer/ApiKeysList.tsx
@@ -30,6 +30,7 @@ interface ApiKeysListProps {
   onEdit: (id: string) => void;
   onRevoke: (id: string) => void;
   onRotate: (id: string) => void;
+  isLoading?: boolean;
 }
 
 export function ApiKeysList({
@@ -39,6 +40,7 @@ export function ApiKeysList({
   onEdit,
   onRevoke,
   onRotate,
+  isLoading = false,
 }: ApiKeysListProps) {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<

--- a/frontend/components/developer/ApiKeysManagement.tsx
+++ b/frontend/components/developer/ApiKeysManagement.tsx
@@ -1,24 +1,15 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Plus, KeyRound } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { apiClient } from '@/lib/api-client';
 import { ApiKeysList } from './ApiKeysList';
 import { ApiKeyForm } from './ApiKeyForm';
 import { ApiKeyGenerate } from './ApiKeyGenerate';
 import { ApiKeyDetails } from './ApiKeyDetails';
 import type { ApiKey } from './ApiKeysList';
 import type { ApiKeyFormValues } from './ApiKeyForm';
-
-function generateKey(prefix: string): string {
-  const chars =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let result = '';
-  const array = new Uint8Array(40);
-  crypto.getRandomValues(array);
-  array.forEach((n) => (result += chars[n % chars.length]));
-  return `${prefix}_${result}`;
-}
 
 export function ApiKeysManagement() {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
@@ -29,6 +20,29 @@ export function ApiKeysManagement() {
     key: string;
     name: string;
   } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
+
+  // Load API keys on component mount
+  useEffect(() => {
+    const loadKeys = async () => {
+      try {
+        setIsInitializing(true);
+        const { data } = await apiClient.get<ApiKey[]>('/developer/api-keys', {
+          retries: 1,
+          timeoutMs: 5000,
+        });
+        setApiKeys(data || []);
+      } catch (error) {
+        toast.error('Failed to load API keys');
+        console.error('Error loading API keys:', error);
+      } finally {
+        setIsInitializing(false);
+      }
+    };
+
+    loadKeys();
+  }, []);
 
   const selectedKey = useMemo(
     () => apiKeys.find((k) => k.id === selectedId),
@@ -36,82 +50,145 @@ export function ApiKeysManagement() {
   );
 
   const handleCreate = async (data: ApiKeyFormValues) => {
-    const fullKey = generateKey('chk');
-    const prefix = fullKey.slice(0, 8);
-    const newKey: ApiKey = {
-      id: `key_${Date.now()}`,
-      name: data.name,
-      description: data.description || undefined,
-      keyPrefix: prefix,
-      permissions: data.permissions,
-      status: 'active',
-      createdAt: new Date().toISOString(),
-      expiresAt: data.expiresAt
-        ? new Date(data.expiresAt).toISOString()
-        : undefined,
-    };
-    setApiKeys((prev) => [newKey, ...prev]);
-    setGeneratedKey({ key: fullKey, name: data.name });
-    setShowForm(false);
-    toast.success('API key generated');
+    try {
+      setIsLoading(true);
+      const payload = {
+        name: data.name,
+        description: data.description || undefined,
+        permissions: data.permissions,
+      };
+      const { data: response } = await apiClient.post<{
+        id: string;
+        key: string;
+        name: string;
+        expiresAt: string;
+      }>('/developer/api-keys', payload, { retries: 1 });
+
+      // Refresh the keys list
+      const { data: updatedKeys } = await apiClient.get<ApiKey[]>(
+        '/developer/api-keys',
+        { retries: 1 },
+      );
+      setApiKeys(updatedKeys || []);
+
+      setGeneratedKey({ key: response.key, name: response.name });
+      setShowForm(false);
+      toast.success('API key generated');
+    } catch (error) {
+      toast.error('Failed to create API key');
+      console.error('Error creating API key:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleUpdate = async (id: string, data: ApiKeyFormValues) => {
-    setApiKeys((prev) =>
-      prev.map((k) =>
-        k.id === id
-          ? {
-              ...k,
-              name: data.name,
-              description: data.description || undefined,
-              permissions: data.permissions,
-              expiresAt: data.expiresAt
-                ? new Date(data.expiresAt).toISOString()
-                : undefined,
-            }
-          : k,
-      ),
-    );
-    toast.success('API key updated');
-    setEditingId(null);
-    setShowForm(false);
+    try {
+      setIsLoading(true);
+      const payload: {
+        name: string;
+        description?: string;
+        expiresAt?: string;
+        permissions?: string[];
+      } = {
+        name: data.name,
+      };
+
+      if (data.description) {
+        payload.description = data.description;
+      }
+
+      if (data.expiresAt) {
+        payload.expiresAt = new Date(data.expiresAt).toISOString();
+      }
+
+      if (data.permissions) {
+        payload.permissions = data.permissions;
+      }
+
+      await apiClient.patch(`/developer/api-keys/${id}`, payload, {
+        retries: 1,
+      });
+
+      // Refresh the keys list
+      const { data: updatedKeys } = await apiClient.get<ApiKey[]>(
+        '/developer/api-keys',
+        { retries: 1 },
+      );
+      setApiKeys(updatedKeys || []);
+
+      toast.success('API key updated');
+      setEditingId(null);
+      setShowForm(false);
+    } catch (error) {
+      toast.error('Failed to update API key');
+      console.error('Error updating API key:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
-  const handleRevoke = (id: string) => {
+  const handleRevoke = async (id: string) => {
     if (
       !confirm(
         'Revoke this API key? All requests using it will immediately fail.',
       )
     )
       return;
-    setApiKeys((prev) =>
-      prev.map((k) => (k.id === id ? { ...k, status: 'revoked' } : k)),
-    );
-    if (selectedId === id) setSelectedId(null);
-    toast.success('API key revoked');
+
+    try {
+      setIsLoading(true);
+      await apiClient.delete(`/developer/api-keys/${id}`, { retries: 1 });
+
+      // Refresh the keys list
+      const { data: updatedKeys } = await apiClient.get<ApiKey[]>(
+        '/developer/api-keys',
+        { retries: 1 },
+      );
+      setApiKeys(updatedKeys || []);
+
+      if (selectedId === id) setSelectedId(null);
+      toast.success('API key revoked');
+    } catch (error) {
+      toast.error('Failed to revoke API key');
+      console.error('Error revoking API key:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
-  const handleRotate = (id: string) => {
+  const handleRotate = async (id: string) => {
     if (
       !confirm(
         'Rotate this key? The current key will be revoked and a new one generated.',
       )
     )
       return;
-    const key = apiKeys.find((k) => k.id === id);
-    if (!key) return;
 
-    const fullKey = generateKey('chk');
-    const prefix = fullKey.slice(0, 8);
-    setApiKeys((prev) =>
-      prev.map((k) =>
-        k.id === id
-          ? { ...k, keyPrefix: prefix, createdAt: new Date().toISOString() }
-          : k,
-      ),
-    );
-    setGeneratedKey({ key: fullKey, name: key.name });
-    toast.success('Key rotated — save your new key');
+    try {
+      setIsLoading(true);
+      const { data: response } = await apiClient.post<{
+        id: string;
+        key: string;
+        name: string;
+        expiresAt: string;
+      }>(`/developer/api-keys/${id}/rotate`, {}, { retries: 1 });
+
+      // Refresh the keys list
+      const { data: updatedKeys } = await apiClient.get<ApiKey[]>(
+        '/developer/api-keys',
+        { retries: 1 },
+      );
+      setApiKeys(updatedKeys || []);
+
+      setGeneratedKey({ key: response.key, name: response.name });
+      toast.success('Key rotated — save your new key');
+    } catch (error) {
+      toast.error('Failed to rotate API key');
+      console.error('Error rotating API key:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -136,7 +213,8 @@ export function ApiKeysManagement() {
             setEditingId(null);
             setShowForm(!showForm);
           }}
-          className="px-4 py-2.5 bg-cyan-600 hover:bg-cyan-500 text-white rounded-xl font-semibold text-sm flex items-center gap-2 transition-all self-start sm:self-auto"
+          disabled={isLoading || isInitializing}
+          className="px-4 py-2.5 bg-cyan-600 hover:bg-cyan-500 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-xl font-semibold text-sm flex items-center gap-2 transition-all self-start sm:self-auto"
         >
           <Plus size={18} />
           New API Key
@@ -161,6 +239,7 @@ export function ApiKeysManagement() {
             apiKey={
               editingId ? apiKeys.find((k) => k.id === editingId) : undefined
             }
+            isLoading={isLoading}
             onSubmit={(data) =>
               editingId ? handleUpdate(editingId, data) : handleCreate(data)
             }
@@ -175,17 +254,24 @@ export function ApiKeysManagement() {
       {/* List + Detail */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-1">
-          <ApiKeysList
-            apiKeys={apiKeys}
-            selectedId={selectedId}
-            onSelect={setSelectedId}
-            onEdit={(id) => {
-              setEditingId(id);
-              setShowForm(true);
-            }}
-            onRevoke={handleRevoke}
-            onRotate={handleRotate}
-          />
+          {isInitializing ? (
+            <div className="bg-white/5 backdrop-blur-sm rounded-3xl p-6 border border-white/10 flex items-center justify-center min-h-[300px]">
+              <p className="text-blue-200/60">Loading API keys...</p>
+            </div>
+          ) : (
+            <ApiKeysList
+              apiKeys={apiKeys}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              onEdit={(id) => {
+                setEditingId(id);
+                setShowForm(true);
+              }}
+              onRevoke={handleRevoke}
+              onRotate={handleRotate}
+              isLoading={isLoading}
+            />
+          )}
         </div>
 
         <div className="lg:col-span-2">
@@ -194,11 +280,14 @@ export function ApiKeysManagement() {
               apiKey={selectedKey}
               onRevoke={handleRevoke}
               onRotate={handleRotate}
+              isLoading={isLoading}
             />
           ) : (
             <div className="bg-white/5 backdrop-blur-sm rounded-3xl p-6 border border-white/10 flex items-center justify-center min-h-[400px]">
               <p className="text-blue-200/60">
-                Select an API key to view details
+                {isInitializing
+                  ? 'Loading API keys...'
+                  : 'Select an API key to view details'}
               </p>
             </div>
           )}


### PR DESCRIPTION
# Fix: API Keys Page - Connect to Real Backend

## Summary

Fixed the critical issue where the developer API keys page was entirely client-side fake state with no persistence. All API key operations now properly integrate with the backend endpoints and data persists across page reloads.

## What Changed

### Backend

- Added `description` and `permissions` fields to the `ApiKey` entity
- Updated `CreateApiKeyDto` and `UpdateApiKeyDto` to accept permissions and description
- Modified `DeveloperService` to handle new fields in create/list/update operations
- Updated `DeveloperController` responses to include permissions and description
- Created migration to add new columns to the database

### Frontend

- Removed client-side fake `generateKey()` function
- Replaced all local state mutations with real API calls:
  - `POST /developer/api-keys` for creation
  - `GET /developer/api-keys` for listing (loaded on mount)
  - `PATCH /developer/api-keys/:id` for updates
  - `POST /developer/api-keys/:id/rotate` for rotation
  - `DELETE /developer/api-keys/:id` for revocation
- Added `isLoading` and `isInitializing` states for UX feedback
- Added error toast notifications for failed operations
- All API keys now properly persist server-side and survive page reloads

## Issue Fixed

closes #1331 

## Testing

- Verified TypeScript compilation with no errors
- Ran ESLint - no issues in modified code
- All changes follow existing project patterns and conventions
