### PR TITLE
perf(frontend): cache CORS preflight responses for /api routes

### DIFF
--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,7 +1,21 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { proxyToBackend } from '@/lib/api/backend-proxy';
 
 type RouteContext = { params: Promise<{ path: string[] }> };
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': process.env.CORS_ALLOW_ORIGIN ?? '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, X-Requested-With, Idempotency-Key',
+  // Lets browsers cache the preflight for 24h instead of re-sending
+  // an OPTIONS request before every complex call.
+  'Access-Control-Max-Age': '86400',
+};
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
 
 async function handle(request: NextRequest, context: RouteContext) {
   const { path } = await context.params;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -51,13 +51,27 @@ const nextConfig: NextConfig = {
         source: '/api/(.*)',
         headers: [
           {
+            key: 'Access-Control-Allow-Origin',
+            value: process.env.CORS_ALLOW_ORIGIN ?? '*',
+          },
+          {
+            key: 'Vary',
+            value: 'Origin',
+          },
+          {
             key: 'Access-Control-Allow-Methods',
             value: 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
           },
           {
             key: 'Access-Control-Allow-Headers',
             value:
-              'Content-Content, Authorization, X-Requested-With, Idempotency-Key',
+              'Content-Type, Authorization, X-Requested-With, Idempotency-Key',
+          },
+          {
+            // Lets browsers cache preflight responses for 24h instead of
+            // re-sending an OPTIONS request before every complex call.
+            key: 'Access-Control-Max-Age',
+            value: '86400',
           },
         ],
       },


### PR DESCRIPTION
## Summary

Every complex (non-simple) cross-origin request to `/api/*` triggered a fresh OPTIONS preflight, doubling request latency. Preflight responses were not cacheable by browsers:

- The static `/api/(.*)` headers in `next.config.ts` set `Allow-Methods` / `Allow-Headers` but never emitted `Access-Control-Max-Age`, so nothing was cached.
- The catch-all backend proxy (`app/api/[...path]/route.ts`) had no `OPTIONS` export, so preflights were answered with **405 Method Not Allowed** — which browsers treat as an uncacheable/failed preflight.
- Bonus fix: `Access-Control-Allow-Headers` listed `Content-Content` (typo) instead of `Content-Type`, so JSON requests from allowed origins could fail the preflight check outright.

The backend (`backend/src/main.ts`) already sets `maxAge: 86400` and is verified by `test/security.e2e-spec.ts`; this PR closes the equivalent gap on the frontend edge.

## Changes

- `frontend/next.config.ts`
  - Emit `Access-Control-Max-Age: 86400` (24h) for all `/api/*` routes so browsers cache preflight decisions instead of re-sending OPTIONS per request.
  - Emit `Access-Control-Allow-Origin` via new `CORS_ALLOW_ORIGIN` env var (defaults to `*`) plus `Vary: Origin` so caches vary correctly per origin.
  - Fix `Content-Content` → `Content-Type` typo in allowed headers.
- `frontend/app/api/[...path]/route.ts`
  - Export an explicit `OPTIONS` handler returning `204 No Content` with CORS + `Max-Age` headers, replacing the previous 405.

Fixes #1466

## Test plan

- [x] `curl -i -X OPTIONS https://<host>/api/v1/any/path -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST"` → `204` with `Access-Control-Max-Age: 86400`
- [x] Repeat request within cache window → browser sends no second preflight (verified via DevTools network log)
- [x] Existing backend behavior unchanged (`security.e2e-spec.ts` already asserts `Access-Control-Max-Age: 86400`)
- [ ] Set `CORS_ALLOW_ORIGIN=https://app.example.com` in a deployment and confirm credentialed cross-origin calls still pass