### PR TITLE
feat: add RouteErrorBoundary/RouteLoading shared templates and route-group error/loading boundaries

### DIFF
--- a/frontend/app/(auth)/error.tsx
+++ b/frontend/app/(auth)/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function AuthRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="(auth)" label="Authentication" homeHref="/login" />;
+}

--- a/frontend/app/(auth)/loading.tsx
+++ b/frontend/app/(auth)/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function AuthRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/admin/error.tsx
+++ b/frontend/app/admin/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function AdminRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="admin" label="Admin" homeHref="/admin" />;
+}

--- a/frontend/app/admin/loading.tsx
+++ b/frontend/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function AdminRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/developer/error.tsx
+++ b/frontend/app/developer/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function DeveloperRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="developer" label="Developer" homeHref="/developer" />;
+}

--- a/frontend/app/developer/loading.tsx
+++ b/frontend/app/developer/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function DeveloperRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/guest/error.tsx
+++ b/frontend/app/guest/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function GuestRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="guest" label="Guest" homeHref="/guest" />;
+}

--- a/frontend/app/guest/loading.tsx
+++ b/frontend/app/guest/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function GuestRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/host/error.tsx
+++ b/frontend/app/host/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function HostRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="host" label="Host" homeHref="/host" />;
+}

--- a/frontend/app/host/loading.tsx
+++ b/frontend/app/host/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function HostRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/messages/error.tsx
+++ b/frontend/app/messages/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function MessagesRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="messages" label="Messaging" homeHref="/messages" />;
+}

--- a/frontend/app/messages/loading.tsx
+++ b/frontend/app/messages/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function MessagesRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/modals-demo/error.tsx
+++ b/frontend/app/modals-demo/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function ModalsDemoRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="modals-demo" label="Modals demo" homeHref="/modals-demo" />;
+}

--- a/frontend/app/modals-demo/loading.tsx
+++ b/frontend/app/modals-demo/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function ModalsDemoRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/offline/error.tsx
+++ b/frontend/app/offline/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function OfflineRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="offline" label="Offline" homeHref="/offline" />;
+}

--- a/frontend/app/offline/loading.tsx
+++ b/frontend/app/offline/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function OfflineRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/privacy/error.tsx
+++ b/frontend/app/privacy/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function PrivacyRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="privacy" label="Privacy" homeHref="/privacy" />;
+}

--- a/frontend/app/privacy/loading.tsx
+++ b/frontend/app/privacy/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function PrivacyRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/properties/error.tsx
+++ b/frontend/app/properties/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function PropertiesRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="properties" label="Properties" homeHref="/properties" />;
+}

--- a/frontend/app/properties/loading.tsx
+++ b/frontend/app/properties/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function PropertiesRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/reset-password/error.tsx
+++ b/frontend/app/reset-password/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function ResetPasswordRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="reset-password" label="Password reset" homeHref="/reset-password" />;
+}

--- a/frontend/app/reset-password/loading.tsx
+++ b/frontend/app/reset-password/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function ResetPasswordRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/resources/error.tsx
+++ b/frontend/app/resources/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function ResourcesRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="resources" label="Resources" homeHref="/resources" />;
+}

--- a/frontend/app/resources/loading.tsx
+++ b/frontend/app/resources/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function ResourcesRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/settings/error.tsx
+++ b/frontend/app/settings/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function SettingsRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="settings" label="Settings" homeHref="/settings" />;
+}

--- a/frontend/app/settings/loading.tsx
+++ b/frontend/app/settings/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function SettingsRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/stays/error.tsx
+++ b/frontend/app/stays/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function StaysRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="stays" label="Stays" homeHref="/stays" />;
+}

--- a/frontend/app/stays/loading.tsx
+++ b/frontend/app/stays/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function StaysRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/sublet/error.tsx
+++ b/frontend/app/sublet/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function SubletRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="sublet" label="Sublet" homeHref="/sublet" />;
+}

--- a/frontend/app/sublet/loading.tsx
+++ b/frontend/app/sublet/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function SubletRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/terms/error.tsx
+++ b/frontend/app/terms/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function TermsRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="terms" label="Terms" homeHref="/terms" />;
+}

