### PR TITLE
API key scoping, feedback rate limiting, inquiry state machine, partial escrow refunds

### DIFF
--- a/backend/migrations/1930000000000-AddRefundedAmountToStellarEscrows.ts
+++ b/backend/migrations/1930000000000-AddRefundedAmountToStellarEscrows.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRefundedAmountToStellarEscrows1930000000000
+  implements MigrationInterface
+{
+  name = 'AddRefundedAmountToStellarEscrows1930000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "stellar_escrows"
+      ADD COLUMN "refunded_amount" decimal(20,7) NOT NULL DEFAULT 0
+    `);
+
+    // Escrows already fully refunded before partial-refund support existed
+    // were refunded in one whole-amount operation.
+    await queryRunner.query(`
+      UPDATE "stellar_escrows"
+      SET "refunded_amount" = "amount"
+      WHERE "status" = 'REFUNDED'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "stellar_escrows" DROP COLUMN "refunded_amount"
+    `);
+  }
+}

--- a/backend/src/modules/developer/constants/api-scopes.ts
+++ b/backend/src/modules/developer/constants/api-scopes.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical vocabulary of API key scopes.
+ *
+ * Every scope granted to a key must come from this list, and endpoints opt in
+ * to enforcement with the `@RequireApiScopes()` decorator. A key with no
+ * scopes can only reach endpoints that do not declare required scopes.
+ */
+export const API_SCOPES = [
+  'properties:read',
+  'properties:write',
+  'bookings:read',
+  'bookings:write',
+  'payments:read',
+  'analytics:read',
+] as const;
+
+export type ApiScope = (typeof API_SCOPES)[number];
+
+/**
+ * Return the subset of `scopes` that are not part of the canonical vocabulary.
+ */
+export function findUnknownScopes(scopes: string[]): string[] {
+  const known = new Set<string>(API_SCOPES);
+  return scopes.filter((scope) => !known.has(scope));
+}

--- a/backend/src/modules/developer/decorators/api-scopes.decorator.ts
+++ b/backend/src/modules/developer/decorators/api-scopes.decorator.ts
@@ -1,0 +1,13 @@
+import { SetMetadata } from '@nestjs/common';
+import { ApiScope } from '../constants/api-scopes';
+
+export const API_SCOPES_KEY = 'api_key_required_scopes';
+
+/**
+ * Declare the API key scopes required to access a handler or controller.
+ *
+ * Enforced by `ApiKeyGuard`: the authenticated key's `permissions` must
+ * include every listed scope, otherwise the request is rejected with 403.
+ */
+export const RequireApiScopes = (...scopes: ApiScope[]) =>
+  SetMetadata(API_SCOPES_KEY, scopes);

--- a/backend/src/modules/developer/developer.service.spec.ts
+++ b/backend/src/modules/developer/developer.service.spec.ts
@@ -117,6 +117,46 @@ describe('DeveloperService', () => {
 
       expect(result.expiresAt).toEqual(customExpiration);
     });
+
+    it('should reject scopes outside the canonical vocabulary', async () => {
+      await expect(
+        service.createKey('user-123', 'Bad Key', undefined, [
+          'properties:read',
+          'admin:everything',
+        ]),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockApiKeyRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should accept scopes from the canonical vocabulary', async () => {
+      mockApiKeyRepo.create.mockImplementation((data) => data as ApiKey);
+      mockApiKeyRepo.save.mockImplementation((key) =>
+        Promise.resolve({ ...(key as ApiKey), id: 'key-1' }),
+      );
+
+      const result = await service.createKey('user-123', 'Scoped', undefined, [
+        'properties:read',
+        'bookings:write',
+      ]);
+
+      expect(result).toHaveProperty('key');
+      const created = mockApiKeyRepo.create.mock.calls[0][0] as Partial<ApiKey>;
+      expect(created.permissions).toEqual([
+        'properties:read',
+        'bookings:write',
+      ]);
+    });
+  });
+
+  describe('updateKey', () => {
+    it('should reject unknown scopes before touching the key', async () => {
+      await expect(
+        service.updateKey('user-123', 'key-1', {
+          permissions: ['not:a:scope'],
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockApiKeyRepo.findOne).not.toHaveBeenCalled();
+    });
   });
 
   describe('rotateKey', () => {
@@ -186,6 +226,89 @@ describe('DeveloperService', () => {
       expect(result).toHaveProperty('id');
       expect(mockApiKeyRepo.create).toHaveBeenCalled();
       expect(mockRotationHistoryRepo.save).toHaveBeenCalled();
+    });
+
+    it('should carry scopes and description over to the new key', async () => {
+      const userId = 'user-123';
+      const keyId = 'key-1';
+      const oldKey = {
+        id: keyId,
+        userId,
+        name: 'Scoped Key',
+        description: 'CI integration',
+        permissions: ['properties:read', 'bookings:read'],
+        keyHash: 'old-hash',
+        keyPrefix: 'chioma_sk_old...',
+        status: ApiKeyStatus.ACTIVE,
+        isExpired: () => false,
+        rotatedAt: null,
+        expiresAt: null,
+      } as unknown as ApiKey;
+
+      mockApiKeyRepo.findOne.mockResolvedValue(oldKey);
+      mockApiKeyRepo.create.mockImplementation(
+        (data) => ({ ...data, id: 'key-2' }) as ApiKey,
+      );
+      mockApiKeyRepo.save.mockImplementation((key) =>
+        Promise.resolve(key as ApiKey),
+      );
+      mockRotationHistoryRepo.create.mockReturnValue(
+        {} as ApiKeyRotationHistory,
+      );
+      mockRotationHistoryRepo.save.mockResolvedValue(
+        {} as ApiKeyRotationHistory,
+      );
+
+      await service.rotateKey(userId, keyId);
+
+      const created = mockApiKeyRepo.create.mock.calls[0][0] as Partial<ApiKey>;
+      expect(created.permissions).toEqual(['properties:read', 'bookings:read']);
+      expect(created.description).toBe('CI integration');
+    });
+
+    it('should keep the old key active for a bounded overlap window', async () => {
+      const userId = 'user-123';
+      const keyId = 'key-1';
+      const farFuture = new Date();
+      farFuture.setDate(farFuture.getDate() + 90);
+      const oldKey = {
+        id: keyId,
+        userId,
+        name: 'Test Key',
+        permissions: [],
+        keyHash: 'old-hash',
+        keyPrefix: 'chioma_sk_old...',
+        status: ApiKeyStatus.ACTIVE,
+        isExpired: () => false,
+        rotatedAt: null,
+        expiresAt: farFuture,
+      } as unknown as ApiKey;
+
+      mockApiKeyRepo.findOne.mockResolvedValue(oldKey);
+      mockApiKeyRepo.create.mockImplementation(
+        (data) => ({ ...data, id: 'key-2' }) as ApiKey,
+      );
+      mockApiKeyRepo.save.mockImplementation((key) =>
+        Promise.resolve(key as ApiKey),
+      );
+      mockRotationHistoryRepo.create.mockReturnValue(
+        {} as ApiKeyRotationHistory,
+      );
+      mockRotationHistoryRepo.save.mockResolvedValue(
+        {} as ApiKeyRotationHistory,
+      );
+
+      await service.rotateKey(userId, keyId);
+
+      // Second save call persists the old key: still ACTIVE, but its expiry
+      // is capped to the 7-day overlap window instead of the original 90 days.
+      const savedOldKey = mockApiKeyRepo.save.mock.calls[1][0] as ApiKey;
+      expect(savedOldKey.status).toBe(ApiKeyStatus.ACTIVE);
+      expect(savedOldKey.rotatedAt).toBeInstanceOf(Date);
+      const overlapMs =
+        new Date(savedOldKey.expiresAt!).getTime() - Date.now();
+      expect(overlapMs).toBeGreaterThan(6 * 24 * 60 * 60 * 1000);
+      expect(overlapMs).toBeLessThanOrEqual(7 * 24 * 60 * 60 * 1000);
     });
 
     it('should throw BadRequestException when rotating an inactive key', async () => {

--- a/backend/src/modules/developer/developer.service.ts
+++ b/backend/src/modules/developer/developer.service.ts
@@ -8,12 +8,17 @@ import { Repository } from 'typeorm';
 import { createHash, randomBytes } from 'crypto';
 import { ApiKey, ApiKeyStatus } from './entities/api-key.entity';
 import { ApiKeyRotationHistory } from './entities/api-key-rotation-history.entity';
+import { findUnknownScopes } from './constants/api-scopes';
 
 const PREFIX = 'chioma_sk_';
 const KEY_BYTES = 32;
 const HASH_ALG = 'sha256';
 const DEFAULT_EXPIRATION_DAYS = 90;
 const WARNING_DAYS_BEFORE_EXPIRATION = 30;
+// After a rotation the old key stays usable for this long, so integrations
+// can move to the new key without downtime. The old key can still be revoked
+// immediately and independently via revokeKey().
+const ROTATION_OVERLAP_DAYS = 7;
 
 function hashKey(key: string): string {
   return createHash(HASH_ALG).update(key, 'utf8').digest('hex');
@@ -45,6 +50,8 @@ export class DeveloperService {
     permissions?: string[],
     expiresAt?: Date,
   ): Promise<{ id: string; key: string; name: string; expiresAt: Date }> {
+    this.assertKnownScopes(permissions);
+
     const rawKey = PREFIX + generateKey();
     const keyHash = hashKey(rawKey);
     const keyPrefix = rawKey.slice(0, 15) + '...';
@@ -129,6 +136,8 @@ export class DeveloperService {
       permissions?: string[];
     },
   ): Promise<ApiKey> {
+    this.assertKnownScopes(updates.permissions);
+
     const key = await this.getKey(userId, keyId);
 
     if (updates.name) {
@@ -167,10 +176,14 @@ export class DeveloperService {
     const keyPrefix = rawKey.slice(0, 15) + '...';
     const expirationDate = newExpiresAt ?? calculateExpirationDate();
 
-    // Create new key as a rotated version
+    // Create new key as a rotated version, carrying over the old key's
+    // metadata and scopes so rotation never silently broadens or narrows
+    // what the credential can do.
     const newKey = this.apiKeyRepo.create({
       userId,
       name: oldKey.name,
+      description: oldKey.description,
+      permissions: oldKey.permissions || [],
       keyHash,
       keyPrefix,
       expiresAt: expirationDate,
@@ -194,8 +207,16 @@ export class DeveloperService {
 
     await this.rotationHistoryRepo.save(rotationHistory);
 
-    // Mark old key as expired/rotated but keep for transition period
-    oldKey.status = ApiKeyStatus.EXPIRED;
+    // Keep the old key ACTIVE for a bounded overlap window so callers can
+    // migrate to the new key without downtime. Its expiry is capped at
+    // now + ROTATION_OVERLAP_DAYS (never extended), after which the
+    // scheduled expiry sweep deactivates it. It remains independently
+    // revocable at any time via revokeKey().
+    const overlapEnd = new Date();
+    overlapEnd.setDate(overlapEnd.getDate() + ROTATION_OVERLAP_DAYS);
+    if (!oldKey.expiresAt || new Date(oldKey.expiresAt) > overlapEnd) {
+      oldKey.expiresAt = overlapEnd;
+    }
     oldKey.rotatedAt = new Date();
     await this.apiKeyRepo.save(oldKey);
 
@@ -218,6 +239,19 @@ export class DeveloperService {
       where: { apiKeyId: keyId },
       order: { rotatedAt: 'DESC' },
     });
+  }
+
+  /**
+   * Reject scope lists containing values outside the canonical vocabulary.
+   */
+  private assertKnownScopes(scopes?: string[]): void {
+    if (!scopes || scopes.length === 0) return;
+    const unknown = findUnknownScopes(scopes);
+    if (unknown.length > 0) {
+      throw new BadRequestException(
+        `Unknown API key scope(s): ${unknown.join(', ')}`,
+      );
+    }
   }
 
   async revokeKey(userId: string, keyId: string): Promise<void> {

--- a/backend/src/modules/developer/dto/create-api-key.dto.ts
+++ b/backend/src/modules/developer/dto/create-api-key.dto.ts
@@ -1,11 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsString,
+  IsIn,
   MaxLength,
   MinLength,
   IsArray,
   IsOptional,
 } from 'class-validator';
+import { API_SCOPES } from '../constants/api-scopes';
 
 export class CreateApiKeyDto {
   @ApiProperty({ example: 'My integration', minLength: 1, maxLength: 80 })
@@ -28,8 +30,12 @@ export class CreateApiKeyDto {
     example: ['properties:read', 'properties:write'],
     description: 'List of permissions/scopes for this key',
     required: false,
+    enum: API_SCOPES,
+    isArray: true,
   })
   @IsOptional()
   @IsArray()
+  @IsString({ each: true })
+  @IsIn(API_SCOPES, { each: true })
   permissions?: string[];
 }

--- a/backend/src/modules/developer/dto/update-api-key.dto.ts
+++ b/backend/src/modules/developer/dto/update-api-key.dto.ts
@@ -3,10 +3,12 @@ import {
   IsString,
   IsOptional,
   IsDateString,
+  IsIn,
   MaxLength,
   MinLength,
   IsArray,
 } from 'class-validator';
+import { API_SCOPES } from '../constants/api-scopes';
 
 export class UpdateApiKeyDto {
   @ApiPropertyOptional({
@@ -40,9 +42,13 @@ export class UpdateApiKeyDto {
   @ApiPropertyOptional({
     example: ['properties:read', 'properties:write'],
     description: 'List of permissions/scopes for this key',
+    enum: API_SCOPES,
+    isArray: true,
   })
   @IsOptional()
   @IsArray()
+  @IsString({ each: true })
+  @IsIn(API_SCOPES, { each: true })
   permissions?: string[];
 }
 

--- a/backend/src/modules/developer/guards/api-key.guard.spec.ts
+++ b/backend/src/modules/developer/guards/api-key.guard.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ApiKeyGuard, API_KEY_HEADER } from './api-key.guard';
 import { DeveloperService } from '../developer.service';
@@ -116,6 +120,86 @@ describe('ApiKeyGuard', () => {
         id: 'user-id-456',
         apiKeyId: 'key-id-123',
       });
+    });
+  });
+
+  describe('scope enforcement', () => {
+    // First getAllAndOverride call resolves IS_PUBLIC_KEY, second resolves
+    // the required scopes for the handler/class.
+    function mockPublicAndScopes(requiredScopes: string[] | undefined) {
+      reflector.getAllAndOverride
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(requiredScopes);
+    }
+
+    it('should reject a key missing a required scope with 403', async () => {
+      mockPublicAndScopes(['properties:write']);
+      const context = createMockExecutionContext({
+        'x-api-key': 'chioma_sk_validkey123',
+      });
+      developerService.validateKey.mockResolvedValue({
+        id: 'key-id-123',
+        userId: 'user-id-456',
+        permissions: ['properties:read'],
+      } as ApiKey);
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        ForbiddenException,
+      );
+      const request = context.switchToHttp().getRequest();
+      expect(request.user).toBeUndefined();
+    });
+
+    it('should reject a key with no scopes on a scoped endpoint', async () => {
+      mockPublicAndScopes(['analytics:read']);
+      const context = createMockExecutionContext({
+        'x-api-key': 'chioma_sk_validkey123',
+      });
+      developerService.validateKey.mockResolvedValue({
+        id: 'key-id-123',
+        userId: 'user-id-456',
+        permissions: [],
+      } as unknown as ApiKey);
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should allow a key holding every required scope', async () => {
+      mockPublicAndScopes(['properties:read', 'properties:write']);
+      const context = createMockExecutionContext({
+        'x-api-key': 'chioma_sk_validkey123',
+      });
+      developerService.validateKey.mockResolvedValue({
+        id: 'key-id-123',
+        userId: 'user-id-456',
+        permissions: ['properties:read', 'properties:write', 'bookings:read'],
+      } as ApiKey);
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      const request = context.switchToHttp().getRequest();
+      expect(request.apiKeyScopes).toEqual([
+        'properties:read',
+        'properties:write',
+        'bookings:read',
+      ]);
+    });
+
+    it('should not enforce scopes on endpoints without a scope requirement', async () => {
+      mockPublicAndScopes(undefined);
+      const context = createMockExecutionContext({
+        'x-api-key': 'chioma_sk_validkey123',
+      });
+      developerService.validateKey.mockResolvedValue({
+        id: 'key-id-123',
+        userId: 'user-id-456',
+        permissions: [],
+      } as unknown as ApiKey);
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
     });
   });
 });

--- a/backend/src/modules/developer/guards/api-key.guard.ts
+++ b/backend/src/modules/developer/guards/api-key.guard.ts
@@ -1,12 +1,14 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { DeveloperService } from '../developer.service';
 import { IS_PUBLIC_KEY } from '../../auth/decorators/public.decorator';
+import { API_SCOPES_KEY } from '../decorators/api-scopes.decorator';
 
 export const API_KEY_HEADER = 'x-api-key';
 
@@ -30,14 +32,32 @@ export class ApiKeyGuard implements CanActivate {
     if (!apiKey || typeof apiKey !== 'string') return false;
 
     const key = await this.developerService.validateKey(apiKey.trim());
-    if (key) {
-      request.user = { id: key.userId, apiKeyId: key.id };
-      return true;
+    if (!key) {
+      throw new UnauthorizedException({
+        message: 'Invalid, expired, or revoked API key',
+        code: 'API_KEY_INVALID',
+      });
     }
 
-    throw new UnauthorizedException({
-      message: 'Invalid, expired, or revoked API key',
-      code: 'API_KEY_INVALID',
-    });
+    const requiredScopes =
+      this.reflector.getAllAndOverride<string[] | undefined>(API_SCOPES_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]) || [];
+
+    if (requiredScopes.length > 0) {
+      const granted = new Set(key.permissions ?? []);
+      const missing = requiredScopes.filter((scope) => !granted.has(scope));
+      if (missing.length > 0) {
+        throw new ForbiddenException({
+          message: `API key is missing required scope(s): ${missing.join(', ')}`,
+          code: 'API_KEY_SCOPE_INSUFFICIENT',
+        });
+      }
+    }
+
+    request.user = { id: key.userId, apiKeyId: key.id };
+    request.apiKeyScopes = key.permissions ?? [];
+    return true;
   }
 }

--- a/backend/src/modules/feedback/feedback.controller.ts
+++ b/backend/src/modules/feedback/feedback.controller.ts
@@ -1,18 +1,30 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { FeedbackService } from './feedback.service';
 import { SubmitFeedbackDto } from './dto/submit-feedback.dto';
+import {
+  EndpointCategory,
+  RateLimitCategory,
+  RateLimitGuard,
+  RateLimitPoints,
+} from '../rate-limiting';
 
 @ApiTags('Community & Support')
 @Controller('feedback')
+@UseGuards(RateLimitGuard)
+@RateLimitCategory(EndpointCategory.PUBLIC)
 export class FeedbackController {
   constructor(private readonly feedbackService: FeedbackService) {}
 
   @Post()
+  // Submissions are writes from an (often) unauthenticated surface, so each
+  // one costs several points of the caller's public-tier budget. Keyed per
+  // user when authenticated, per client IP otherwise.
+  @RateLimitPoints(5)
   @ApiOperation({
     summary: 'Submit feedback',
     description:
-      'Submit bug reports, feature requests, or general feedback. Optional auth to associate with your account.',
+      'Submit bug reports, feature requests, or general feedback. Optional auth to associate with your account. Rate limited per user/IP.',
   })
   @ApiResponse({
     status: 201,
@@ -20,6 +32,7 @@ export class FeedbackController {
     schema: { type: 'object', properties: { id: { type: 'string' } } },
   })
   @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   async submit(
     @Body() dto: SubmitFeedbackDto,
     @Req() req: { user?: { id: string } },

--- a/backend/src/modules/feedback/feedback.module.ts
+++ b/backend/src/modules/feedback/feedback.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Feedback } from './entities/feedback.entity';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
+import { RateLimitingModule } from '../rate-limiting/rate-limiting.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Feedback])],
+  imports: [TypeOrmModule.forFeature([Feedback]), RateLimitingModule],
   controllers: [FeedbackController],
   providers: [FeedbackService],
   exports: [FeedbackService],

--- a/backend/src/modules/feedback/feedback.service.spec.ts
+++ b/backend/src/modules/feedback/feedback.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { FeedbackService } from './feedback.service';
 import { FeedbackType } from './entities/feedback.entity';
 
@@ -5,13 +6,24 @@ describe('FeedbackService', () => {
   const feedbackRepo = {
     create: jest.fn(),
     save: jest.fn(),
+    findOne: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const configService = {
+    get: jest.fn((_key: string, defaultValue: unknown) => defaultValue),
   };
 
   let service: FeedbackService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new FeedbackService(feedbackRepo as never);
+    feedbackRepo.findOne.mockResolvedValue(null);
+    feedbackRepo.count.mockResolvedValue(0);
+    service = new FeedbackService(
+      feedbackRepo as never,
+      configService as never,
+    );
   });
 
   it('submits general feedback by default', async () => {
@@ -81,5 +93,87 @@ describe('FeedbackService', () => {
         type: FeedbackType.BUG,
       }),
     ).rejects.toThrow(error);
+  });
+
+  describe('spam protection', () => {
+    it('rejects messages with more links than the configured maximum', async () => {
+      const spam =
+        'Check https://a.example https://b.example https://c.example https://d.example now';
+
+      await expect(service.submit({ message: spam })).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(feedbackRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('allows messages at the link limit', async () => {
+      feedbackRepo.create.mockImplementation((value) => value);
+      feedbackRepo.save.mockResolvedValue({ id: 'feedback-4' });
+
+      await expect(
+        service.submit({
+          message:
+            'See https://a.example https://b.example https://c.example for context',
+        }),
+      ).resolves.toEqual({ id: 'feedback-4' });
+    });
+
+    it('rejects a duplicate message from the same user inside the window', async () => {
+      feedbackRepo.findOne.mockResolvedValue({ id: 'existing' });
+
+      await expect(
+        service.submit(
+          { message: 'Same message as before, resent.' },
+          'user-1',
+        ),
+      ).rejects.toThrow('already submitted');
+      expect(feedbackRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the hourly submission cap is reached', async () => {
+      feedbackRepo.count.mockResolvedValue(5);
+
+      await expect(
+        service.submit(
+          { message: 'Another perfectly valid feedback message.' },
+          'user-1',
+        ),
+      ).rejects.toThrow('limit reached');
+      expect(feedbackRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('keys anonymous throttling on the provided email', async () => {
+      feedbackRepo.count.mockResolvedValue(5);
+
+      await expect(
+        service.submit({
+          email: 'burst@example.com',
+          message: 'Anonymous but attributable submission.',
+        }),
+      ).rejects.toThrow('limit reached');
+    });
+
+    it('skips persistence throttling for anonymous submissions without email', async () => {
+      feedbackRepo.create.mockImplementation((value) => value);
+      feedbackRepo.save.mockResolvedValue({ id: 'feedback-5' });
+
+      await expect(
+        service.submit({ message: 'Anonymous feedback with no identity.' }),
+      ).resolves.toEqual({ id: 'feedback-5' });
+      expect(feedbackRepo.findOne).not.toHaveBeenCalled();
+      expect(feedbackRepo.count).not.toHaveBeenCalled();
+    });
+
+    it('reads limits from configuration', () => {
+      expect(configService.get).toHaveBeenCalledWith('FEEDBACK_MAX_LINKS', 3);
+      expect(configService.get).toHaveBeenCalledWith(
+        'FEEDBACK_MAX_PER_HOUR',
+        5,
+      );
+      expect(configService.get).toHaveBeenCalledWith(
+        'FEEDBACK_DUPLICATE_WINDOW_HOURS',
+        24,
+      );
+    });
   });
 });

--- a/backend/src/modules/feedback/feedback.service.ts
+++ b/backend/src/modules/feedback/feedback.service.ts
@@ -1,20 +1,43 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
 import { Feedback, FeedbackType } from './entities/feedback.entity';
 import { SubmitFeedbackDto } from './dto/submit-feedback.dto';
 
+const URL_PATTERN = /https?:\/\/\S+/gi;
+
 @Injectable()
 export class FeedbackService {
+  // Configurable via env; defaults keep honest users unaffected while
+  // blunting scripted submissions.
+  private readonly maxLinks: number;
+  private readonly maxPerHour: number;
+  private readonly duplicateWindowHours: number;
+
   constructor(
     @InjectRepository(Feedback)
     private readonly feedbackRepo: Repository<Feedback>,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.maxLinks = this.configService.get<number>('FEEDBACK_MAX_LINKS', 3);
+    this.maxPerHour = this.configService.get<number>(
+      'FEEDBACK_MAX_PER_HOUR',
+      5,
+    );
+    this.duplicateWindowHours = this.configService.get<number>(
+      'FEEDBACK_DUPLICATE_WINDOW_HOURS',
+      24,
+    );
+  }
 
   async submit(
     dto: SubmitFeedbackDto,
     userId?: string,
   ): Promise<{ id: string }> {
+    this.assertNotSpammy(dto.message);
+    await this.assertWithinSubmissionLimits(dto, userId);
+
     const feedback = this.feedbackRepo.create({
       email: dto.email ?? undefined,
       message: dto.message,
@@ -23,5 +46,64 @@ export class FeedbackService {
     });
     const saved = await this.feedbackRepo.save(feedback);
     return { id: saved.id };
+  }
+
+  /**
+   * Content heuristics for automated submissions. IP/user request throttling
+   * is handled by RateLimitGuard on the controller; these checks target the
+   * content itself.
+   */
+  private assertNotSpammy(message: string): void {
+    const links = message.match(URL_PATTERN) ?? [];
+    if (links.length > this.maxLinks) {
+      throw new BadRequestException(
+        `Feedback may contain at most ${this.maxLinks} links`,
+      );
+    }
+  }
+
+  /**
+   * Persistence-level throttle keyed on the submitter identity we can
+   * attribute (user id for authenticated users, email otherwise). Rejects
+   * duplicate messages inside the configured window and caps submissions
+   * per hour. Anonymous submissions without an email are covered only by
+   * the per-IP guard throttle.
+   */
+  private async assertWithinSubmissionLimits(
+    dto: SubmitFeedbackDto,
+    userId?: string,
+  ): Promise<void> {
+    const identityWhere = userId
+      ? { userId }
+      : dto.email
+        ? { email: dto.email }
+        : null;
+    if (!identityWhere) return;
+
+    const duplicateSince = new Date(
+      Date.now() - this.duplicateWindowHours * 60 * 60 * 1000,
+    );
+    const duplicate = await this.feedbackRepo.findOne({
+      where: {
+        ...identityWhere,
+        message: dto.message,
+        createdAt: MoreThan(duplicateSince),
+      },
+    });
+    if (duplicate) {
+      throw new BadRequestException(
+        'This feedback was already submitted recently',
+      );
+    }
+
+    const hourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const recentCount = await this.feedbackRepo.count({
+      where: { ...identityWhere, createdAt: MoreThan(hourAgo) },
+    });
+    if (recentCount >= this.maxPerHour) {
+      throw new BadRequestException(
+        'Feedback submission limit reached, please try again later',
+      );
+    }
   }
 }

--- a/backend/src/modules/inquiries/entities/property-inquiry.entity.ts
+++ b/backend/src/modules/inquiries/entities/property-inquiry.entity.ts
@@ -10,6 +10,8 @@ import {
 export enum PropertyInquiryStatus {
   PENDING = 'pending',
   VIEWED = 'viewed',
+  /** Terminal state: either party ended the conversation. */
+  CLOSED = 'closed',
 }
 
 @Entity('property_inquiries')

--- a/backend/src/modules/inquiries/inquiries.controller.ts
+++ b/backend/src/modules/inquiries/inquiries.controller.ts
@@ -53,4 +53,11 @@ export class InquiriesController {
   async markViewed(@Param('id') id: string, @CurrentUser() user: User) {
     return this.inquiriesService.markViewed(id, user.id);
   }
+
+  @Patch(':id/close')
+  @ApiOperation({ summary: 'Close an inquiry (sender or recipient)' })
+  @ApiResponse({ status: 400, description: 'Invalid lifecycle transition' })
+  async close(@Param('id') id: string, @CurrentUser() user: User) {
+    return this.inquiriesService.close(id, user.id);
+  }
 }

--- a/backend/src/modules/inquiries/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/inquiries.service.spec.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { InquiriesService } from './inquiries.service';
+import { PropertyInquiryStatus } from './entities/property-inquiry.entity';
+import { InvalidInquiryTransitionError } from './inquiry-state-machine';
 
 describe('InquiriesService', () => {
   const inquiryRepository = {
@@ -184,5 +186,88 @@ describe('InquiriesService', () => {
         },
       }),
     ]);
+  });
+
+  describe('lifecycle transitions', () => {
+    it('marks a pending inquiry as viewed', async () => {
+      inquiryRepository.findOne.mockResolvedValue({
+        id: 'inq-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.PENDING,
+        viewedAt: null,
+      });
+      inquiryRepository.save.mockImplementation((inquiry) =>
+        Promise.resolve(inquiry),
+      );
+
+      const result = await service.markViewed('inq-1', 'owner-1');
+
+      expect(result.status).toBe(PropertyInquiryStatus.VIEWED);
+      expect(result.viewedAt).toBeInstanceOf(Date);
+    });
+
+    it('is idempotent when re-viewing a viewed inquiry', async () => {
+      const inquiry = {
+        id: 'inq-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.VIEWED,
+      };
+      inquiryRepository.findOne.mockResolvedValue(inquiry);
+
+      await expect(service.markViewed('inq-1', 'owner-1')).resolves.toBe(
+        inquiry,
+      );
+      expect(inquiryRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects viewing a closed inquiry with a domain error', async () => {
+      inquiryRepository.findOne.mockResolvedValue({
+        id: 'inq-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.CLOSED,
+      });
+
+      await expect(service.markViewed('inq-1', 'owner-1')).rejects.toThrow(
+        InvalidInquiryTransitionError,
+      );
+      expect(inquiryRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('closes a pending inquiry', async () => {
+      inquiryRepository.findOne.mockResolvedValue({
+        id: 'inq-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.PENDING,
+      });
+      inquiryRepository.save.mockImplementation((inquiry) =>
+        Promise.resolve(inquiry),
+      );
+
+      const result = await service.close('inq-1', 'tenant-1');
+
+      expect(result.status).toBe(PropertyInquiryStatus.CLOSED);
+    });
+
+    it('is idempotent when closing an already closed inquiry', async () => {
+      const inquiry = {
+        id: 'inq-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.CLOSED,
+      };
+      inquiryRepository.findOne.mockResolvedValue(inquiry);
+
+      await expect(service.close('inq-1', 'tenant-1')).resolves.toBe(inquiry);
+      expect(inquiryRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when closing an inquiry the user is not part of', async () => {
+      inquiryRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.close('inq-1', 'stranger')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -13,6 +13,7 @@ import {
   PropertyInquiryStatus,
 } from './entities/property-inquiry.entity';
 import { CreatePropertyInquiryDto } from './dto/create-property-inquiry.dto';
+import { assertInquiryTransition } from './inquiry-state-machine';
 
 export interface InquiryPropertySummary {
   id: string;
@@ -196,12 +197,41 @@ export class InquiriesService {
       throw new NotFoundException('Inquiry not found');
     }
 
+    // Idempotent: re-viewing an already viewed inquiry is a no-op.
     if (inquiry.status === PropertyInquiryStatus.VIEWED) {
       return inquiry;
     }
 
+    assertInquiryTransition(inquiry.status, PropertyInquiryStatus.VIEWED);
+
     inquiry.status = PropertyInquiryStatus.VIEWED;
     inquiry.viewedAt = new Date();
+    return this.inquiryRepository.save(inquiry);
+  }
+
+  /**
+   * Close an inquiry. Either party (sender or recipient) may close; closing
+   * is terminal and idempotent.
+   */
+  async close(id: string, userId: string): Promise<PropertyInquiry> {
+    const inquiry = await this.inquiryRepository.findOne({
+      where: [
+        { id, toUserId: userId },
+        { id, fromUserId: userId },
+      ],
+    });
+
+    if (!inquiry) {
+      throw new NotFoundException('Inquiry not found');
+    }
+
+    if (inquiry.status === PropertyInquiryStatus.CLOSED) {
+      return inquiry;
+    }
+
+    assertInquiryTransition(inquiry.status, PropertyInquiryStatus.CLOSED);
+
+    inquiry.status = PropertyInquiryStatus.CLOSED;
     return this.inquiryRepository.save(inquiry);
   }
 }

--- a/backend/src/modules/inquiries/inquiry-state-machine.spec.ts
+++ b/backend/src/modules/inquiries/inquiry-state-machine.spec.ts
@@ -1,0 +1,62 @@
+import { PropertyInquiryStatus } from './entities/property-inquiry.entity';
+import {
+  INQUIRY_STATUS_TRANSITIONS,
+  InvalidInquiryTransitionError,
+  assertInquiryTransition,
+  canTransitionInquiry,
+} from './inquiry-state-machine';
+
+describe('inquiry state machine', () => {
+  const allStatuses = Object.values(PropertyInquiryStatus);
+
+  it('covers every status in the transition table', () => {
+    for (const status of allStatuses) {
+      expect(INQUIRY_STATUS_TRANSITIONS[status]).toBeDefined();
+    }
+  });
+
+  const legal: Array<[PropertyInquiryStatus, PropertyInquiryStatus]> = [
+    [PropertyInquiryStatus.PENDING, PropertyInquiryStatus.VIEWED],
+    [PropertyInquiryStatus.PENDING, PropertyInquiryStatus.CLOSED],
+    [PropertyInquiryStatus.VIEWED, PropertyInquiryStatus.CLOSED],
+  ];
+
+  it.each(legal)('allows %s -> %s', (from, to) => {
+    expect(canTransitionInquiry(from, to)).toBe(true);
+    expect(() => assertInquiryTransition(from, to)).not.toThrow();
+  });
+
+  it('rejects every transition not in the table', () => {
+    const legalSet = new Set(legal.map(([from, to]) => `${from}->${to}`));
+    for (const from of allStatuses) {
+      for (const to of allStatuses) {
+        if (legalSet.has(`${from}->${to}`)) continue;
+        expect(canTransitionInquiry(from, to)).toBe(false);
+        expect(() => assertInquiryTransition(from, to)).toThrow(
+          InvalidInquiryTransitionError,
+        );
+      }
+    }
+  });
+
+  it('treats CLOSED as terminal', () => {
+    expect(INQUIRY_STATUS_TRANSITIONS[PropertyInquiryStatus.CLOSED]).toEqual(
+      [],
+    );
+  });
+
+  it('exposes a stable domain error code', () => {
+    try {
+      assertInquiryTransition(
+        PropertyInquiryStatus.CLOSED,
+        PropertyInquiryStatus.VIEWED,
+      );
+      fail('expected InvalidInquiryTransitionError');
+    } catch (error) {
+      const response = (error as InvalidInquiryTransitionError).getResponse();
+      expect(response).toMatchObject({
+        code: 'INQUIRY_INVALID_TRANSITION',
+      });
+    }
+  });
+});

--- a/backend/src/modules/inquiries/inquiry-state-machine.ts
+++ b/backend/src/modules/inquiries/inquiry-state-machine.ts
@@ -1,0 +1,58 @@
+import { BadRequestException } from '@nestjs/common';
+import { PropertyInquiryStatus } from './entities/property-inquiry.entity';
+
+/**
+ * Domain error for lifecycle violations. Carries a stable `code` so API
+ * consumers can distinguish it from generic validation failures.
+ */
+export class InvalidInquiryTransitionError extends BadRequestException {
+  constructor(
+    readonly from: PropertyInquiryStatus,
+    readonly to: PropertyInquiryStatus,
+  ) {
+    super({
+      message: `Invalid inquiry status transition: ${from} -> ${to}`,
+      code: 'INQUIRY_INVALID_TRANSITION',
+    });
+  }
+}
+
+/**
+ * The explicit inquiry lifecycle. Every legal transition is listed here;
+ * anything not in the table is rejected. Terminal states have an empty list.
+ *
+ *   PENDING ──▶ VIEWED ──▶ CLOSED
+ *      └────────────────────▲
+ */
+export const INQUIRY_STATUS_TRANSITIONS: Record<
+  PropertyInquiryStatus,
+  readonly PropertyInquiryStatus[]
+> = {
+  [PropertyInquiryStatus.PENDING]: [
+    PropertyInquiryStatus.VIEWED,
+    PropertyInquiryStatus.CLOSED,
+  ],
+  [PropertyInquiryStatus.VIEWED]: [PropertyInquiryStatus.CLOSED],
+  [PropertyInquiryStatus.CLOSED]: [],
+};
+
+export function canTransitionInquiry(
+  from: PropertyInquiryStatus,
+  to: PropertyInquiryStatus,
+): boolean {
+  return (INQUIRY_STATUS_TRANSITIONS[from] ?? []).includes(to);
+}
+
+/**
+ * Assert a lifecycle transition is legal, throwing the domain error when not.
+ * Same-state "transitions" are also rejected: callers wanting idempotent
+ * behavior should short-circuit before asserting.
+ */
+export function assertInquiryTransition(
+  from: PropertyInquiryStatus,
+  to: PropertyInquiryStatus,
+): void {
+  if (!canTransitionInquiry(from, to)) {
+    throw new InvalidInquiryTransitionError(from, to);
+  }
+}

--- a/backend/src/modules/payments/dto/payment-gateway.dto.ts
+++ b/backend/src/modules/payments/dto/payment-gateway.dto.ts
@@ -97,6 +97,21 @@ export class RefundEscrowGatewayDto {
   @IsOptional()
   @IsString()
   reason?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Amount to refund as a decimal string (max 7 decimal places). ' +
+      'Omit for a full refund of the remaining escrow balance. Partial ' +
+      'amounts leave the escrow active and accumulate in its ' +
+      'refunded-to-date balance; the sum of partial refunds can never ' +
+      'exceed the original escrow amount.',
+    example: '25.5000000',
+  })
+  @IsOptional()
+  @Matches(/^(?!0+(\.0+)?$)\d+(\.\d{1,7})?$/, {
+    message: 'amount must be a positive decimal with at most 7 decimal places',
+  })
+  amount?: string;
 }
 
 export class ReconcilePaymentsDto {

--- a/backend/src/modules/payments/payment.controller.ts
+++ b/backend/src/modules/payments/payment.controller.ts
@@ -165,7 +165,11 @@ export class PaymentController {
   ) {
     return this.paymentService.refundEscrowDeposit(
       parseInt(escrowId, 10),
-      { escrowId: parseInt(escrowId, 10), reason: dto.reason },
+      {
+        escrowId: parseInt(escrowId, 10),
+        reason: dto.reason,
+        amount: dto.amount,
+      },
       req.user?.id || '',
     );
   }

--- a/backend/src/modules/payments/payment.service.spec.ts
+++ b/backend/src/modules/payments/payment.service.spec.ts
@@ -665,6 +665,73 @@ describe('PaymentService', () => {
       expect(mockStellarService.getEscrowById).toHaveBeenCalledWith(7);
     });
 
+    it('marks the payment as partially refunded after a partial escrow refund', async () => {
+      mockStellarService.refundEscrow.mockResolvedValue({
+        id: 7,
+        status: 'ACTIVE',
+        amount: '100.0000000',
+        refundedAmount: '25.0000000',
+        refundTransactionHash: 'partial_refund_hash',
+      });
+      (paymentRepository.findOne as jest.Mock).mockResolvedValue({
+        id: 'pay_1',
+        userId: 'user_1',
+        referenceNumber: 'escrow:7',
+        refundAmount: 0,
+        metadata: { gateway: 'stellar', flow: 'escrow_deposit' },
+      });
+      (paymentRepository.save as jest.Mock).mockImplementation((payment) =>
+        Promise.resolve(payment),
+      );
+
+      const result = await service.refundEscrowDeposit(
+        7,
+        { escrowId: 7, reason: 'damage deduction', amount: '25.0000000' },
+        'user_1',
+      );
+
+      expect(mockStellarService.refundEscrow).toHaveBeenCalledWith({
+        escrowId: 7,
+        reason: 'damage deduction',
+        amount: '25.0000000',
+      });
+      expect(result?.status).toBe(PaymentStatus.PARTIAL_REFUND);
+      expect(result?.refundAmount).toBe(25);
+      expect(result?.metadata).toMatchObject({
+        refundedToDate: '25.0000000',
+        refundTransactionHash: 'partial_refund_hash',
+      });
+    });
+
+    it('marks the payment refunded after a full escrow refund', async () => {
+      mockStellarService.refundEscrow.mockResolvedValue({
+        id: 7,
+        status: 'REFUNDED',
+        amount: '100.0000000',
+        refundedAmount: '100.0000000',
+        refundTransactionHash: 'full_refund_hash',
+      });
+      (paymentRepository.findOne as jest.Mock).mockResolvedValue({
+        id: 'pay_1',
+        userId: 'user_1',
+        referenceNumber: 'escrow:7',
+        refundAmount: 0,
+        metadata: { gateway: 'stellar', flow: 'escrow_deposit' },
+      });
+      (paymentRepository.save as jest.Mock).mockImplementation((payment) =>
+        Promise.resolve(payment),
+      );
+
+      const result = await service.refundEscrowDeposit(
+        7,
+        { escrowId: 7, reason: 'full refund' },
+        'user_1',
+      );
+
+      expect(result?.status).toBe(PaymentStatus.REFUNDED);
+      expect(result?.refundAmount).toBe(100);
+    });
+
     it('retries failed payments that still have a payment method', async () => {
       (paymentRepository.find as jest.Mock).mockResolvedValue([
         {

--- a/backend/src/modules/payments/payment.service.ts
+++ b/backend/src/modules/payments/payment.service.ts
@@ -43,7 +43,10 @@ import {
   ProcessStellarRentGatewayDto,
 } from './dto/payment-gateway.dto';
 import { RefundEscrowDto, ReleaseEscrowDto } from '../stellar/dto/escrow.dto';
-import { StellarEscrow } from '../stellar/entities/stellar-escrow.entity';
+import {
+  EscrowStatus,
+  StellarEscrow,
+} from '../stellar/entities/stellar-escrow.entity';
 import { TransactionStatus } from '../stellar/entities/stellar-transaction.entity';
 import { Idempotent, IdempotencyService } from '../../common/idempotency';
 import { FraudHooksService } from '../fraud/fraud-hooks.service';
@@ -689,12 +692,27 @@ export class PaymentService {
     const escrow = await this.stellarService.refundEscrow({
       escrowId,
       reason: dto.reason,
+      amount: dto.amount,
     });
-    return this.syncEscrowPaymentFromState(escrowId, escrow.status, userId, {
-      refundTransactionHash: escrow.refundTransactionHash,
-      refundReason: dto.reason,
-      reconciledAt: new Date().toISOString(),
-    });
+    // A partial refund leaves the escrow ACTIVE (which alone would map back
+    // to PENDING); reflect it on the payment ledger explicitly instead.
+    const refundedToDate = Number(escrow.refundedAmount ?? 0);
+    const isPartialRefund =
+      escrow.status === EscrowStatus.ACTIVE && refundedToDate > 0;
+    return this.syncEscrowPaymentFromState(
+      escrowId,
+      escrow.status,
+      userId,
+      {
+        refundTransactionHash: escrow.refundTransactionHash,
+        refundReason: dto.reason,
+        refundedToDate: escrow.refundedAmount,
+        reconciledAt: new Date().toISOString(),
+      },
+      isPartialRefund
+        ? { status: PaymentStatus.PARTIAL_REFUND, refundAmount: refundedToDate }
+        : { refundAmount: refundedToDate },
+    );
   }
 
   async reconcileStellarPayments(userId: string, limit = 50) {
@@ -944,6 +962,7 @@ export class PaymentService {
     status: string,
     userId: string,
     metadata: Record<string, unknown> = {},
+    overrides: { status?: PaymentStatus; refundAmount?: number } = {},
   ): Promise<Payment | null> {
     const referenceNumber = `escrow:${escrowId}`;
     const payment = await this.paymentRepository.findOne({
@@ -954,7 +973,16 @@ export class PaymentService {
       return null;
     }
 
-    payment.status = PAYMENT_STATUS_MAP[status] ?? PaymentStatus.PENDING;
+    // Escrow statuses arrive uppercase (EscrowStatus enum) while the map is
+    // keyed lowercase; normalize so RELEASED/REFUNDED actually map instead
+    // of falling back to PENDING.
+    payment.status =
+      overrides.status ??
+      PAYMENT_STATUS_MAP[status?.toLowerCase()] ??
+      PaymentStatus.PENDING;
+    if (overrides.refundAmount !== undefined) {
+      payment.refundAmount = overrides.refundAmount;
+    }
     payment.metadata = {
       ...(payment.metadata ?? {}),
       ...metadata,

--- a/backend/src/modules/stellar/dto/escrow.dto.ts
+++ b/backend/src/modules/stellar/dto/escrow.dto.ts
@@ -148,6 +148,19 @@ export class RefundEscrowDto {
   @IsOptional()
   @IsString()
   reason?: string;
+
+  /**
+   * Amount to refund, as a decimal string with up to 7 decimal places.
+   * Omit for a full refund of the remaining escrow balance. When provided
+   * and less than the remaining balance, the escrow performs a partial
+   * refund: funds move back to the source account, the escrow stays ACTIVE,
+   * and the cumulative refunded-to-date balance is updated.
+   */
+  @IsOptional()
+  @Matches(/^(?!0+(\.0+)?$)\d+(\.\d{1,7})?$/, {
+    message: 'amount must be a positive decimal with at most 7 decimal places',
+  })
+  amount?: string;
 }
 
 export class EscrowResponseDto {

--- a/backend/src/modules/stellar/entities/stellar-escrow.entity.ts
+++ b/backend/src/modules/stellar/entities/stellar-escrow.entity.ts
@@ -76,6 +76,20 @@ export class StellarEscrow {
   @Column({ type: 'decimal', precision: 20, scale: 7 })
   amount: string;
 
+  /**
+   * Cumulative amount refunded to the source account so far. Partial
+   * refunds accumulate here; the invariant refundedAmount <= amount is
+   * enforced in StellarService.refundEscrow().
+   */
+  @Column({
+    name: 'refunded_amount',
+    type: 'decimal',
+    precision: 20,
+    scale: 7,
+    default: 0,
+  })
+  refundedAmount: string;
+
   @Column({ name: 'asset_type', length: 16 })
   assetType: AssetType;
 

--- a/backend/src/modules/stellar/services/stellar.service.ts
+++ b/backend/src/modules/stellar/services/stellar.service.ts
@@ -796,7 +796,14 @@ export class StellarService {
   }
 
   /**
-   * Refund escrow funds back to source
+   * Refund escrow funds back to source.
+   *
+   * Without `dto.amount` the full remaining balance is refunded and the
+   * escrow account is merged away (status REFUNDED). With `dto.amount` less
+   * than the remaining refundable balance, only that amount is paid back:
+   * the escrow stays ACTIVE, the account is kept open, and the cumulative
+   * `refundedAmount` is advanced. The sum of partial refunds can never
+   * exceed the original escrow amount.
    */
   async refundEscrow(dto: RefundEscrowDto): Promise<StellarEscrow> {
     const queryRunner = this.dataSource.createQueryRunner();
@@ -811,6 +818,37 @@ export class StellarService {
           `Cannot refund escrow in ${escrow.status} status`,
         );
       }
+
+      // All monetary comparisons in stroops (1 XLM = 10^7 stroops) to avoid
+      // float drift on 7-decimal amounts.
+      const toStroops = (value: string | number): number =>
+        Math.round(Number(value) * 10_000_000);
+      const escrowStroops = toStroops(escrow.amount);
+      const refundedStroops = toStroops(escrow.refundedAmount ?? '0');
+      const remainingStroops = escrowStroops - refundedStroops;
+
+      if (remainingStroops <= 0) {
+        throw new BadRequestException(
+          `Escrow ${escrow.id} has no remaining refundable balance`,
+        );
+      }
+
+      const requestedStroops =
+        dto.amount !== undefined ? toStroops(dto.amount) : remainingStroops;
+
+      if (requestedStroops <= 0) {
+        throw new BadRequestException('Refund amount must be positive');
+      }
+
+      if (requestedStroops > remainingStroops) {
+        throw new BadRequestException(
+          `Refund amount ${dto.amount} exceeds the remaining refundable ` +
+            `balance of ${(remainingStroops / 10_000_000).toFixed(7)} ` +
+            `(escrow ${escrow.amount}, already refunded ${escrow.refundedAmount ?? '0'})`,
+        );
+      }
+
+      const isFullRefund = requestedStroops === remainingStroops;
 
       // Get accounts
       const escrowAccount = await this.getAccountById(escrow.escrowAccountId);
@@ -834,57 +872,92 @@ export class StellarService {
       );
       const availableBalance = parseFloat(nativeBalance?.balance || '0');
       const reserveRequired = 1;
-      const amountToSend = (availableBalance - reserveRequired).toFixed(7);
+      const spendableStroops = toStroops(
+        (availableBalance - reserveRequired).toFixed(7),
+      );
 
-      // Build transaction to refund and merge account
-      const transaction = new StellarSdk.TransactionBuilder(networkAccount, {
-        fee: this.baseFee,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          StellarSdk.Operation.payment({
-            destination: sourceAccount.publicKey,
-            asset: StellarSdk.Asset.native(),
-            amount: amountToSend,
-          }),
-        )
-        .addOperation(
+      // For full refunds keep the drain-everything behavior; partial refunds
+      // send exactly the requested amount.
+      const sendStroops = isFullRefund
+        ? spendableStroops
+        : Math.min(requestedStroops, spendableStroops);
+
+      if (sendStroops <= 0) {
+        throw new BadRequestException(
+          `Escrow account ${escrowAccount.publicKey} has no spendable balance to refund`,
+        );
+      }
+
+      const amountToSend = (sendStroops / 10_000_000).toFixed(7);
+
+      // Build refund transaction; only a full refund merges the account away.
+      const transactionBuilder = new StellarSdk.TransactionBuilder(
+        networkAccount,
+        {
+          fee: this.baseFee,
+          networkPassphrase: this.networkPassphrase,
+        },
+      ).addOperation(
+        StellarSdk.Operation.payment({
+          destination: sourceAccount.publicKey,
+          asset: StellarSdk.Asset.native(),
+          amount: amountToSend,
+        }),
+      );
+
+      if (isFullRefund) {
+        transactionBuilder.addOperation(
           StellarSdk.Operation.accountMerge({
             destination: sourceAccount.publicKey,
           }),
-        )
-        .setTimeout(180)
-        .build();
+        );
+      }
+
+      const transaction = transactionBuilder.setTimeout(180).build();
 
       transaction.sign(escrowKeypair);
 
       // Submit transaction
       const result = await this.horizon.submitTransaction(transaction);
 
-      // Update escrow status
-      escrow.status = EscrowStatus.REFUNDED;
-      escrow.refundedAt = new Date();
+      // Update escrow state: cumulative refunded-to-date balance always
+      // advances; only a full refund is terminal.
+      escrow.refundedAmount = (
+        (refundedStroops + requestedStroops) /
+        10_000_000
+      ).toFixed(7);
       escrow.refundTransactionHash = result.hash;
+      if (isFullRefund) {
+        escrow.status = EscrowStatus.REFUNDED;
+        escrow.refundedAt = new Date();
+      }
       await queryRunner.manager.save(escrow);
 
-      // Deactivate escrow account
-      escrowAccount.isActive = false;
-      escrowAccount.balance = '0';
+      if (isFullRefund) {
+        // Deactivate escrow account
+        escrowAccount.isActive = false;
+        escrowAccount.balance = '0';
+      } else {
+        escrowAccount.balance = (
+          (spendableStroops - sendStroops) / 10_000_000 +
+          reserveRequired
+        ).toFixed(7);
+      }
       await queryRunner.manager.save(escrowAccount);
 
-      // Record the refund transaction
+      // Record the refund transaction with the actual refunded amount
       const txRecord = this.transactionRepository.create({
         transactionHash: result.hash,
         fromAccountId: escrowAccount.id,
         toAccountId: sourceAccount.id,
         sourceAccount: escrowAccount.publicKey,
         destinationAccount: sourceAccount.publicKey,
-        amount: escrow.amount,
+        amount: (requestedStroops / 10_000_000).toFixed(7),
         assetType: escrow.assetType,
         assetCode: escrow.assetCode,
         assetIssuer: escrow.assetIssuer,
         feePaid: parseInt(this.baseFee),
-        memo: `Escrow refund for escrow ${escrow.id}: ${dto.reason || 'No reason provided'}`,
+        memo: `Escrow ${isFullRefund ? 'refund' : 'partial refund'} for escrow ${escrow.id}: ${dto.reason || 'No reason provided'}`,
         memoType: MemoType.TEXT,
         status: TransactionStatus.COMPLETED,
         ledger: result.ledger,
@@ -893,7 +966,10 @@ export class StellarService {
       await queryRunner.manager.save(txRecord);
       await queryRunner.commitTransaction();
 
-      this.logger.log(`Refunded escrow ${escrow.id}`);
+      this.logger.log(
+        `Refunded escrow ${escrow.id} (${amountToSend}, ` +
+          `${isFullRefund ? 'full' : 'partial'}; refunded to date ${escrow.refundedAmount})`,
+      );
 
       return this.getEscrowById(escrow.id);
     } catch (error) {


### PR DESCRIPTION
## Summary
Four backend hardening changes: API keys gain enforced scopes and a safe rotation overlap, feedback submissions get throttling and spam heuristics, the inquiry lifecycle becomes an explicit state machine, and escrow refunds support partial amounts with cumulative validation reflected on the payment ledger.

closes #1585
closes #1590
closes #1592
closes #1596

## Changes
- **#1585 — API key scoping & rotation overlap**: `ApiKey.permissions` existed but was never enforced. Adds a canonical scope vocabulary (`developer/constants/api-scopes.ts`), a `@RequireApiScopes()` decorator, and enforcement in `ApiKeyGuard` (403 `API_KEY_SCOPE_INSUFFICIENT` listing missing scopes; granted scopes attached to the request). Create/update DTOs and the service now reject unknown scopes. `rotateKey` previously expired the old key immediately (contradicting its own Swagger doc) and silently dropped the key's permissions and description — the new key now inherits both, and the old key stays ACTIVE for a bounded 7-day overlap window (expiry capped, never extended) while remaining independently revocable via the existing DELETE endpoint.
- **#1590 — Feedback rate limiting & spam protection**: the existing `RateLimitGuard` (per-user when authenticated, per-socket-IP otherwise) is applied to `POST /feedback` with `PUBLIC` category at 5 points per submission — first wiring of this guard to a controller. The service adds content heuristics: max links per message, duplicate-message rejection within a window, and an hourly per-submitter cap (keyed on user id or email; anonymous submissions without email are covered by the per-IP guard only). Limits are configurable via `FEEDBACK_MAX_LINKS`, `FEEDBACK_MAX_PER_HOUR`, `FEEDBACK_DUPLICATE_WINDOW_HOURS`.
- **#1592 — Inquiry lifecycle state machine**: new `inquiry-state-machine.ts` with an explicit transition table (`PENDING → VIEWED → CLOSED`, `PENDING → CLOSED`; CLOSED terminal), a `InvalidInquiryTransitionError` domain error (`INQUIRY_INVALID_TRANSITION`), and assertion helpers. `markViewed` now asserts transitions (viewing a closed inquiry is rejected instead of silently overwriting), a `CLOSED` status plus `PATCH /inquiries/:id/close` endpoint let either party terminate the lifecycle, both idempotently.
- **#1596 — Partial escrow refunds**: `RefundEscrowDto`/`RefundEscrowGatewayDto` accept an optional decimal `amount` (≤7 dp). `StellarService.refundEscrow` does all validation in integer stroops: cumulative refunds can never exceed the original escrow amount, partial refunds pay exactly the requested amount and keep the escrow ACTIVE (no account merge), full refunds keep the drain-and-merge behavior. New `refunded_amount` column (migration `1930000000000`, backfilled to `amount` for already-REFUNDED rows) tracks the refunded-to-date balance, and the ledger transaction record now carries the actual refunded amount instead of always the full escrow amount. The payment record maps partial refunds to `PARTIAL_REFUND` with `refundAmount` set. Also fixes a latent bug in `syncEscrowPaymentFromState`: uppercase escrow statuses (`RELEASED`/`REFUNDED`) were looked up in a lowercase-keyed map, so every escrow sync silently regressed the payment to `PENDING`.

## Test plan
- New/updated unit tests: guard scope enforcement (4 cases), key rotation overlap + scope inheritance + unknown-scope rejection, feedback heuristics and throttle keying (7 cases), a table-driven state-machine spec asserting every illegal transition, inquiry service lifecycle tests, and partial/full escrow refund payment-mapping tests.
- Existing specs updated where constructors gained dependencies (feedback).

---
Caveats: dependencies are not installed in this environment, so the suite was not executed locally — relying on CI for build/lint/test. The Stellar-side partial refund path (payment without merge) follows the existing full-refund transaction pattern but was not exercised against Horizon.