### PR TITLE
fix : validate phone number and formatting

### DIFF
--- a/backend/src/common/utils/validation/__tests__/validation.utils.spec.ts
+++ b/backend/src/common/utils/validation/__tests__/validation.utils.spec.ts
@@ -16,15 +16,33 @@ describe('ValidationUtils', () => {
     });
   });
 
-  describe('validatePhone', () => {
-    it('should return true for valid international phones', () => {
-      expect(ValidationUtils.validatePhone('+1234567890')).toBe(true);
-      expect(ValidationUtils.validatePhone('1234567890')).toBe(true);
+  describe('normalizePhoneNumber', () => {
+    it.each([
+      ['08012345678', '+2348012345678'],
+      ['8012345678', '+2348012345678'],
+      ['2348012345678', '+2348012345678'],
+      ['+2348012345678', '+2348012345678'],
+      ['+234 801 234 5678', '+2348012345678'],
+      ['+234-801-234-5678', '+2348012345678'],
+      ['00234 801 234 5678', '+2348012345678'],
+      ['  08012345678  ', '+2348012345678'],
+    ])('normalizes %j to canonical E.164 %j', (input, expected) => {
+      expect(ValidationUtils.normalizePhoneNumber(input)).toBe(expected);
     });
 
-    it('should return false for invalid phones', () => {
-      expect(ValidationUtils.validatePhone('abc')).toBe(false);
-      expect(ValidationUtils.validatePhone('+')).toBe(false);
+    it('returns null for empty/blank input (clear phone) and passes null/undefined through', () => {
+      expect(ValidationUtils.normalizePhoneNumber('')).toBeNull();
+      expect(ValidationUtils.normalizePhoneNumber('   ')).toBeNull();
+      expect(ValidationUtils.normalizePhoneNumber(null)).toBeNull();
+      expect(ValidationUtils.normalizePhoneNumber(undefined)).toBeUndefined();
+    });
+
+    it('returns malformed input unchanged so validation can reject it', () => {
+      expect(ValidationUtils.normalizePhoneNumber('abc8012345678')).toBe(
+        'abc8012345678',
+      );
+      expect(ValidationUtils.normalizePhoneNumber('abc')).toBe('abc');
+      expect(ValidationUtils.normalizePhoneNumber('+')).toBe('+');
     });
   });
 

--- a/backend/src/common/utils/validation/validation.utils.ts
+++ b/backend/src/common/utils/validation/validation.utils.ts
@@ -7,12 +7,39 @@ export class ValidationUtils {
     return emailRegex.test(email);
   }
 
-  /**
-   * Validates a phone number format (Basic international format)
-   */
-  static validatePhone(phone: string): boolean {
-    const phoneRegex = /^\+?[1-9]\d{1,14}$/;
-    return phoneRegex.test(phone);
+  static normalizePhoneNumber(value: unknown): unknown {
+    if (value === null || value === undefined) return value;
+    if (typeof value !== 'string') return value;
+
+    const trimmed = value.trim();
+    if (trimmed === '') return null;
+
+    // Remove ONLY legitimate formatting characters.
+    const stripped = trimmed.replace(/[\s\-().]/g, '');
+
+    // If anything besides digits and an optional leading '+' remains, the
+    // input is malformed — return it unchanged so validation rejects it.
+    if (!/^\+?\d+$/.test(stripped)) return trimmed;
+
+    let digits = stripped;
+    if (digits.startsWith('00')) {
+      digits = digits.slice(2); // international prefix (00…)
+    } else if (digits.startsWith('+')) {
+      digits = digits.slice(1);
+    }
+
+    if (digits.startsWith('0')) {
+      // National number with trunk prefix: 08012345678 → 2348012345678
+      digits = `234${digits.slice(1)}`;
+    } else if (digits.startsWith('234') && digits.length >= 12) {
+      // Already contains the +234 country code (e.g. 2348012345678)
+    } else if (digits.length === 10) {
+      // National number without trunk prefix: 8012345678 → 2348012345678
+      digits = `234${digits}`;
+    }
+   
+
+    return `+${digits}`;
   }
 
   /**

--- a/backend/src/modules/users/dto/update-user.dto.spec.ts
+++ b/backend/src/modules/users/dto/update-user.dto.spec.ts
@@ -1,0 +1,88 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateUserProfileDto } from './update-user.dto';
+
+describe('UpdateUserProfileDto phoneNumber', () => {
+  async function normalizeAndValidate(
+    input: unknown,
+  ): Promise<{ value: unknown; errorCount: number }> {
+    const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: input });
+    const errors = await validate(dto);
+    return { value: dto.phoneNumber, errorCount: errors.length };
+  }
+
+  it('accepts a valid  format and normalizes it to E.164', async () => {
+    const { value, errorCount } = await normalizeAndValidate('08012345678');
+    expect(errorCount).toBe(0);
+    expect(value).toBe('+2348012345678');
+  });
+
+  it('accepts a valid +234 format and keeps it canonical', async () => {
+    const { value, errorCount } = await normalizeAndValidate('+2348012345678');
+    expect(errorCount).toBe(0);
+    expect(value).toBe('+2348012345678');
+  });
+
+  it('normalizes formatted +234 input', async () => {
+    const { value, errorCount } =
+      await normalizeAndValidate('+234 801 234 5678');
+    expect(errorCount).toBe(0);
+    expect(value).toBe('+2348012345678');
+  });
+
+  it('normalizes 00-prefixed international input', async () => {
+    const { value, errorCount } =
+      await normalizeAndValidate('00234 801 234 5678');
+    expect(errorCount).toBe(0);
+    expect(value).toBe('+2348012345678');
+  });
+
+  it('produces the same canonical value for equivalent representations', async () => {
+    const inputs = [
+      '08012345678',
+      '8012345678',
+      '2348012345678',
+      '+2348012345678',
+      '+234 801 234 5678',
+      '+234-801-234-5678',
+      '00234 801 234 5678',
+    ];
+    for (const input of inputs) {
+      const { value, errorCount } = await normalizeAndValidate(input);
+      expect(errorCount).toBe(0);
+      expect(value).toBe('+2348012345678');
+    }
+  });
+
+  it('rejects malformed values such as abc, +, and invalid numbers', async () => {
+    for (const input of ['abc', 'abc8012345678', '+', 'not a phone', '123']) {
+      const { errorCount } = await normalizeAndValidate(input);
+      expect(errorCount).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects non-Nigerian numbers', async () => {
+    const { value, errorCount } = await normalizeAndValidate('+15551234567');
+    expect(errorCount).toBeGreaterThan(0);
+    expect(value).toBe('+15551234567');
+  });
+
+  it('treats an empty string as a clear (null) and is not an error', async () => {
+    const { value, errorCount } = await normalizeAndValidate('');
+    expect(errorCount).toBe(0);
+    expect(value).toBeNull();
+  });
+
+  it('treats null as a clear (null) and is not an error', async () => {
+    const { value, errorCount } = await normalizeAndValidate(null);
+    expect(errorCount).toBe(0);
+    expect(value).toBeNull();
+  });
+
+  it('leaves the field undefined when omitted', async () => {
+    const dto = plainToInstance(UpdateUserProfileDto, { firstName: 'Ada' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.phoneNumber).toBeUndefined();
+  });
+});

--- a/backend/src/modules/users/dto/update-user.dto.ts
+++ b/backend/src/modules/users/dto/update-user.dto.ts
@@ -1,13 +1,16 @@
 import { PartialType } from '@nestjs/mapped-types';
+import { Transform } from 'class-transformer';
 import {
   IsString,
   IsEmail,
   IsOptional,
+  IsPhoneNumber,
   MinLength,
   Matches,
   IsBoolean,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ValidationUtils } from '../../../common/utils/validation/validation.utils';
 import { CreateUserDto } from './create-user.dto';
 
 export class UpdateUserProfileDto {
@@ -21,9 +24,18 @@ export class UpdateUserProfileDto {
   @IsString()
   lastName?: string;
 
-  @ApiPropertyOptional({ example: '+1234567890', description: 'Phone number' })
+  @ApiPropertyOptional({
+    example: '+2348012345678',
+    description: 'Phone number',
+  })
   @IsOptional()
-  @IsString()
+  @Transform(({ value }) => ValidationUtils.normalizePhoneNumber(value))
+  @Matches(/^\+?\d+$/, {
+    message: 'phoneNumber must contain only digits (optionally prefixed by +)',
+  })
+  @IsPhoneNumber('NG', {
+    message: 'phoneNumber must be a valid phone number (e.g. +2348012345678)',
+  })
   phoneNumber?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedException,
   BadRequestException,
 } from '@nestjs/common';
+import { createHash } from 'crypto';
 import * as bcrypt from 'bcryptjs';
 import { UsersService } from './users.service';
 import { User, UserRole, AuthMethod } from './entities/user.entity';
@@ -135,10 +136,12 @@ describe('UsersService', () => {
 
   describe('updateProfile', () => {
     it('should update user profile successfully', async () => {
+      const canonicalPhone = '+2348012345678';
       const updateDto = {
         firstName: 'Updated',
         lastName: 'Name',
-        phoneNumber: '+1234567890',
+        // The DTO guarantees the canonical E.164 value reaches the service.
+        phoneNumber: canonicalPhone,
       };
 
       const updatedUser = { ...mockUser, ...updateDto };
@@ -150,7 +153,16 @@ describe('UsersService', () => {
 
       expect(result.firstName).toBe('Updated');
       expect(result.lastName).toBe('Name');
-      expect(mockUserRepository.save).toHaveBeenCalled();
+      expect(result.phoneNumber).toBe(canonicalPhone);
+      // Storage, hash and encryption all operate on the canonical value.
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phoneNumber: canonicalPhone,
+          phoneNumberHash: createHash('sha256')
+            .update(canonicalPhone)
+            .digest('hex'),
+        }),
+      );
     });
 
     it('should throw NotFoundException if user not found', async () => {

--- a/backend/test/user-profile-update.e2e-spec.ts
+++ b/backend/test/user-profile-update.e2e-spec.ts
@@ -182,4 +182,62 @@ describe('User Profile Update Integration', () => {
     // The plain value is returned but hash columns are never exposed
     expect(profile.body).not.toHaveProperty('phoneNumberHash');
   });
+
+  it('PUT /api/users/me – normalizes equivalent phone formats to canonical E.164', async () => {
+    const inputs = [
+      '08012345678',
+      '8012345678',
+      '2348012345678',
+      '+234 801 234 5678',
+      '+234-801-234-5678',
+      '00234 801 234 5678',
+    ];
+
+    for (const input of inputs) {
+      await request(app.getHttpServer())
+        .put('/api/users/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ phoneNumber: input })
+        .expect(200);
+
+      const profile = await request(app.getHttpServer())
+        .get('/api/users/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(profile.body.phoneNumber).toBe('+2348012345678');
+    }
+  });
+
+  it('PUT /api/users/me – rejects invalid phone numbers', async () => {
+    for (const input of [
+      'abc',
+      'abc8012345678',
+      '+',
+      'not a phone',
+      '+1555123567',
+      '+1111111111111555',
+    ]) {
+      await request(app.getHttpServer())
+        .put('/api/users/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ phoneNumber: input })
+        .expect(400);
+    }
+  });
+
+  it('PUT /api/users/me – empty phone value clears the stored phone', async () => {
+    await request(app.getHttpServer())
+      .put('/api/users/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ phoneNumber: '' })
+      .expect(200);
+
+    const profile = await request(app.getHttpServer())
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(profile.body.phoneNumber).toBeNull();
+  });
 });


### PR DESCRIPTION
This PR addresses issue #1467  by adding phone-number validation and formatting.

Changes
Added phone-number validation and formatting.
Updated the user profile update DTO to apply the validation.
Added unit tests for the validation utility.
Added DTO validation tests.
Updated user service tests.
Added/updated end-to-end tests for user profile updates.


Testing
Unit tests added/updated for phone-number validation.
User service tests updated.
User profile update E2E tests updated.


Issue

Closes #1467 