### PR TITLE
fix(web-vitals): batch analytics events into a single request

### DIFF
--- a/frontend/__tests__/app/api/web-vitals.route.test.ts
+++ b/frontend/__tests__/app/api/web-vitals.route.test.ts
@@ -47,4 +47,73 @@ describe('/api/web-vitals', () => {
     expect(JSON.stringify(data)).not.toContain('dangerous');
     expect(data.latest.LCP).toBeDefined();
   });
+
+  it('accepts a batched array of metrics in a single request', async () => {
+    const res = await POST(
+      jsonRequest('http://localhost/api/web-vitals', [
+        {
+          name: 'LCP',
+          value: 1900,
+          id: 'batch-lcp-1',
+          route: '/batch-test',
+        },
+        {
+          name: 'CLS',
+          value: 0.02,
+          id: 'batch-cls-1',
+          route: '/batch-test',
+        },
+        {
+          name: 'TTFB',
+          value: 250,
+          id: 'batch-ttfb-1',
+          route: '/batch-test',
+        },
+      ]),
+    );
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.received).toBe(3);
+
+    const getRes = await GET(
+      new NextRequest(
+        'http://localhost/api/web-vitals?name=CLS&limit=5',
+      ),
+    );
+    const data = await getRes.json();
+    expect(
+      data.metrics.some((m: { id: string }) => m.id === 'batch-cls-1'),
+    ).toBe(true);
+  });
+
+  it('skips invalid items within a batch but keeps the valid ones', async () => {
+    const res = await POST(
+      jsonRequest('http://localhost/api/web-vitals', [
+        { name: 'LCP', value: 1800, id: 'partial-valid-1' },
+        { name: 'CLS' }, // missing value/id
+        'not-even-an-object',
+      ]),
+    );
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.received).toBe(1);
+  });
+
+  it('rejects a batch where every item is invalid', async () => {
+    const res = await POST(
+      jsonRequest('http://localhost/api/web-vitals', [
+        { name: 'LCP' },
+        { value: 100 },
+      ]),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty batch', async () => {
+    const res = await POST(jsonRequest('http://localhost/api/web-vitals', []));
+    expect(res.status).toBe(400);
+  });
 });