--- a/frontend/app/terms/loading.tsx
+++ b/frontend/app/terms/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function TermsRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/verify-email/error.tsx
+++ b/frontend/app/verify-email/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function VerifyEmailRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="verify-email" label="Email verification" homeHref="/verify-email" />;
+}

--- a/frontend/app/verify-email/loading.tsx
+++ b/frontend/app/verify-email/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function VerifyEmailRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/app/vitals/error.tsx
+++ b/frontend/app/vitals/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import type { RouteErrorBoundaryProps } from '@/components/error/RouteErrorBoundary';
+
+export default function VitalsRouteError(props: RouteErrorBoundaryProps) {
+  return <RouteErrorBoundary {...props} section="vitals" label="Vitals" homeHref="/vitals" />;
+}

--- a/frontend/app/vitals/loading.tsx
+++ b/frontend/app/vitals/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/loading/RouteLoading';
+
+export default function VitalsRouteLoading() {
+  return <RouteLoading cards={3} />;
+}

--- a/frontend/components/error/RouteErrorBoundary.tsx
+++ b/frontend/components/error/RouteErrorBoundary.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+import ErrorFallback from '@/components/error/ErrorFallback';
+import { classifyUnknownError, logError } from '@/lib/errors';
+
+export type RouteErrorBoundaryProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  /** Route group key, e.g. 'admin', 'host', 'sublet'. Used for logging and the default home link. */
+  section: string;
+  /** Human-readable section label, e.g. 'Admin area'. Defaults to a formatted version of `section`. */
+  label?: string;
+  /** Home href for the "Go to safety" link. Defaults to `/${section}`. */
+  homeHref?: string;
+};
+
+/**
+ * Shared error boundary for top-level route groups.
+ *
+ * Drop into any `app/<section>/error.tsx` to get a consistent error UI with
+ * section-appropriate messaging, a retry button, and a "Go to safety" link
+ * that navigates to the section's home.
+ *
+ * Usage:
+ *   ```tsx
+ *   import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+ *   export default function AdminRouteError(props: import('@/components/error/RouteErrorBoundary').RouteErrorBoundaryProps) {
+ *     return <RouteErrorBoundary {...props} section="admin" label="Admin area" />;
+ *   }
+ *   ```
+ */
+export default function RouteErrorBoundary({
+  error,
+  reset,
+  section,
+  label,
+  homeHref,
+}: RouteErrorBoundaryProps) {
+  const sectionLabel = label ?? section.charAt(0).toUpperCase() + section.slice(1);
+  const appError = classifyUnknownError(error, {
+    source: `app/${section}/error.tsx`,
+    action: `render-${section}-error`,
+    route: `/${section}`,
+  });
+
+  useEffect(() => {
+    logError(appError, appError.context);
+  }, [appError]);
+
+  return (
+    <ErrorFallback
+      title={`${sectionLabel} area error`}
+      description={appError.userMessage}
+      error={error}
+      retry={reset}
+      severity={appError.severity}
+      homeHref={homeHref ?? `/${section}`}
+    />
+  );
+}

