### PR TITLE
feat: migrate ad hoc form validation to shared zod schemas with zodResolver

### DIFF
--- a/frontend/__tests__/components/properties/PropertyInquiryModal.test.tsx
+++ b/frontend/__tests__/components/properties/PropertyInquiryModal.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PropertyInquiryModal } from '@/components/properties/PropertyInquiryModal';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/properties',
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuth: () => ({ user: null, isAuthenticated: false }),
+}));
+
+vi.mock('@/components/ui', () => ({
+  notify: { success: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PropertyInquiryModal', () => {
+  it('shows sign-in prompt when user is not authenticated', () => {
+    render(
+      <PropertyInquiryModal
+        isOpen={true}
+        onClose={vi.fn()}
+        propertyTitle="Test Property"
+      />,
+    );
+    expect(screen.getByText('Sign in required')).toBeDefined();
+  });
+});

--- a/frontend/__tests__/components/user/MaintenanceForm.test.tsx
+++ b/frontend/__tests__/components/user/MaintenanceForm.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MaintenanceForm } from '@/components/user/MaintenanceForm';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: () => ({ user: null }),
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('MaintenanceForm', () => {
+  it('renders the form title', () => {
+    render(<MaintenanceForm />);
+    expect(screen.getByText('New Maintenance Request')).toBeDefined();
+  });
+
+  it('shows validation error for empty title on submit', async () => {
+    render(<MaintenanceForm />);
+    fireEvent.click(screen.getByText('Submit Request'));
+    await waitFor(() => {
+      expect(screen.getByText('Title is required')).toBeDefined();
+    });
+  });
+
+  it('shows validation error for empty description on submit', async () => {
+    render(<MaintenanceForm />);
+    fireEvent.click(screen.getByText('Submit Request'));
+    await waitFor(() => {
+      expect(screen.getByText('Description is required')).toBeDefined();
+    });
+  });
+});

--- a/frontend/components/communication/ContactForm.tsx
+++ b/frontend/components/communication/ContactForm.tsx
@@ -3,21 +3,12 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2, Mail, MessageSquare, Phone, Send, User } from 'lucide-react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
+import {
+  contactSchema,
+  type ContactFormData,
+} from '@/lib/validation/forms';
 
-const contactSchema = z.object({
-  name: z.string().min(2, 'Enter your name'),
-  email: z.email('Enter a valid email address'),
-  phone: z
-    .string()
-    .min(7, 'Enter a valid phone number')
-    .optional()
-    .or(z.literal('')),
-  subject: z.string().min(4, 'Enter a subject'),
-  message: z.string().min(12, 'Message should be at least 12 characters'),
-});
-
-export type ContactFormData = z.infer<typeof contactSchema>;
+export type { ContactFormData };
 
 interface ContactFormProps {
   onSubmit: (data: ContactFormData) => Promise<void>;

--- a/frontend/components/modals/DisputeFilingModal.tsx
+++ b/frontend/components/modals/DisputeFilingModal.tsx
@@ -3,12 +3,15 @@
 import React from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { AlertTriangle, Scale } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BaseModal } from './BaseModal';
 import { Uploader } from '@/components/ui/Uploader';
 import type { DisputeType } from '@/lib/dashboard-data';
