### PR TITLE
Harden maintenance stream and web vitals endpoint

### DIFF
--- a/frontend/app/api/maintenance/stream/route.ts
+++ b/frontend/app/api/maintenance/stream/route.ts
@@ -5,6 +5,12 @@ const BACKEND_API_BASE =
   process.env.NEXT_PUBLIC_BACKEND_API_BASE_URL ??
   'http://localhost:5000/api';
 
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const MAX_CONNECTIONS_PER_CLIENT = 3;
+const connectionCounts = new Map<string, number>();
+
+const encoder = new TextEncoder();
+
 const buildUrl = (path: string): string =>
   `${BACKEND_API_BASE.replace(/\/$/, '')}${path}`;
 
@@ -21,22 +27,118 @@ const extractForwardHeaders = (request: NextRequest): HeadersInit => {
   return headers;
 };
 
+function getConnectionKey(request: NextRequest): string {
+  const auth = request.headers.get('authorization');
+  if (auth) return `auth:${auth.slice(0, 80)}`;
+
+  const cookie = request.headers.get('cookie');
+  if (cookie) return `cookie:${cookie.slice(0, 120)}`;
+
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  return `ip:${forwardedFor || realIp || 'unknown'}`;
+}
+
+function acquireConnection(key: string): boolean {
+  const current = connectionCounts.get(key) ?? 0;
+  if (current >= MAX_CONNECTIONS_PER_CLIENT) return false;
+  connectionCounts.set(key, current + 1);
+  return true;
+}
+
+function releaseConnection(key: string) {
+  const current = connectionCounts.get(key) ?? 0;
+  if (current <= 1) {
+    connectionCounts.delete(key);
+    return;
+  }
+  connectionCounts.set(key, current - 1);
+}
+
 export async function GET(request: NextRequest) {
+  const connectionKey = getConnectionKey(request);
+  if (!acquireConnection(connectionKey)) {
+    return NextResponse.json(
+      { message: 'Too many maintenance stream connections.' },
+      { status: 429 },
+    );
+  }
+
+  const upstreamAbort = new AbortController();
+  const release = () => {
+    upstreamAbort.abort();
+    releaseConnection(connectionKey);
+  };
+
   try {
     const response = await fetch(buildUrl('/maintenance/stream'), {
       method: 'GET',
       headers: extractForwardHeaders(request),
       cache: 'no-store',
+      signal: upstreamAbort.signal,
     });
 
     if (!response.ok || !response.body) {
+      release();
       return NextResponse.json(
         { message: 'Maintenance stream is unavailable.' },
         { status: 502 },
       );
     }
 
-    return new NextResponse(response.body, {
+    const reader = response.body.getReader();
+    let released = false;
+    let closed = false;
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+
+    const cleanup = () => {
+      if (released) return;
+      released = true;
+      if (heartbeat) clearInterval(heartbeat);
+      release();
+      reader.cancel().catch(() => undefined);
+    };
+
+    request.signal.addEventListener('abort', cleanup, { once: true });
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        heartbeat = setInterval(() => {
+          if (!closed) {
+            controller.enqueue(encoder.encode(': heartbeat\n\n'));
+          }
+        }, HEARTBEAT_INTERVAL_MS);
+
+        const pump = async () => {
+          try {
+            while (!released) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              if (value) controller.enqueue(value);
+            }
+            if (!closed) {
+              closed = true;
+              controller.close();
+            }
+          } catch (error) {
+            if (!closed) {
+              closed = true;
+              controller.error(error);
+            }
+          } finally {
+            cleanup();
+          }
+        };
+
+        pump();
+      },
+      cancel() {
+        closed = true;
+        cleanup();
+      },
+    });
+
+    return new NextResponse(stream, {
       status: 200,
       headers: {
         'content-type': 'text/event-stream',
@@ -45,6 +147,7 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch {
+    release();
     return NextResponse.json(
       { message: 'Maintenance stream is unavailable.' },
       { status: 502 },

--- a/frontend/app/api/web-vitals/route.ts
+++ b/frontend/app/api/web-vitals/route.ts
@@ -7,26 +7,60 @@ import {
 } from '@/lib/web-vitals';
 
 const MAX_BUFFER = 200;
+const MAX_BODY_BYTES = 4_096;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 60;
+const VALID_WEB_VITAL_NAMES = new Set(['CLS', 'FCP', 'FID', 'INP', 'LCP', 'TTFB']);
 
 /** In-process ring buffer for local aggregation / GET dashboard. */
 const buffer: WebVitalPayload[] = [];
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
 
 function push(payload: WebVitalPayload) {
   buffer.unshift(payload);
   if (buffer.length > MAX_BUFFER) buffer.length = MAX_BUFFER;
 }
 
+function clientKey(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  return forwardedFor || realIp || 'unknown';
+}
+
+function isRateLimited(request: NextRequest): boolean {
+  const key = clientKey(request);
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    rateLimitBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) return true;
+  bucket.count += 1;
+  return false;
+}
+
 function isValidBody(body: unknown): body is RawWebVitalMetric & {
   route?: string;
   timestamp?: string;
 } {
-  if (!body || typeof body !== 'object') return false;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
   const b = body as Record<string, unknown>;
   return (
     typeof b.name === 'string' &&
+    VALID_WEB_VITAL_NAMES.has(b.name) &&
     typeof b.value === 'number' &&
     Number.isFinite(b.value) &&
-    typeof b.id === 'string'
+    b.value >= 0 &&
+    typeof b.id === 'string' &&
+    b.id.length > 0 &&
+    b.id.length <= 128 &&
+    (b.rating === undefined || typeof b.rating === 'string') &&
+    (b.delta === undefined || (typeof b.delta === 'number' && Number.isFinite(b.delta))) &&
+    (b.navigationType === undefined || typeof b.navigationType === 'string') &&
+    (b.route === undefined || typeof b.route === 'string')
   );
 }
 
@@ -35,9 +69,22 @@ function isValidBody(body: unknown): body is RawWebVitalMetric & {
  * Re-sanitizes on the server so query strings / entries never stick.
  */
 export async function POST(request: NextRequest) {
+  const contentLength = Number.parseInt(request.headers.get('content-length') || '0', 10);
+  if (contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
+  if (isRateLimited(request)) {
+    return NextResponse.json({ error: 'Too many web vitals submissions' }, { status: 429 });
+  }
+
   let body: unknown;
   try {
-    body = await request.json();
+    const raw = await request.text();
+    if (new TextEncoder().encode(raw).length > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+    }
+    body = JSON.parse(raw);
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
@@ -50,25 +97,20 @@ export async function POST(request: NextRequest) {
     {
       name: body.name,
       value: body.value,
-      rating: typeof body.rating === 'string' ? body.rating : undefined,
-      delta: typeof body.delta === 'number' ? body.delta : undefined,
+      rating: body.rating,
+      delta: body.delta,
       id: body.id,
-      navigationType:
-        typeof body.navigationType === 'string'
-          ? body.navigationType
-          : undefined,
+      navigationType: body.navigationType,
     },
     typeof body.route === 'string' ? body.route : sanitizeRoute('/'),
   );
 
-  // Prefer client-provided sanitized route if already set
   if (typeof body.route === 'string') {
     payload.route = sanitizeRoute(body.route);
   }
 
   push(payload);
 
-  // Structured log for terminal / log aggregation
   console.info(
     JSON.stringify({
       type: 'web_vital',


### PR DESCRIPTION
Closes #1668
Closes #1669
Closes #1667
Closes #1663

## Summary
This PR hardens two public-facing frontend API routes: the maintenance SSE stream and the unauthenticated web-vitals ingestion endpoint.

## What changed
- Adds a per-client connection cap to the maintenance stream route so duplicate tabs or stuck clients cannot accumulate unlimited open SSE connections.
- Adds periodic SSE heartbeat comments to keep idle connections alive through proxies and load balancers.
- Adds explicit cleanup for client aborts, upstream stream completion, and stream cancellation so connection counts are released reliably.
- Adds web-vitals request body size checks using both `content-length` and actual encoded body size.
- Adds in-process IP-based throttling for web-vitals submissions.
- Tightens schema validation for accepted metric names, numeric values, IDs, route type, rating, delta, and navigation type before storing metrics.

## Testing
Not run, per request.