--- a/frontend/components/error/__tests__/RouteErrorBoundary.test.tsx
+++ b/frontend/components/error/__tests__/RouteErrorBoundary.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RouteErrorBoundary from '@/components/error/RouteErrorBoundary';
+import RouteLoading from '@/components/loading/RouteLoading';
+
+// Regression coverage for issue #1549: every top-level route group must have
+// its own error.tsx / loading.tsx so errors in one section (payments,
+// agreements, disputes) show section-specific messaging instead of bubbling
+// up to the generic root fallback. These tests lock in the behavior of the
+// two shared templates used by those route-group files.
+
+const renderError = (overrides: Record<string, unknown> = {}) =>
+  render(
+    <RouteErrorBoundary
+      error={new Error('boom')}
+      reset={() => {}}
+      section="admin"
+      label="Admin"
+      homeHref="/admin"
+      {...overrides}
+    />,
+  );
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('RouteErrorBoundary', () => {
+  it('renders section-appropriate title and description', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    renderError();
+    expect(screen.getByText('Admin area error')).toBeDefined();
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('renders a retry button that calls reset', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const reset = vi.fn();
+    render(<RouteErrorBoundary error={new Error('x')} reset={reset} section="host" label="Host" homeHref="/host" />);
+    const retry = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(retry);
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('links the "Go to safety" button to the section home', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    renderError();
+    const link = screen.getByRole('link', { name: 'Go to safety' });
+    expect(link.getAttribute('href')).toBe('/admin');
+  });
+
+  it('hides dev-only error detail outside development mode', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    renderError({ error: new Error('<img src=x onerror=alert(1)>') });
+    expect(screen.queryByText('<img src=x onerror=alert(1)>')).toBeNull();
+  });
+
+  it('shows the raw message in development mode for debugging', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    renderError({ error: new Error('dev-only detail') });
+    expect(screen.getByText('dev-only detail')).toBeDefined();
+  });
+});
+
+describe('RouteLoading', () => {
+  it('renders a busy live region with skeleton cards', () => {
+    const { container } = render(<RouteLoading cards={2} />);
+    expect(screen.getByLabelText('Page loading')).toBeDefined();
+    expect(container.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/components/loading/RouteLoading.tsx
+++ b/frontend/components/loading/RouteLoading.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { SkeletonLoader } from '@/components/loading/Skeleton';
+
+export interface RouteLoadingProps {
+  /** Number of card skeletons to show. Defaults to 3. */
+  cards?: number;
+  className?: string;
+}
+
+/**
+ * Shared page-level loading placeholder for route groups.
+ *
+ * Drop into any `app/<section>/loading.tsx` to get a consistent loading state
+ * while the page's data is being fetched.
+ *
+ * Usage:
+ *   ```tsx
+ *   import RouteLoading from '@/components/loading/RouteLoading';
+ *   export default function AdminRouteLoading() {
+ *     return <RouteLoading cards={4} />;
+ *   }
+ *   ```
+ */
+export default function RouteLoading({ cards = 3, className = '' }: RouteLoadingProps) {
+  return (
+    <div className={`space-y-6 p-6 ${className}`} aria-busy="true" aria-label="Page loading">
+      {/* Title skeleton */}
+      <div className="animate-pulse">
+        <div className="h-8 w-48 rounded bg-neutral-200" />
+      </div>
+
+      {/* Loading indicator */}
+      <div className="animate-pulse space-y-4">
+        <div className="h-3 w-96 rounded bg-neutral-200" />
+        <div className="h-3 w-80 rounded bg-neutral-200" />
+      </div>
+
+      {/* Card grid skeletons */}
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: cards }).map((_, i) => (
+          <SkeletonLoader key={i} variant="card" />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add shared `RouteErrorBoundary` and `RouteLoading` template components and wire them into every top-level route group under `frontend/app/` so unhandled errors render section-specific fallbacks instead of bubbling to the generic root page, and navigation shows a consistent loading state.

## Changes

### New shared components
- **`frontend/components/error/RouteErrorBoundary.tsx`** — client component that accepts `section`, `label`, and `homeHref` to render section-appropriate error messaging with a retry button and "Go to safety" link
- **`frontend/components/loading/RouteLoading.tsx`** — skeleton loading placeholder with card grid, title shimmer, and loading indicator

### Route-group files (18 groups × 2 files = 36 files)
Each top-level route group under `frontend/app/` now has its own `error.tsx` and `loading.tsx`:
- `(auth)`, `admin`, `developer`, `guest`, `host`, `messages`, `modals-demo`, `offline`, `privacy`, `properties`, `reset-password`, `resources`, `settings`, `stays`, `sublet`, `terms`, `verify-email`, `vitals`

### Testing
- **`frontend/components/error/__tests__/RouteErrorBoundary.test.tsx`** — 5 tests covering title rendering, retry callback, home link, error detail visibility in dev/prod, and route loading skeleton

Excluded: `api/` (route handlers, no UI), `user/` (already had error.tsx/loading.tsx)

Closes #1549