+import {
+  disputeFilingSchema,
+  type DisputeFilingFormData,
+} from '@/lib/validation/forms';
 
 const disputeTypes: { value: DisputeType; label: string }[] = [
   { value: 'RENT_PAYMENT', label: 'Rent Payment' },
@@ -19,30 +22,7 @@ const disputeTypes: { value: DisputeType; label: string }[] = [
   { value: 'OTHER', label: 'Other' },
 ];
 
-const schema = z.object({
-  agreementId: z.string().min(1, 'Agreement ID is required'),
-  disputeType: z.enum([
-    'RENT_PAYMENT',
-    'SECURITY_DEPOSIT',
-    'PROPERTY_DAMAGE',
-    'MAINTENANCE',
-    'TERMINATION',
-    'OTHER',
-  ]),
-  description: z
-    .string()
-    .min(20, 'Description must be at least 20 characters')
-    .max(2000, 'Description cannot exceed 2000 characters'),
-  requestedAmount: z
-    .string()
-    .optional()
-    .refine(
-      (val) => !val || (!isNaN(Number(val)) && Number(val) > 0),
-      'Must be a positive number',
-    ),
-});
-
-type FormValues = z.infer<typeof schema>;
+type FormValues = DisputeFilingFormData;
 
 export interface DisputeFilingData {
   agreementId: string;
@@ -74,7 +54,7 @@ export const DisputeFilingModal: React.FC<DisputeFilingModalProps> = ({
     control,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
-    resolver: zodResolver(schema),
+    resolver: zodResolver(disputeFilingSchema),
     defaultValues: {
       agreementId,
       disputeType: 'MAINTENANCE',

--- a/frontend/components/properties/PropertyInquiryModal.tsx
+++ b/frontend/components/properties/PropertyInquiryModal.tsx
@@ -1,23 +1,26 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { LogIn } from 'lucide-react';
 import { BaseModal } from '@/components/modals/BaseModal';
 import { notify } from '@/components/ui';
 import { useAuth } from '@/store/authStore';
-import type { PropertyInquiryData } from '@/components/modals/types';
+import {
+  propertyInquirySchema,
+  type PropertyInquiryFormData,
+} from '@/lib/validation/forms';
 
 interface PropertyInquiryModalProps {
   isOpen: boolean;
   onClose: () => void;
   propertyId?: string;
   propertyTitle?: string;
-  onSubmit?: (data: PropertyInquiryData) => Promise<void>;
+  onSubmit?: (data: PropertyInquiryFormData) => Promise<void>;
 }
-
-type FormErrors = Partial<Record<keyof PropertyInquiryData, string>>;
 
 export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
   isOpen,
@@ -26,16 +29,6 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
   propertyTitle = 'this property',
   onSubmit,
 }) => {
-  const [form, setForm] = useState<PropertyInquiryData>({
-    propertyId,
-    propertyTitle,
-    name: '',
-    email: '',
-    phone: '',
-    message: '',
-  });
-  const [errors, setErrors] = useState<FormErrors>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const { user, isAuthenticated } = useAuth();
   const pathname = usePathname();
 
@@ -45,16 +38,30 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
     [propertyTitle],
   );
 
-  React.useEffect(() => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<PropertyInquiryFormData>({
+    resolver: zodResolver(propertyInquirySchema),
+    defaultValues: {
+      propertyId,
+      propertyTitle,
+      name: '',
+      email: '',
+      phone: '',
+      message: initialMessage,
+    },
+  });
+
+  useEffect(() => {
     if (!isOpen) return;
-    // Pre-fill from the signed-in account so returning users don't retype
-    // their own details; still editable for anyone sending on someone
-    // else's behalf, and blank for guests.
     const knownName =
       isAuthenticated && user
         ? `${user.firstName} ${user.lastName}`.trim()
         : '';
-    setForm({
+    reset({
       propertyId,
       propertyTitle,
       name: knownName,
@@ -62,45 +69,7 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
       phone: '',
       message: initialMessage,
     });
-    setErrors({});
-  }, [
-    initialMessage,
-    isOpen,
-    propertyId,
-    propertyTitle,
-    isAuthenticated,
-    user,
-  ]);
-
-  const validate = () => {
-    const nextErrors: FormErrors = {};
-    if (!form.name.trim()) nextErrors.name = 'Name is required';
-    if (!form.email.trim()) nextErrors.email = 'Email is required';
-    if (form.email && !/^\S+@\S+\.\S+$/.test(form.email)) {
-      nextErrors.email = 'Enter a valid email address';
-    }
-    if (!form.message.trim()) nextErrors.message = 'Message is required';
-    setErrors(nextErrors);
-    return Object.keys(nextErrors).length === 0;
-  };
-
-  const handleSubmit = async () => {
-    if (!onSubmit) return;
-    if (!validate()) return;
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(form);
-      notify.success('Inquiry sent successfully');
-      onClose();
-    } catch (error) {
-      notify.error(
-        error instanceof Error ? error.message : 'Failed to send inquiry',
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  }, [isOpen, propertyId, propertyTitle, initialMessage, isAuthenticated, user, reset]);
 
   if (!isAuthenticated) {
     const loginHref = `/login?next=${encodeURIComponent(pathname || '/properties')}`;
@@ -140,6 +109,19 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
     );
   }
 
+  const onFormSubmit = async (data: PropertyInquiryFormData) => {
+    if (!onSubmit) return;
+    try {
+      await onSubmit(data);
+      notify.success('Inquiry sent successfully');
+      onClose();
+    } catch (error) {
+      notify.error(
+        error instanceof Error ? error.message : 'Failed to send inquiry',
+      );
+    }
+  };
+
   return (
     <BaseModal
       isOpen={isOpen}
@@ -158,7 +140,7 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
           </button>
           <button
             type="button"
-            onClick={handleSubmit}
+            onClick={handleSubmit(onFormSubmit)}
             disabled={isSubmitting}
             className="rounded-xl bg-brand-blue px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
           >
@@ -173,15 +155,12 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
             Name *
           </label>
           <input
-            value={form.name}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, name: e.target.value }))
-            }
+            {...register('name')}
             className="w-full rounded-xl border border-neutral-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
             placeholder="Your full name"
           />
           {errors.name && (
-            <p className="mt-1 text-xs text-red-600">{errors.name}</p>
+            <p className="mt-1 text-xs text-red-600">{errors.name.message}</p>
           )}
         </div>
         <div>
@@ -190,15 +169,12 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
           </label>
           <input
             type="email"
-            value={form.email}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, email: e.target.value }))
-            }
+            {...register('email')}
             className="w-full rounded-xl border border-neutral-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
             placeholder="name@email.com"
           />
           {errors.email && (
-            <p className="mt-1 text-xs text-red-600">{errors.email}</p>
+            <p className="mt-1 text-xs text-red-600">{errors.email.message}</p>
           )}
         </div>
         <div>