--- a/frontend/__tests__/app/api/web-vitals.route.test.ts
+++ b/frontend/__tests__/app/api/web-vitals.route.test.ts
@@ -77,9 +77,7 @@ describe('/api/web-vitals', () => {
     expect(body.received).toBe(3);
 
     const getRes = await GET(
-      new NextRequest(
-        'http://localhost/api/web-vitals?name=CLS&limit=5',
-      ),
+      new NextRequest('http://localhost/api/web-vitals?name=CLS&limit=5'),
     );
     const data = await getRes.json();
     expect(

--- a/frontend/__tests__/lib/web-vitals.test.ts
+++ b/frontend/__tests__/lib/web-vitals.test.ts
@@ -127,8 +127,8 @@ describe('reportWebVital', () => {
     await vi.advanceTimersByTimeAsync(300);
 
     expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
-    const [url, blob] = (navigator.sendBeacon as ReturnType<typeof vi.fn>)
-      .mock.calls[0] as [string, Blob];
+    const [url, blob] = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, Blob];
     expect(url).toBe('/api/web-vitals');
     expect(blob.type).toBe('application/json');
 

--- a/frontend/__tests__/lib/web-vitals.test.ts
+++ b/frontend/__tests__/lib/web-vitals.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeRoute,
   toWebVitalPayload,
   reportWebVital,
+  flushWebVitals,
   setWebVitalSink,
 } from '@/lib/web-vitals';
 
@@ -68,6 +69,7 @@ describe('toWebVitalPayload', () => {
 
 describe('reportWebVital', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     setWebVitalSink(null);
     vi.stubGlobal(
       'fetch',
@@ -80,12 +82,14 @@ describe('reportWebVital', () => {
   });
 
   afterEach(() => {
+    flushWebVitals();
+    vi.useRealTimers();
     setWebVitalSink(null);
     vi.unstubAllGlobals();
     delete window.__CHIOMA_WEB_VITALS_REPORTER__;
   });
 
-  it('forwards to sink, beacon, and optional window reporter', () => {
+  it('forwards to sink and optional window reporter synchronously', () => {
     const sink = vi.fn();
     const external = vi.fn();
     setWebVitalSink(sink);
@@ -109,9 +113,56 @@ describe('reportWebVital', () => {
     expect(external).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'INP', route: '/vitals' }),
     );
-    expect(navigator.sendBeacon).toHaveBeenCalled();
-    const beaconArg = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock
+    // Queued for batching, not sent to the network yet.
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it('batches metrics reported close together into a single request', async () => {
+    reportWebVital({ name: 'LCP', value: 2000, id: 'lcp-1' }, '/a');
+    reportWebVital({ name: 'CLS', value: 0.05, id: 'cls-1' }, '/a');
+    reportWebVital({ name: 'TTFB', value: 300, id: 'ttfb-1' }, '/a');
+
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
+    const [url, blob] = (navigator.sendBeacon as ReturnType<typeof vi.fn>)
+      .mock.calls[0] as [string, Blob];
+    expect(url).toBe('/api/web-vitals');
+    expect(blob.type).toBe('application/json');
+
+    const sent = JSON.parse(await blob.text());
+    expect(sent).toHaveLength(3);
+    expect(sent.map((m: { name: string }) => m.name)).toEqual([
+      'LCP',
+      'CLS',
+      'TTFB',
+    ]);
+  });
+
+  it('flushes immediately when the page becomes hidden', () => {
+    reportWebVital({ name: 'LCP', value: 2000, id: 'lcp-2' }, '/b');
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes immediately once the batch hits its size cap, without waiting for the timer', async () => {
+    for (let i = 0; i < 10; i++) {
+      reportWebVital({ name: 'CLS', value: 0.01 * i, id: `cls-${i}` }, '/c');
+    }
+
+    expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
+    const blob = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock
       .calls[0][1] as Blob;
-    expect(beaconArg.type).toBe('application/json');
+    const sent = JSON.parse(await blob.text());
+    expect(sent).toHaveLength(10);
   });
 });

--- a/frontend/app/api/web-vitals/route.ts
+++ b/frontend/app/api/web-vitals/route.ts
@@ -18,7 +18,10 @@ function push(payload: WebVitalPayload) {
   if (buffer.length > MAX_BUFFER) buffer.length = MAX_BUFFER;
 }
 
-type RawWebVitalBody = RawWebVitalMetric & { route?: string; timestamp?: string };
+type RawWebVitalBody = RawWebVitalMetric & {
+  route?: string;
+  timestamp?: string;
+};
 
 function isValidBody(body: unknown): body is RawWebVitalBody {
   if (!body || typeof body !== 'object') return false;
@@ -73,10 +76,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const items = (Array.isArray(body) ? body : [body]).slice(
-    0,
-    MAX_BATCH_ITEMS,
-  );
+  const items = (Array.isArray(body) ? body : [body]).slice(0, MAX_BATCH_ITEMS);
   const validItems = items.filter(isValidBody);
 
   if (validItems.length === 0) {

--- a/frontend/app/api/web-vitals/route.ts
+++ b/frontend/app/api/web-vitals/route.ts
@@ -7,6 +7,8 @@ import {
 } from '@/lib/web-vitals';
 
 const MAX_BUFFER = 200;
+/** Hard cap on items accepted from a single batched request. */
+const MAX_BATCH_ITEMS = 25;
 
 /** In-process ring buffer for local aggregation / GET dashboard. */
 const buffer: WebVitalPayload[] = [];
@@ -16,10 +18,9 @@ function push(payload: WebVitalPayload) {
   if (buffer.length > MAX_BUFFER) buffer.length = MAX_BUFFER;
 }
 
-function isValidBody(body: unknown): body is RawWebVitalMetric & {
-  route?: string;
-  timestamp?: string;
-} {
+type RawWebVitalBody = RawWebVitalMetric & { route?: string; timestamp?: string };
+
+function isValidBody(body: unknown): body is RawWebVitalBody {
   if (!body || typeof body !== 'object') return false;
   const b = body as Record<string, unknown>;
   return (
@@ -30,22 +31,7 @@ function isValidBody(body: unknown): body is RawWebVitalMetric & {
   );
 }
 
-/**
- * Ingest anonymized Web Vitals from the browser (sendBeacon / fetch).
- * Re-sanitizes on the server so query strings / entries never stick.
- */
-export async function POST(request: NextRequest) {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-  }
-
-  if (!isValidBody(body)) {
-    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
-  }
-
+function buildPayload(body: RawWebVitalBody): WebVitalPayload {
   const payload = toWebVitalPayload(
     {
       name: body.name,
@@ -66,17 +52,54 @@ export async function POST(request: NextRequest) {
     payload.route = sanitizeRoute(body.route);
   }
 
-  push(payload);
+  return payload;
+}
 
-  // Structured log for terminal / log aggregation
-  console.info(
-    JSON.stringify({
-      type: 'web_vital',
-      ...payload,
-    }),
+/**
+ * Ingest anonymized Web Vitals from the browser (sendBeacon / fetch).
+ * Re-sanitizes on the server so query strings / entries never stick.
+ *
+ * Accepts either a single metric object (legacy shape) or an array of
+ * metrics (the client batches multiple metrics into one request rather
+ * than sending one per event). Invalid items within a batch are skipped
+ * rather than failing the whole request; only an empty/all-invalid body
+ * is rejected.
+ */
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const items = (Array.isArray(body) ? body : [body]).slice(
+    0,
+    MAX_BATCH_ITEMS,
   );
+  const validItems = items.filter(isValidBody);
 
-  return NextResponse.json({ ok: true }, { status: 202 });
+  if (validItems.length === 0) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  for (const item of validItems) {
+    const payload = buildPayload(item);
+    push(payload);
+
+    // Structured log for terminal / log aggregation
+    console.info(
+      JSON.stringify({
+        type: 'web_vital',
+        ...payload,
+      }),
+    );
+  }
+
+  return NextResponse.json(
+    { ok: true, received: validItems.length },
+    { status: 202 },
+  );
 }
 
 /**

--- a/frontend/lib/web-vitals/index.ts
+++ b/frontend/lib/web-vitals/index.ts
@@ -8,4 +8,9 @@ export {
   type WebVitalRating,
 } from './types';
 export { sanitizeRoute, toWebVitalPayload } from './sanitize';
-export { reportWebVital, setWebVitalSink, type WebVitalSink } from './report';
+export {
+  reportWebVital,
+  flushWebVitals,
+  setWebVitalSink,
+  type WebVitalSink,
+} from './report';

--- a/frontend/lib/web-vitals/report.ts
+++ b/frontend/lib/web-vitals/report.ts
@@ -16,10 +16,24 @@ export function setWebVitalSink(sink: WebVitalSink | null) {
   extraSink = sink;
 }
 
-function postToApi(payload: WebVitalPayload) {
-  if (typeof window === 'undefined') return;
+// ── Batching ────────────────────────────────────────────────────────────────
+// Metrics finalize one at a time (LCP, CLS, INP, ...), but sending each as
+// its own HTTP request multiplies network overhead for no benefit - the
+// server doesn't need to know the instant one lands. Queue them and flush
+// as a single request, either after a short coalescing window or
+// immediately when the page is hidden/unloaded, since late-finalizing
+// metrics like CLS often only settle right as the user navigates away.
 
-  const body = JSON.stringify(payload);
+const FLUSH_DELAY_MS = 300;
+const MAX_BATCH_SIZE = 10;
+
+let queue: WebVitalPayload[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function sendBatch(batch: WebVitalPayload[]) {
+  if (typeof window === 'undefined' || batch.length === 0) return;
+
+  const body = JSON.stringify(batch);
 
   try {
     if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
@@ -41,8 +55,34 @@ function postToApi(payload: WebVitalPayload) {
   });
 }
 
+/** Flush any queued metrics immediately, as a single batched request. */
+export function flushWebVitals() {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  if (queue.length === 0) return;
+
+  const batch = queue;
+  queue = [];
+  sendBatch(batch);
+}
+
+function scheduleFlush() {
+  if (flushTimer !== null) return;
+  flushTimer = setTimeout(flushWebVitals, FLUSH_DELAY_MS);
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flushWebVitals();
+  });
+  window.addEventListener('pagehide', flushWebVitals);
+}
+
 /**
  * Report a single Web Vital. Safe for production: no PII, non-throwing.
+ * Queued and sent to the server in a batch rather than one request per metric.
  */
 export function reportWebVital(
   metric: RawWebVitalMetric,
@@ -72,7 +112,12 @@ export function reportWebVital(
     }
   }
 
-  postToApi(payload);
+  queue.push(payload);
+  if (queue.length >= MAX_BATCH_SIZE) {
+    flushWebVitals();
+  } else {
+    scheduleFlush();
+  }
 
   return payload;
 }


### PR DESCRIPTION
## Summary

Closes #1461.

`reportWebVital()` (`frontend/lib/web-vitals/report.ts`) sent its own `sendBeacon`/`fetch` POST to `/api/web-vitals` for every metric individually. `next/web-vitals`'s `useReportWebVitals` fires once per metric as each one finalizes (LCP, CLS, INP, TTFB, FCP, plus Next.js-specific timings in dev), so a single page load could fire 5-8 separate HTTP requests purely for telemetry the server didn't need instantly.

- Metrics are now queued client-side and flushed as a single batched request: after a 300ms coalescing window, immediately once 10 metrics accumulate (safety cap so the queue can't grow unbounded), or immediately on `visibilitychange`/`pagehide` - important since CLS in particular often only finalizes right as the user navigates away, and the old code relied on that same moment to fire its (now-batched) beacon.
- `POST /api/web-vitals` now accepts either a single metric object (unchanged shape, for backward compatibility with any other caller) or an array. Each item is validated independently, so one malformed metric doesn't drop an otherwise-valid batch - only a fully-invalid body is rejected.
- No change to the PII-sanitization path (`toWebVitalPayload`/`sanitizeRoute`) - every item in a batch still gets sanitized server-side exactly as before.

## Test plan
- [x] `pnpm exec vitest run __tests__/lib/web-vitals.test.ts __tests__/app/api/web-vitals.route.test.ts` - 16/16 passing (new cases: batching multiple metrics into one request, flush-on-hidden, size-cap flush, batch payload accepted, partial-invalid batch keeps valid items, all-invalid/empty batch rejected)
- [x] `pnpm exec tsc --noEmit` - no new errors (pre-existing unrelated errors in other test files untouched by this change)
- [x] `pnpm exec eslint` on all changed files - no errors