### PR TITLE
feat(api): add per-endpoint deprecation warnings

### DIFF
--- a/backend/docs/api/API-VERSIONING.md
+++ b/backend/docs/api/API-VERSIONING.md
@@ -78,6 +78,16 @@ When a breaking change is unavoidable, we follow a strict deprecation process.
     - `Link: <replacement-url>; rel="successor-version"`
 4.  **Logging:** Backend logs should track the usage of deprecated endpoints to identify high-impact removals.
 
+> [!TIP]
+> This is implemented via the `@Deprecated()` decorator
+> (`backend/src/common/decorators/deprecated.decorator.ts`) and the global
+> `DeprecationInterceptor`
+> (`backend/src/common/interceptors/deprecation.interceptor.ts`). Annotate a
+> handler with `@Deprecated({ sunsetDate, replacementEndpoint,
+> migrationGuideUrl })` to get the headers above plus a per-call warning log,
+> and the route is automatically flagged `deprecated: true` in the OpenAPI
+> spec.
+
 ---
 
 ## 6. Migration Procedures

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -70,6 +70,7 @@ import { BookingsModule } from './modules/bookings/bookings.module';
 import { ApiVersionModule } from './common/api-versioning/api-version.module';
 import { ResponseTimeInterceptor } from './common/interceptors/response-time.interceptor';
 import { TimeoutInterceptor } from './common/interceptors/timeout.interceptor';
+import { DeprecationInterceptor } from './common/interceptors/deprecation.interceptor';
 import { createDatabaseConnectionOptions } from './database/database-config';
 
 const appLogger = new Logger('AppModule');
@@ -289,6 +290,10 @@ const appLogger = new Logger('AppModule');
     {
       provide: APP_INTERCEPTOR,
       useClass: TimeoutInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: DeprecationInterceptor,
     },
   ],
 })

--- a/backend/src/common/decorators/deprecated.decorator.spec.ts
+++ b/backend/src/common/decorators/deprecated.decorator.spec.ts
@@ -1,0 +1,75 @@
+import { ApiOperation } from '@nestjs/swagger';
+import { DECORATORS } from '@nestjs/swagger/dist/constants';
+import { Deprecated, DEPRECATION_METADATA_KEY } from './deprecated.decorator';
+
+describe('@Deprecated decorator', () => {
+  it('attaches the given options under DEPRECATION_METADATA_KEY', () => {
+    class Target {
+      @Deprecated({
+        sunsetDate: '2026-12-31T00:00:00Z',
+        migrationGuideUrl: 'https://docs.example.com/migrate',
+        replacementEndpoint: '/api/v2/widgets',
+        message: 'internal note',
+      })
+      handler() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      DEPRECATION_METADATA_KEY,
+      Target.prototype.handler,
+    );
+
+    expect(metadata).toEqual({
+      sunsetDate: '2026-12-31T00:00:00Z',
+      migrationGuideUrl: 'https://docs.example.com/migrate',
+      replacementEndpoint: '/api/v2/widgets',
+      message: 'internal note',
+    });
+  });
+
+  it('defaults to an empty options object when none are provided', () => {
+    class Target {
+      @Deprecated()
+      handler() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      DEPRECATION_METADATA_KEY,
+      Target.prototype.handler,
+    );
+
+    expect(metadata).toEqual({});
+  });
+
+  it('marks the route as deprecated in the generated Swagger metadata', () => {
+    class Target {
+      @Deprecated()
+      handler() {}
+    }
+
+    const apiOperation = Reflect.getMetadata(
+      DECORATORS.API_OPERATION,
+      Target.prototype.handler,
+    );
+
+    expect(apiOperation).toMatchObject({ deprecated: true });
+  });
+
+  it('preserves an existing @ApiOperation summary applied before it', () => {
+    class Target {
+      @ApiOperation({ summary: 'Does a thing' })
+      @Deprecated()
+      handler() {}
+    }
+
+    const apiOperation = Reflect.getMetadata(
+      DECORATORS.API_OPERATION,
+      Target.prototype.handler,
+    );
+
+    expect(apiOperation).toMatchObject({
+      summary: 'Does a thing',
+      deprecated: true,
+    });
+  });
+});

