### PR TITLE
fix(monitoring): wire up database connection pool utilization metrics

### DIFF
--- a/backend/src/modules/monitoring/database-monitor.service.spec.ts
+++ b/backend/src/modules/monitoring/database-monitor.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { AlertPayload } from './alert.types';
+import { AlertService } from './alert.service';
+import { DatabaseMonitorService } from './database-monitor.service';
+import { MetricsService } from './metrics.service';
+import { PerformanceMonitorService } from './performance-monitor.service';
+
+interface DriverPoolStub {
+  totalCount: number;
+  idleCount: number;
+  waitingCount: number;
+  options?: { max?: number };
+}
+
+function makeQueryMock() {
+  return jest.fn((sql: string) => {
+    if (sql.includes('pg_stat_activity')) {
+      return Promise.resolve([{ total: 5, active: 2, idle: 3, waiting: 0 }]);
+    }
+    if (sql.includes('max_connections')) {
+      return Promise.resolve([{ max_conn: 100 }]);
+    }
+    if (sql.includes('pg_database_size')) {
+      return Promise.resolve([{ size_bytes: 1000, size_human: '1000 bytes' }]);
+    }
+    if (sql.includes('information_schema.tables')) {
+      return Promise.resolve([
+        { table_count: 1, index_count: 1, index_size_bytes: 0 },
+      ]);
+    }
+    if (sql.includes('pg_stat_statements')) {
+      return Promise.resolve([{ total_calls: 0, avg_time: 0, max_time: 0 }]);
+    }
+    if (sql.includes('pg_stat_database')) {
+      return Promise.resolve([{ cache_hit_ratio: 100 }]);
+    }
+    return Promise.resolve([]);
+  });
+}
+
+function makeDataSource(driverPool?: DriverPoolStub): Partial<DataSource> {
+  return {
+    query: makeQueryMock() as unknown as DataSource['query'],
+    driver: (driverPool ? { master: driverPool } : {}) as DataSource['driver'],
+  };
+}
+
+describe('DatabaseMonitorService', () => {
+  let service: DatabaseMonitorService;
+  let metricsService: jest.Mocked<Pick<MetricsService, 'setDatabasePoolUsage'>>;
+  let alertService: jest.Mocked<Pick<AlertService, 'handleAlert'>>;
+
+  async function build(driverPool?: DriverPoolStub) {
+    metricsService = { setDatabasePoolUsage: jest.fn() };
+    alertService = { handleAlert: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DatabaseMonitorService,
+        { provide: getDataSourceToken(), useValue: makeDataSource(driverPool) },
+        { provide: MetricsService, useValue: metricsService },
+        { provide: AlertService, useValue: alertService },
+        { provide: PerformanceMonitorService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(DatabaseMonitorService);
+  }
+
+  function firedAlertNames(): string[] {
+    return alertService.handleAlert.mock.calls.flatMap((call) =>
+      (call[0].alerts as AlertPayload[]).map((a) => a.labels.alertname),
+    );
+  }
+
+  describe('application connection pool metrics', () => {
+    it('reads live stats off the underlying pg.Pool and publishes them via MetricsService', async () => {
+      await build({
+        totalCount: 8,
+        idleCount: 3,
+        waitingCount: 1,
+        options: { max: 20 },
+      });
+
+      const metrics = await service.getPoolMetrics();
+
+      expect(metrics?.applicationPool).toEqual({
+        total: 8,
+        idle: 3,
+        waiting: 1,
+        max: 20,
+        utilizationPercent: 25, // (8 - 3) / 20 * 100
+      });
+      expect(metricsService.setDatabasePoolUsage).toHaveBeenCalledWith(
+        5,
+        3,
+        20,
+        1,
+      );
+    });
+
+    it('returns a null applicationPool and skips the gauge update when the driver pool is unavailable', async () => {
+      await build(undefined);
+
+      const metrics = await service.getPoolMetrics();
+
+      expect(metrics?.applicationPool).toBeNull();
+      expect(metricsService.setDatabasePoolUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('application connection pool alerting', () => {
+    it('fires a critical exhaustion alert when requests are queued waiting for a connection', async () => {
+      await build({
+        totalCount: 20,
+        idleCount: 0,
+        waitingCount: 4,
+        options: { max: 20 },
+      });
+
+      await service.performDatabaseHealthCheck();
+
+      expect(firedAlertNames()).toContain(
+        'database_application_pool_exhausted',
+      );
+    });
+
+    it('fires a critical utilization alert at >=90% usage with nothing queued', async () => {
+      await build({
+        totalCount: 19,
+        idleCount: 0,
+        waitingCount: 0,
+        options: { max: 20 },
+      });
+
+      await service.performDatabaseHealthCheck();
+
+      const names = firedAlertNames();
+      expect(names).toContain('database_application_pool_critical');
+      expect(names).not.toContain('database_application_pool_exhausted');
+    });
+
+    it('fires a warning alert at >=70% usage', async () => {
+      await build({
+        totalCount: 15,
+        idleCount: 0,
+        waitingCount: 0,
+        options: { max: 20 },
+      });
+
+      await service.performDatabaseHealthCheck();
+
+      expect(firedAlertNames()).toContain('database_application_pool_warning');
+    });
+
+    it('fires no application pool alert when usage is healthy', async () => {
+      await build({
+        totalCount: 5,
+        idleCount: 3,
+        waitingCount: 0,
+        options: { max: 20 },
+      });
+
+      await service.performDatabaseHealthCheck();
+
+      expect(firedAlertNames()).not.toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^database_application_pool/),
+        ]),
+      );
+    });
+  });
+});

--- a/backend/src/modules/monitoring/database-monitor.service.ts
+++ b/backend/src/modules/monitoring/database-monitor.service.ts
@@ -14,6 +14,23 @@ export interface DatabasePoolMetrics {
   maxConnections: number;
   waitingClients: number;
   connectionUsagePercent: number;
+  applicationPool: DatabaseApplicationPoolMetrics | null;
+}
+
+/**
+ * Stats read directly off the node-postgres Pool that TypeORM's
+ * PostgresDriver creates for this app (sized via DB_POOL_MAX/DB_POOL_MIN).
+ * Distinct from the pg_stat_activity based fields above, which count every
+ * connection to the database from any client. `waiting > 0` here means
+ * requests are queued because this app's own pool has run out of
+ * connections - the direct signal of pool exhaustion.
+ */
+export interface DatabaseApplicationPoolMetrics {
+  total: number;
+  idle: number;
+  waiting: number;
+  max: number;
+  utilizationPercent: number;
 }
 
 export interface DatabaseQueryMetrics {
@@ -93,7 +110,19 @@ export class DatabaseMonitorService {
       const waiting = rows[0]?.waiting ?? 0;
       const maxConnections = maxResult[0]?.max_conn ?? 100;
 
-      this.metricsService.setDatabaseConnections(active);
+      const applicationPool = this.getApplicationPoolMetrics();
+      if (applicationPool) {
+        this.metricsService.setDatabasePoolUsage(
+          applicationPool.total - applicationPool.idle,
+          applicationPool.idle,
+          applicationPool.max,
+          applicationPool.waiting,
+        );
+      } else {
+        this.logger.warn(
+          'Application connection pool stats unavailable; database_pool_* metrics not updated',
+        );
+      }
 
       return {
         totalConnections: total,
@@ -105,6 +134,7 @@ export class DatabaseMonitorService {
           maxConnections > 0
             ? parseFloat(((active / maxConnections) * 100).toFixed(1))
             : 0,
+        applicationPool,
       };
     } catch (error) {
       this.logger.error(
@@ -113,6 +143,47 @@ export class DatabaseMonitorService {
       );
       return null;
     }
+  }
+
+  /**
+   * Reads live stats directly off the node-postgres Pool that TypeORM's
+   * PostgresDriver holds as `driver.master`. This is the actual connection
+   * pool the app manages (see DB_POOL_MAX/DB_POOL_MIN in database-config.ts),
+   * which is what "exhausts" when traffic outpaces `DB_POOL_MAX` - long
+   * before Postgres' own `max_connections` is anywhere near its limit.
+   */
+  private getApplicationPoolMetrics(): DatabaseApplicationPoolMetrics | null {
+    const pool = (
+      this.dataSource.driver as unknown as {
+        master?: {
+          totalCount?: number;
+          idleCount?: number;
+          waitingCount?: number;
+          options?: { max?: number };
+        };
+      }
+    ).master;
+
+    if (
+      !pool ||
+      typeof pool.totalCount !== 'number' ||
+      typeof pool.idleCount !== 'number' ||
+      typeof pool.waitingCount !== 'number'
+    ) {
+      return null;
+    }
+
+    const max = pool.options?.max ?? 0;
+    const active = pool.totalCount - pool.idleCount;
+
+    return {
+      total: pool.totalCount,
+      idle: pool.idleCount,
+      waiting: pool.waitingCount,
+      max,
+      utilizationPercent:
+        max > 0 ? parseFloat(((active / max) * 100).toFixed(1)) : 0,
+    };
   }
 
   /**
@@ -259,9 +330,6 @@ export class DatabaseMonitorService {
       // Check pool metrics
       if (snapshot.pool) {
         const usage = snapshot.pool.connectionUsagePercent;
-        this.metricsService.setDatabaseConnections(
-          snapshot.pool.activeConnections,
-        );
 
         if (usage >= this.POOL_CRITICAL_PERCENT * 100) {
           alerts.push({
@@ -293,6 +361,65 @@ export class DatabaseMonitorService {
             startsAt: new Date().toISOString(),
             generatorURL: '',
           });
+        }
+
+        // Check the application's own connection pool (DB_POOL_MAX), which
+        // exhausts independently of - and usually well before - Postgres'
+        // server-wide max_connections checked above.
+        const appPool = snapshot.pool.applicationPool;
+        if (appPool) {
+          if (appPool.waiting > 0) {
+            alerts.push({
+              status: 'firing',
+              labels: {
+                alertname: 'database_application_pool_exhausted',
+                severity: 'critical',
+                service: 'chioma-backend',
+              },
+              annotations: {
+                summary: `Application connection pool exhausted: ${appPool.waiting} request(s) queued waiting for a connection`,
+                description: `Total: ${appPool.total}, Idle: ${appPool.idle}, Max: ${appPool.max}, Utilization: ${appPool.utilizationPercent}%`,
+              },
+              startsAt: new Date().toISOString(),
+              generatorURL: '',
+            });
+          } else if (
+            appPool.utilizationPercent >=
+            this.POOL_CRITICAL_PERCENT * 100
+          ) {
+            alerts.push({
+              status: 'firing',
+              labels: {
+                alertname: 'database_application_pool_critical',
+                severity: 'critical',
+                service: 'chioma-backend',
+              },
+              annotations: {
+                summary: `Application connection pool near exhaustion: ${appPool.utilizationPercent}% used`,
+                description: `Total: ${appPool.total}, Idle: ${appPool.idle}, Max: ${appPool.max}`,
+              },
+              startsAt: new Date().toISOString(),
+              generatorURL: '',
+            });
+          } else if (
+            appPool.utilizationPercent >=
+            this.POOL_WARNING_PERCENT * 100
+          ) {
+            alerts.push({
+              status: 'firing',
+              labels: {
+                alertname: 'database_application_pool_warning',
+                severity: 'warning',
+                service: 'chioma-backend',
+              },
+              annotations: {
+                summary: `Application connection pool usage elevated: ${appPool.utilizationPercent}%`,
+                description: `Total: ${appPool.total}, Max: ${appPool.max}`,
+              },
+              startsAt: new Date().toISOString(),
+              generatorURL: '',
+            });
+          }
         }
       }
 

--- a/backend/src/modules/monitoring/metrics.service.spec.ts
+++ b/backend/src/modules/monitoring/metrics.service.spec.ts
@@ -75,8 +75,8 @@ describe('MetricsService', () => {
   });
 
   describe('Database metrics', () => {
-    it('setDatabaseConnections does not throw', () => {
-      expect(() => service.setDatabaseConnections(10)).not.toThrow();
+    it('setDatabasePoolUsage does not throw', () => {
+      expect(() => service.setDatabasePoolUsage(5, 3, 10, 1)).not.toThrow();
     });
 
     it('recordDatabaseQuery does not throw', () => {

--- a/backend/src/modules/monitoring/metrics.service.ts
+++ b/backend/src/modules/monitoring/metrics.service.ts
@@ -234,8 +234,6 @@ export class MetricsService implements OnModuleInit {
     this.blockchainDuration.observe({ type }, durationMs);
   }
 
-  setDatabaseConnections(_count: number): void {}
-
   setDatabasePoolUsage(
     active: number,
     idle: number,


### PR DESCRIPTION
## Summary

Closes #1456.

`MetricsService` already had fully-formed Prometheus gauges for the connection pool (`database_pool_active`/`idle`/`max`/`waiting`) exposed via `setDatabasePoolUsage()`, but `DatabaseMonitorService` never called it — it called a dead no-op stub, `setDatabaseConnections()`, instead. The gauges were permanently stuck at zero, so pool utilization was invisible on `/metrics`.

Separately, the pool metrics that *were* computed came entirely from `pg_stat_activity` compared against Postgres' server-wide `max_connections`, which counts every connection to the database from any client. That's not the same thing as this application's own connection pool (sized via `DB_POOL_MAX`/`DB_POOL_MIN` in `database-config.ts`), which is what actually exhausts under load — and the real signal for that (requests queued waiting for a pooled connection) was never captured at all.

### Changes
- Remove the dead `setDatabaseConnections()` stub from `MetricsService`.
- Add `DatabaseMonitorService#getApplicationPoolMetrics()`, which reads `totalCount`/`idleCount`/`waitingCount` directly off the node-postgres `Pool` that TypeORM's `PostgresDriver` holds as `driver.master`, and wires the result into the now-live `setDatabasePoolUsage()` gauges. Exposed as `applicationPool` on the existing `GET /api/database/pool` response.
- Add cron-driven alerts (`database_application_pool_exhausted`/`critical`/`warning`) so pool exhaustion actually fires instead of going undetected: an immediate critical alert the moment requests start queueing (`waiting > 0`), plus the existing 70%/90% utilization thresholds applied against the real pool size.
- Add unit tests covering the new pool-stats extraction and each new alert threshold.

## Test plan
- [x] `pnpm exec jest src/modules/monitoring/database-monitor.service.spec.ts src/modules/monitoring/metrics.service.spec.ts` — 21/21 passing
- [x] `pnpm exec tsc --noEmit` — no errors
- [x] `pnpm exec eslint` on all changed files — no errors
- [ ] `pnpm test:e2e` — not run locally (requires a live Postgres instance not available in this environment); confirmed by inspection that `metrics-collection.e2e-spec.ts` only calls `setDatabasePoolUsage` (kept) and never references the removed `setDatabaseConnections`, so it should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)