@@ -206,10 +182,7 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
             Phone
           </label>
           <input
-            value={form.phone}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, phone: e.target.value }))
-            }
+            {...register('phone')}
             className="w-full rounded-xl border border-neutral-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
             placeholder="+1 555 123 4567"
           />
@@ -219,15 +192,14 @@ export const PropertyInquiryModal: React.FC<PropertyInquiryModalProps> = ({
             Message *
           </label>
           <textarea
-            value={form.message}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, message: e.target.value }))
-            }
+            {...register('message')}
             rows={5}
             className="w-full rounded-xl border border-neutral-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
           />
           {errors.message && (
-            <p className="mt-1 text-xs text-red-600">{errors.message}</p>
+            <p className="mt-1 text-xs text-red-600">
+              {errors.message.message}
+            </p>
           )}
         </div>
       </div>

--- a/frontend/components/user/MaintenanceForm.tsx
+++ b/frontend/components/user/MaintenanceForm.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2, Upload, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -15,6 +17,10 @@ import {
 } from '@/components/ui/select';
 import { MaintenancePriority } from '@/lib/query/hooks/use-landlord-maintenance';
 import { useAuthStore } from '@/store/authStore';
+import {
+  maintenanceSchema,
+  type MaintenanceFormData,
+} from '@/lib/validation/forms';
 
 interface MaintenanceFormProps {
   propertyId?: string;
@@ -33,19 +39,23 @@ export function MaintenanceForm({
 }: MaintenanceFormProps) {
   const router = useRouter();
   const { user } = useAuthStore();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [formData, setFormData] = useState({
-    title: '',
-    description: '',
-    priority: 'MEDIUM' as MaintenancePriority,
-    propertyId: propertyId || '',
-    propertyName: propertyName || '',
-  });
   const [photos, setPhotos] = useState<File[]>([]);
 
-  const handleInputChange = (field: string, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-  };
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<MaintenanceFormData>({
+    resolver: zodResolver(maintenanceSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+      priority: 'MEDIUM' as MaintenancePriority,
+      propertyId: propertyId || '',
+      propertyName: propertyName || '',
+    },
+  });
 
   const handlePhotoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -58,10 +68,7 @@ export function MaintenanceForm({
     setPhotos((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!formData.title.trim() || !formData.description.trim()) return;
-
+  const onSubmit = async (data: MaintenanceFormData) => {
     setIsSubmitting(true);
     try {
       // In a real implementation, this would call the API
@@ -81,7 +88,7 @@ export function MaintenanceForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className={`space-y-6 ${className}`}>
+    <form onSubmit={handleSubmit(onSubmit)} className={`space-y-6 ${className}`}>
       <div className="bg-white rounded-3xl p-8 border border-neutral-100 shadow-sm">
         <h2 className="text-2xl font-bold text-neutral-900 mb-6">
           New Maintenance Request
@@ -98,12 +105,13 @@ export function MaintenanceForm({
             </label>
             <Input
               id="title"
+              {...register('title')}
               placeholder="Brief description of the issue"
-              value={formData.title}
-              onChange={(e) => handleInputChange('title', e.target.value)}
-              required
               className="w-full"
             />
+            {errors.title && (
+              <p className="text-xs text-red-600">{errors.title.message}</p>
+            )}
           </div>
 
           {/* Description */}
@@ -116,12 +124,15 @@ export function MaintenanceForm({
             </label>
             <Textarea
               id="description"
+              {...register('description')}
               placeholder="Provide detailed information about the maintenance issue..."
-              value={formData.description}
-              onChange={(e) => handleInputChange('description', e.target.value)}
-              required
               className="min-h-[150px] resize-none"
             />
+            {errors.description && (
+              <p className="text-xs text-red-600">
+                {errors.description.message}
+              </p>
+            )}
           </div>
 
           {/* Priority */}
@@ -133,8 +144,12 @@ export function MaintenanceForm({
               Priority
             </label>
             <Select
-              value={formData.priority}
-              onValueChange={(value) => handleInputChange('priority', value)}
+              defaultValue="MEDIUM"
+              onValueChange={(value) =>
+                setValue('priority', value as MaintenancePriority, {
+                  shouldValidate: true,
+                })
+              }
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select priority" />
@@ -159,11 +174,8 @@ export function MaintenanceForm({
               </label>
               <Input
                 id="property"
+                {...register('propertyName')}
                 placeholder="Property name or address"
-                value={formData.propertyName}
-                onChange={(e) =>
-                  handleInputChange('propertyName', e.target.value)
-                }
                 className="w-full"
               />
             </div>
@@ -233,14 +245,7 @@ export function MaintenanceForm({
             Cancel
           </Button>
         )}
-        <Button
-          type="submit"
-          disabled={
-            isSubmitting ||
-            !formData.title.trim() ||
-            !formData.description.trim()
-          }
-        >
+        <Button type="submit" disabled={isSubmitting}>
           {isSubmitting ? (
             <>
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />

--- a/frontend/components/user/TenantOnboardingWizard.tsx
+++ b/frontend/components/user/TenantOnboardingWizard.tsx
@@ -28,6 +28,11 @@ import {
 } from '@/lib/tenant-onboarding';
 import { trackTenantOnboardingEvent } from '@/lib/onboarding-analytics';
 import { useOnboardingContext } from '@/contexts/OnboardingContext';
+import {
+  tenantOnboardingProfileSchema,
+  tenantOnboardingSearchSchema,
+  tenantOnboardingDiscoverySchema,
+} from '@/lib/validation/forms';
 
 const TOTAL_STEPS = 4;
 
@@ -606,13 +611,13 @@ export function TenantOnboardingWizard() {
   const canGoNext = useMemo(() => {
     if (step === 0) return true; // profile is optional, can skip
     if (step === 1) return true; // preferences always valid
-    if (step === 2) return data.search.savedSearchCity.trim() !== '';
+    if (step === 2) {
+      const result = tenantOnboardingSearchSchema.safeParse(data.search);
+      return result.success;
+    }
     if (step === 3) {
-      return (
-        data.discovery.paymentsAcknowledged &&
-        data.discovery.disputesAcknowledged &&
-        data.discovery.blockchainAcknowledged
-      );
+      const result = tenantOnboardingDiscoverySchema.safeParse(data.discovery);
+      return result.success;
     }
     return true;
   }, [data, step]);

--- a/frontend/lib/validation/__tests__/forms.validation.test.ts
+++ b/frontend/lib/validation/__tests__/forms.validation.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import {
+  maintenanceSchema,
+  contactSchema,
+  propertyInquirySchema,
+  disputeFilingSchema,
+  tenantOnboardingSearchSchema,
+  tenantOnboardingDiscoverySchema,
+} from '@/lib/validation/forms';
+
+describe('maintenanceSchema', () => {
+  const valid = {
+    title: 'Broken faucet',
+    description: 'The kitchen faucet is leaking water steadily.',
+    priority: 'MEDIUM',
+    propertyId: '',
+    propertyName: 'Apartment 4B',
+  };
+
+  it('accepts a valid maintenance request', () => {
+    expect(maintenanceSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects a missing title with message', () => {
+    const result = maintenanceSchema.safeParse({
+      ...valid,
+      title: '',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'title');
+      expect(issue?.message).toBe('Title is required');
+    }
+  });
+
+  it('rejects a missing description with message', () => {
+    const result = maintenanceSchema.safeParse({
+      ...valid,
+      description: '',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === 'description',
+      );
+      expect(issue?.message).toBe('Description is required');
+    }
+  });
+
+  it('rejects an invalid priority enum value', () => {
+    const result = maintenanceSchema.safeParse({
+      ...valid,
+      priority: 'CRITICAL',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('contactSchema', () => {
+  const valid = {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    phone: '',
+    subject: 'Property inquiry',
+    message: 'I would like more information about the apartment.',
+  };
+
+  it('accepts a valid contact submission', () => {
+    expect(contactSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects an invalid email with message', () => {
+    const result = contactSchema.safeParse({
+      ...valid,
+      email: 'not-an-email',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'email');
+      expect(issue?.message).toBe('Enter a valid email address');
+    }
+  });
+
+  it('rejects a short name with message', () => {
+    const result = contactSchema.safeParse({ ...valid, name: 'J' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'name');
+      expect(issue?.message).toBe('Enter your name');
+    }
+  });
+
+  it('rejects a short message with message', () => {
+    const result = contactSchema.safeParse({ ...valid, message: 'hi' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'message');
+      expect(issue?.message).toBe(
+        'Message should be at least 12 characters',
+      );
+    }
+  });
+});
+
+describe('propertyInquirySchema', () => {
+  const valid = {
+    propertyId: 'prop-1',
+    propertyTitle: 'Ocean View Loft',
+    name: 'John Smith',
+    email: 'john@example.com',
+    phone: '',
+    message: 'Hello, I am interested in this property.',
+  };
+
+  it('accepts a valid inquiry', () => {
+    expect(propertyInquirySchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects a missing name with message', () => {
+    const result = propertyInquirySchema.safeParse({ ...valid, name: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'name');
+      expect(issue?.message).toBe('Name is required');
+    }
+  });
+
+  it('rejects an invalid email with message', () => {
+    const result = propertyInquirySchema.safeParse({
+      ...valid,
+      email: 'bad-email',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'email');
+      expect(issue?.message).toBe('Enter a valid email address');
+    }
+  });
+
+  it('rejects a too-short message with message', () => {
+    const result = propertyInquirySchema.safeParse({
+      ...valid,
+      message: 'short',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('disputeFilingSchema', () => {
+  const valid = {
+    agreementId: 'ag-123',
+    disputeType: 'MAINTENANCE',
+    description:
+      'The landlord failed to fix the broken water heater for over two weeks despite multiple requests.',
+    requestedAmount: '',
+  };
+
+  it('accepts a valid dispute filing', () => {
+    expect(disputeFilingSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects a missing agreementId with message', () => {
+    const result = disputeFilingSchema.safeParse({
+      ...valid,
+      agreementId: '',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === 'agreementId',
+      );
+      expect(issue?.message).toBe('Agreement ID is required');
+    }
+  });
+
+  it('rejects a too-short description with message', () => {
+    const result = disputeFilingSchema.safeParse({
+      ...valid,
+      description: 'Too short',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === 'description',
+      );
+      expect(issue?.message).toBe(
+        'Description must be at least 20 characters',
+      );
+    }
+  });
+
+  it('rejects a negative requested amount', () => {
+    const result = disputeFilingSchema.safeParse({
+      ...valid,
+      requestedAmount: '-5',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid disputeType enum', () => {
+    const result = disputeFilingSchema.safeParse({
+      ...valid,
+      disputeType: 'FAKE_TYPE',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('tenantOnboardingSearchSchema', () => {
+  it('accepts a city entry', () => {
+    const result = tenantOnboardingSearchSchema.safeParse({
+      savedSearchCity: 'Lagos',
+      notificationsEnabled: true,
+      searchRadius: '10',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty city with message', () => {
+    const result = tenantOnboardingSearchSchema.safeParse({
+      savedSearchCity: '',
+      notificationsEnabled: true,
+      searchRadius: '10',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === 'savedSearchCity',
+      );
+      expect(issue?.message).toBe('Please enter a city or neighborhood');
+    }
+  });
+});
+
+describe('tenantOnboardingDiscoverySchema', () => {
+  const allAcknowledged = {
+    paymentsAcknowledged: true,
+    disputesAcknowledged: true,
+    blockchainAcknowledged: true,
+  };
+
+  it('accepts when all features are acknowledged', () => {
+    expect(
+      tenantOnboardingDiscoverySchema.safeParse(allAcknowledged).success,
+    ).toBe(true);
+  });
+
+  it('rejects when payments are not acknowledged with message', () => {
+    const result = tenantOnboardingDiscoverySchema.safeParse({
+      ...allAcknowledged,
+      paymentsAcknowledged: false,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === 'paymentsAcknowledged',
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain('instant rent payments');
+    }
+  });
+
+  it('rejects when disputes are not acknowledged', () => {
+    const result = tenantOnboardingDiscoverySchema.safeParse({
+      ...allAcknowledged,
+      disputesAcknowledged: false,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/lib/validation/forms.ts
+++ b/frontend/lib/validation/forms.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { z } from 'zod';
+
+// ─── Maintenance Form ──────────────────────────────────────────────────────────
+
+export const maintenanceSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200, 'Title cannot exceed 200 characters'),
+  description: z.string().min(1, 'Description is required').max(2000, 'Description cannot exceed 2000 characters'),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'URGENT']),
+  propertyId: z.string().optional(),
+  propertyName: z.string().optional(),
+});
+
+export type MaintenanceFormData = z.infer<typeof maintenanceSchema>;
+
+// ─── Contact Form ──────────────────────────────────────────────────────────────
+
+export const contactSchema = z.object({
+  name: z.string().min(2, 'Enter your name'),
+  email: z.string().email('Enter a valid email address'),
+  phone: z
+    .string()
+    .min(7, 'Enter a valid phone number')
+    .optional()
+    .or(z.literal('')),
+  subject: z.string().min(4, 'Enter a subject'),
+  message: z.string().min(12, 'Message should be at least 12 characters'),
+});
+
+export type ContactFormData = z.infer<typeof contactSchema>;
+
+// ─── Property Inquiry Form ─────────────────────────────────────────────────────
+
+export const propertyInquirySchema = z.object({
+  propertyId: z.string().optional(),
+  propertyTitle: z.string().optional(),
+  name: z.string().min(1, 'Name is required').max(100, 'Name cannot exceed 100 characters'),
+  email: z.string().email('Enter a valid email address'),
+  phone: z.string().optional().or(z.literal('')),
+  message: z.string().min(10, 'Message must be at least 10 characters'),
+});
+
+export type PropertyInquiryFormData = z.infer<typeof propertyInquirySchema>;
+
+// ─── Dispute Filing Form ───────────────────────────────────────────────────────
+
+export const disputeFilingSchema = z.object({
+  agreementId: z.string().min(1, 'Agreement ID is required'),
+  disputeType: z.enum([
+    'RENT_PAYMENT',
+    'SECURITY_DEPOSIT',
+    'PROPERTY_DAMAGE',
+    'MAINTENANCE',
+    'TERMINATION',
+    'OTHER',
+  ]),
+  description: z
+    .string()
+    .min(20, 'Description must be at least 20 characters')
+    .max(2000, 'Description cannot exceed 2000 characters'),
+  requestedAmount: z
+    .string()
+    .optional()
+    .refine(
+      (val) => !val || (!isNaN(Number(val)) && Number(val) > 0),
+      'Must be a positive number',
+    ),
+});
+
+export type DisputeFilingFormData = z.infer<typeof disputeFilingSchema>;
+
+// ─── Tenant Onboarding Form ────────────────────────────────────────────────────
+
+export const tenantOnboardingProfileSchema = z.object({
+  phone: z.string().optional().or(z.literal('')),
+  bio: z.string().max(300, 'Bio cannot exceed 300 characters').optional().or(z.literal('')),
+  location: z.string().optional().or(z.literal('')),
+});
+
+export const tenantOnboardingSearchSchema = z.object({
+  savedSearchCity: z.string().min(1, 'Please enter a city or neighborhood'),
+  notificationsEnabled: z.boolean(),
+  searchRadius: z.string().optional(),
+});
+
+export const tenantOnboardingDiscoverySchema = z.object({
+  paymentsAcknowledged: z
+    .boolean()
+    .refine(
+      (val) => val === true,
+      'Please acknowledge the instant rent payments feature',
+    ),
+  disputesAcknowledged: z
+    .boolean()
+    .refine(
+      (val) => val === true,
+      'Please acknowledge the dispute resolution feature',
+    ),
+  blockchainAcknowledged: z
+    .boolean()
+    .refine(
+      (val) => val === true,
+      'Please acknowledge the blockchain lease agreements feature',
+    ),
+});


### PR DESCRIPTION
## Summary

Consolidates ad hoc form validation across the frontend into a shared `zod` schema directory, as described in #1555.

### Changes

- **`frontend/lib/validation/forms.ts`** — New shared directory with reusable zod schemas for all migrated forms (`maintenanceSchema`, `contactSchema`, `propertyInquirySchema`, `disputeFilingSchema`, `tenantOnboardingSearchSchema`, `tenantOnboardingDiscoverySchema`)
- **`frontend/components/user/MaintenanceForm.tsx`** — Migrated from `useState` + manual inline validation (`if (!title.trim()) return`) to `react-hook-form` + `zodResolver`
- **`frontend/components/properties/PropertyInquiryModal.tsx`** — Migrated from `useState` + manual `validate()` function with regex to `react-hook-form` + `zodResolver`
- **`frontend/components/communication/ContactForm.tsx`** — Extracted inline `z.object({...})` schema to shared `contactSchema`
- **`frontend/components/modals/DisputeFilingModal.tsx`** — Extracted inline `z.object({...})` schema to shared `disputeFilingSchema`
- **`frontend/components/user/TenantOnboardingWizard.tsx`** — Replaced hardcoded step-gating checks (`savedSearchCity.trim() !== ''`, boolean `&&` chain) with `safeParse` against shared `tenantOnboardingSearchSchema` and `tenantOnboardingDiscoverySchema`
- **Validation error messaging** — All migrated forms use consistent inline error display (matching `errors.field.message` pattern)
- **Tests** — 22 validation unit tests covering each schema's accept/reject behaviour, plus component tests for `MaintenanceForm` and `PropertyInquiryModal`

### Testing

```bash
cd frontend && npx vitest run lib/validation/__tests__/forms.validation.test.ts
# → 22 passed
```

Closes #1555