--- a/backend/src/common/decorators/deprecated.decorator.ts
+++ b/backend/src/common/decorators/deprecated.decorator.ts
@@ -1,0 +1,38 @@
+import { applyDecorators, SetMetadata } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+export const DEPRECATION_METADATA_KEY = 'deprecation:options';
+
+export interface DeprecationOptions {
+  /** When the endpoint is expected to stop working. Anything `Date` can parse. */
+  sunsetDate?: string;
+  /** URL to documentation describing how to migrate away from this endpoint. */
+  migrationGuideUrl?: string;
+  /** Path (or description) of the endpoint that replaces this one. */
+  replacementEndpoint?: string;
+  /** Note logged alongside each deprecated call. Not exposed to clients. */
+  message?: string;
+}
+
+/**
+ * Marks a controller method (or an entire controller) as deprecated.
+ *
+ * Combined with DeprecationInterceptor, this surfaces standard `Deprecation`,
+ * `Sunset` (RFC 8594) and `Link` response headers to callers, logs a warning
+ * per call, and flags the route as deprecated in the generated Swagger docs.
+ *
+ * Usage:
+ * @Get('legacy-endpoint')
+ * @Deprecated({
+ *   sunsetDate: '2026-12-31T00:00:00Z',
+ *   migrationGuideUrl: 'https://docs.example.com/migrate-to-v2',
+ *   replacementEndpoint: '/api/v2/widgets',
+ * })
+ * async handler() { ... }
+ */
+export function Deprecated(options: DeprecationOptions = {}) {
+  return applyDecorators(
+    SetMetadata(DEPRECATION_METADATA_KEY, options),
+    ApiOperation({ deprecated: true }),
+  );
+}

--- a/backend/src/common/interceptors/deprecation.interceptor.spec.ts
+++ b/backend/src/common/interceptors/deprecation.interceptor.spec.ts
@@ -1,0 +1,124 @@
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { of } from 'rxjs';
+
+import { DeprecationInterceptor } from './deprecation.interceptor';
+import { Deprecated } from '../decorators/deprecated.decorator';
+
+class TestController {
+  @Deprecated({
+    sunsetDate: '2026-12-31T00:00:00Z',
+    migrationGuideUrl: 'https://docs.example.com/migrate',
+    replacementEndpoint: '/api/v2/widgets',
+    message: 'internal note',
+  })
+  deprecatedHandler() {}
+
+  @Deprecated()
+  bareDeprecatedHandler() {}
+
+  activeHandler() {}
+}
+
+function makeContext(
+  handler: () => void,
+  opts: { method?: string; path?: string } = {},
+): { context: ExecutionContext; response: { setHeader: jest.Mock } } {
+  const request = { method: opts.method ?? 'GET', path: opts.path ?? '/test' };
+  const response = { setHeader: jest.fn() };
+
+  const context = {
+    getHandler: () => handler,
+    getClass: () => TestController,
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+
+  return { context, response };
+}
+
+const nextHandler: CallHandler = { handle: () => of('ok') };
+
+describe('DeprecationInterceptor', () => {
+  let interceptor: DeprecationInterceptor;
+  let loggerWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    interceptor = new DeprecationInterceptor(new Reflector());
+    loggerWarnSpy = jest
+      .spyOn((interceptor as any).logger, 'warn')
+      .mockImplementation(() => {});
+  });
+
+  it('passes through untouched when the route is not deprecated', (done) => {
+    const { context, response } = makeContext(
+      TestController.prototype.activeHandler,
+    );
+
+    interceptor.intercept(context, nextHandler).subscribe((value) => {
+      expect(value).toBe('ok');
+      expect(response.setHeader).not.toHaveBeenCalled();
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('sets Deprecation, Sunset and Link headers for a fully configured route', (done) => {
+    const { context, response } = makeContext(
+      TestController.prototype.deprecatedHandler,
+      { method: 'GET', path: '/messaging/history' },
+    );
+
+    interceptor.intercept(context, nextHandler).subscribe((value) => {
+      expect(value).toBe('ok');
+      expect(response.setHeader).toHaveBeenCalledWith('Deprecated', 'true');
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Sunset',
+        new Date('2026-12-31T00:00:00Z').toUTCString(),
+      );
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Link',
+        '</api/v2/widgets>; rel="successor-version", <https://docs.example.com/migrate>; rel="deprecation"',
+      );
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'Deprecated endpoint called: GET /messaging/history',
+        expect.objectContaining({ message: 'internal note' }),
+      );
+      done();
+    });
+  });
+
+  it('only sets the Deprecated header when no other options are configured', (done) => {
+    const { context, response } = makeContext(
+      TestController.prototype.bareDeprecatedHandler,
+    );
+
+    interceptor.intercept(context, nextHandler).subscribe(() => {
+      expect(response.setHeader).toHaveBeenCalledWith('Deprecated', 'true');
+      expect(response.setHeader).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('ignores an unparseable sunsetDate instead of sending a garbage header', (done) => {
+    class BadDateController {
+      @Deprecated({ sunsetDate: 'not-a-date' })
+      handler() {}
+    }
+
+    const { context, response } = makeContext(
+      BadDateController.prototype.handler,
+    );
+
+    interceptor.intercept(context, nextHandler).subscribe(() => {
+      expect(response.setHeader).toHaveBeenCalledWith('Deprecated', 'true');
+      expect(response.setHeader).not.toHaveBeenCalledWith(
+        'Sunset',
+        expect.anything(),
+      );
+      done();
+    });
+  });
+});

--- a/backend/src/common/interceptors/deprecation.interceptor.ts
+++ b/backend/src/common/interceptors/deprecation.interceptor.ts
@@ -1,0 +1,77 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request, Response } from 'express';
+import { Observable } from 'rxjs';
+import {
+  DEPRECATION_METADATA_KEY,
+  DeprecationOptions,
+} from '../decorators/deprecated.decorator';
+
+/**
+ * Adds standard deprecation signaling to responses from routes annotated
+ * with @Deprecated(), per the header contract defined in
+ * `backend/docs/api/API-VERSIONING.md` section 5: `Deprecated`, `Sunset`
+ * (HTTP-date), and a `Link` header pointing clients at the replacement
+ * endpoint and/or migration docs.
+ */
+@Injectable()
+export class DeprecationInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(DeprecationInterceptor.name);
+
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const options = this.reflector.getAllAndOverride<
+      DeprecationOptions | undefined
+    >(DEPRECATION_METADATA_KEY, [context.getHandler(), context.getClass()]);
+
+    if (!options) {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const response = context.switchToHttp().getResponse<Response>();
+
+    this.applyHeaders(response, options);
+
+    this.logger.warn(
+      `Deprecated endpoint called: ${request.method} ${request.path}`,
+      {
+        sunsetDate: options.sunsetDate,
+        migrationGuideUrl: options.migrationGuideUrl,
+        replacementEndpoint: options.replacementEndpoint,
+        message: options.message,
+      },
+    );
+
+    return next.handle();
+  }
+
+  private applyHeaders(response: Response, options: DeprecationOptions): void {
+    response.setHeader('Deprecated', 'true');
+
+    if (options.sunsetDate) {
+      const sunset = new Date(options.sunsetDate);
+      if (!Number.isNaN(sunset.getTime())) {
+        response.setHeader('Sunset', sunset.toUTCString());
+      }
+    }
+
+    const links: string[] = [];
+    if (options.replacementEndpoint) {
+      links.push(`<${options.replacementEndpoint}>; rel="successor-version"`);
+    }
+    if (options.migrationGuideUrl) {
+      links.push(`<${options.migrationGuideUrl}>; rel="deprecation"`);
+    }
+    if (links.length > 0) {
+      response.setHeader('Link', links.join(', '));
+    }
+  }
+}

--- a/backend/src/modules/messaging/messaging.controller.ts
+++ b/backend/src/modules/messaging/messaging.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { MessagingService } from './messaging.service';
+import { Deprecated } from '../../common/decorators/deprecated.decorator';
 
 @ApiTags('Messaging')
 @Controller('messaging')
@@ -21,6 +22,17 @@ export class MessagingController {
   // ── Legacy history endpoint ──────────────────────────────────────────────
 
   @Get('history')
+  @ApiOperation({ summary: '[Deprecated] Get chat history for a chat group' })
+  @Deprecated({
+    sunsetDate: '2026-12-31T00:00:00Z',
+    migrationGuideUrl:
+      'https://docs.chioma.app/api/migrating-from-messaging-history',
+    replacementEndpoint: '/messaging/rooms/:roomId/messages',
+    message:
+      'Superseded by GET /messaging/rooms/:roomId/messages, which is ' +
+      'room-scoped and paginated consistently with the rest of the ' +
+      'messaging API.',
+  })
   async getHistory(
     @Query('chatGroupId') chatGroupId: string,
     @Query('page') page = 1,


### PR DESCRIPTION
Adds a @Deprecated() decorator and global DeprecationInterceptor so individual endpoints can signal upcoming retirement, not just whole API versions. Sets the Deprecated/Sunset/Link response headers and logs deprecated-endpoint usage per the policy already documented in backend/docs/api/API-VERSIONING.md section 5, which had no code implementing it.

Applies it to the legacy GET /messaging/history endpoint, which was superseded by GET /messaging/rooms/:roomId/messages but gave clients no signal that it was retired.

Closes #1457

## 📝 Description

<!-- Brief description of the changes -->

## 🎯 Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧹 Code cleanup/refactoring


