### PR TITLE
Add DTO validation to security/search/rent controllers and rent unit tests

### DIFF
--- a/backend/src/modules/rent/dto/calculate-late-fee.dto.ts
+++ b/backend/src/modules/rent/dto/calculate-late-fee.dto.ts
@@ -1,0 +1,45 @@
+import { IsNumber, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CalculateLateFeeDto {
+  @ApiProperty({
+    example: 1500.0,
+    description: 'Monthly rent amount',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  monthlyRent: number;
+
+  @ApiProperty({
+    example: 10,
+    description: 'Number of days the payment is late',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  daysLate: number;
+
+  @ApiPropertyOptional({
+    example: 5,
+    description: 'Grace period in days before late fees apply',
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  gracePeriodDays?: number;
+
+  @ApiPropertyOptional({
+    example: 0.05,
+    description: 'Daily late fee rate as a decimal (e.g., 0.05 = 5% per day)',
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  lateFeeRate?: number;
+}

--- a/backend/src/modules/rent/dto/calculate-prorated-rent.dto.ts
+++ b/backend/src/modules/rent/dto/calculate-prorated-rent.dto.ts
@@ -1,0 +1,22 @@
+import { IsDateString, IsNumber, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CalculateProratedRentDto {
+  @ApiProperty({
+    example: 1500.0,
+    description: 'Full monthly rent amount',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  monthlyRent: number;
+
+  @ApiProperty({
+    example: '2026-06-15',
+    description: 'Move-in date for proration calculation (ISO 8601)',
+  })
+  @IsDateString()
+  moveInDate: string;
+}

--- a/backend/src/modules/rent/dto/create-reminders.dto.ts
+++ b/backend/src/modules/rent/dto/create-reminders.dto.ts
@@ -1,0 +1,45 @@
+import {
+  IsDateString,
+  IsEmail,
+  IsNumber,
+  IsString,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateRemindersDto {
+  @ApiProperty({
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'UUID of the rent agreement',
+  })
+  @IsString()
+  agreementId: string;
+
+  @ApiProperty({
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'UUID of the tenant',
+  })
+  @IsString()
+  tenantId: string;
+
+  @ApiProperty({
+    example: 'tenant@example.com',
+    description: 'Tenant email address for reminder delivery',
+  })
+  @IsEmail()
+  tenantEmail: string;
+
+  @ApiProperty({
+    example: '2026-07-01',
+    description: 'Rent due date (ISO 8601)',
+  })
+  @IsDateString()
+  dueDate: string;
+
+  @ApiProperty({ example: 1500.0, description: 'Rent amount due', minimum: 0 })
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  amount: number;
+}

--- a/backend/src/modules/rent/dto/index.ts
+++ b/backend/src/modules/rent/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './calculate-late-fee.dto';
+export * from './calculate-prorated-rent.dto';
+export * from './create-reminders.dto';

--- a/backend/src/modules/rent/rent-reminder.service.spec.ts
+++ b/backend/src/modules/rent/rent-reminder.service.spec.ts
@@ -1,0 +1,379 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { RentReminderService } from './rent-reminder.service';
+import {
+  RentReminder,
+  ReminderStatus,
+  ReminderType,
+} from './entities/rent-reminder.entity';
+import { EmailService } from '../notifications/email.service';
+
+describe('RentReminderService', () => {
+  let service: RentReminderService;
+  let reminderRepository: jest.Mocked<Repository<RentReminder>>;
+  let emailService: jest.Mocked<EmailService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RentReminderService,
+        {
+          provide: getRepositoryToken(RentReminder),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: EmailService,
+          useValue: { sendNotificationEmail: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RentReminderService>(RentReminderService);
+    reminderRepository = module.get(getRepositoryToken(RentReminder));
+    emailService = module.get(EmailService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createRemindersForAgreement', () => {
+    it('creates one reminder per configured day-offset', async () => {
+      reminderRepository.create.mockImplementation(
+        (data) => data as RentReminder,
+      );
+      reminderRepository.save.mockImplementation((data) =>
+        Promise.resolve(data as RentReminder[]),
+      );
+
+      const dueDate = new Date('2026-07-01T00:00:00.000Z');
+      const result = await service.createRemindersForAgreement(
+        'agreement-1',
+        'tenant-1',
+        'tenant@example.com',
+        dueDate,
+        1500,
+      );
+
+      // REMINDER_OFFSETS = [7, 3, 1, 0, -1]
+      expect(result).toHaveLength(5);
+      expect(reminderRepository.create).toHaveBeenCalledTimes(5);
+      expect(reminderRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets every reminder to PENDING status and EMAIL type by default', async () => {
+      const created: Partial<RentReminder>[] = [];
+      reminderRepository.create.mockImplementation((data) => {
+        created.push(data as RentReminder);
+        return data as RentReminder;
+      });
+      reminderRepository.save.mockImplementation((data) =>
+        Promise.resolve(data as RentReminder[]),
+      );
+
+      await service.createRemindersForAgreement(
+        'agreement-1',
+        'tenant-1',
+        'tenant@example.com',
+        new Date('2026-07-01T00:00:00.000Z'),
+        1500,
+      );
+
+      for (const reminder of created) {
+        expect(reminder.status).toBe(ReminderStatus.PENDING);
+        expect(reminder.type).toBe(ReminderType.EMAIL);
+        expect(reminder.sent).toBe(false);
+        expect(reminder.agreementId).toBe('agreement-1');
+        expect(reminder.tenantId).toBe('tenant-1');
+        expect(reminder.tenantEmail).toBe('tenant@example.com');
+        expect(reminder.amount).toBe(1500);
+      }
+    });
+
+    it('includes the exact set of day-offsets from due date', async () => {
+      const created: Partial<RentReminder>[] = [];
+      reminderRepository.create.mockImplementation((data) => {
+        created.push(data as RentReminder);
+        return data as RentReminder;
+      });
+      reminderRepository.save.mockImplementation((data) =>
+        Promise.resolve(data as RentReminder[]),
+      );
+
+      await service.createRemindersForAgreement(
+        'agreement-1',
+        'tenant-1',
+        'tenant@example.com',
+        new Date('2026-07-01T00:00:00.000Z'),
+        1500,
+      );
+
+      expect(created.map((r) => r.daysBefore).sort((a, b) => a! - b!)).toEqual(
+        [-1, 0, 1, 3, 7],
+      );
+    });
+  });
+
+  describe('processPendingReminders', () => {
+    it('sends reminders whose scheduled send date has arrived', async () => {
+      const now = new Date('2026-07-01T12:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      const dueReminder = {
+        id: 'r1',
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        daysBefore: 0,
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      reminderRepository.find.mockResolvedValue([dueReminder]);
+      reminderRepository.save.mockResolvedValue(dueReminder);
+      emailService.sendNotificationEmail.mockResolvedValue(undefined);
+
+      const sentCount = await service.processPendingReminders();
+
+      expect(sentCount).toBe(1);
+      expect(emailService.sendNotificationEmail).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
+    });
+
+    it('skips reminders whose scheduled send date is still in the future', async () => {
+      const now = new Date('2026-06-01T00:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      const futureReminder = {
+        id: 'r1',
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        daysBefore: 7, // send date = June 24, still after "now" of June 1
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      reminderRepository.find.mockResolvedValue([futureReminder]);
+
+      const sentCount = await service.processPendingReminders();
+
+      expect(sentCount).toBe(0);
+      expect(emailService.sendNotificationEmail).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
+    });
+
+    it('continues processing remaining reminders when one fails to send', async () => {
+      const now = new Date('2026-07-01T12:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      const failing = {
+        id: 'r-fail',
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        daysBefore: 0,
+        tenantEmail: 'fail@example.com',
+        amount: 100,
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+      const succeeding = {
+        id: 'r-ok',
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        daysBefore: 0,
+        tenantEmail: 'ok@example.com',
+        amount: 200,
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      reminderRepository.find.mockResolvedValue([failing, succeeding]);
+      reminderRepository.save.mockImplementation((r) =>
+        Promise.resolve(r as RentReminder),
+      );
+      emailService.sendNotificationEmail
+        .mockRejectedValueOnce(new Error('SMTP down'))
+        .mockResolvedValueOnce(undefined);
+
+      const sentCount = await service.processPendingReminders();
+
+      expect(sentCount).toBe(1);
+      expect(emailService.sendNotificationEmail).toHaveBeenCalledTimes(2);
+
+      jest.useRealTimers();
+    });
+
+    it('returns zero when there are no pending reminders', async () => {
+      reminderRepository.find.mockResolvedValue([]);
+
+      const sentCount = await service.processPendingReminders();
+
+      expect(sentCount).toBe(0);
+      expect(emailService.sendNotificationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendReminder', () => {
+    it('marks the reminder as SENT on successful delivery', async () => {
+      const reminder = {
+        id: 'r1',
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        daysBefore: 3,
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        agreementId: 'agreement-1',
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      emailService.sendNotificationEmail.mockResolvedValue(undefined);
+      reminderRepository.save.mockResolvedValue(reminder);
+
+      await service.sendReminder(reminder);
+
+      expect(reminder.status).toBe(ReminderStatus.SENT);
+      expect(reminder.sent).toBe(true);
+      expect(reminder.sentAt).toBeInstanceOf(Date);
+      expect(reminderRepository.save).toHaveBeenCalledWith(reminder);
+    });
+
+    it('marks the reminder as FAILED and rethrows on delivery error', async () => {
+      const reminder = {
+        id: 'r1',
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        daysBefore: 3,
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        agreementId: 'agreement-1',
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      emailService.sendNotificationEmail.mockRejectedValue(
+        new Error('SMTP down'),
+      );
+      reminderRepository.save.mockResolvedValue(reminder);
+
+      await expect(service.sendReminder(reminder)).rejects.toThrow(
+        'SMTP down',
+      );
+
+      expect(reminder.status).toBe(ReminderStatus.FAILED);
+      expect(reminder.errorMessage).toBe('SMTP down');
+    });
+
+    it('builds a due-today subject line when daysBefore is zero', async () => {
+      const reminder = {
+        id: 'r1',
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        daysBefore: 0,
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        agreementId: 'agreement-1',
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      emailService.sendNotificationEmail.mockResolvedValue(undefined);
+      reminderRepository.save.mockResolvedValue(reminder);
+
+      await service.sendReminder(reminder);
+
+      const [, subject] = emailService.sendNotificationEmail.mock.calls[0];
+      expect(subject).toContain('Rent Due Today');
+    });
+
+    it('builds an overdue subject line when daysBefore is negative', async () => {
+      const reminder = {
+        id: 'r1',
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        daysBefore: -1,
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        agreementId: 'agreement-1',
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      emailService.sendNotificationEmail.mockResolvedValue(undefined);
+      reminderRepository.save.mockResolvedValue(reminder);
+
+      await service.sendReminder(reminder);
+
+      const [, subject] = emailService.sendNotificationEmail.mock.calls[0];
+      expect(subject).toContain('Overdue Rent');
+    });
+
+    it('builds an upcoming subject line when daysBefore is positive', async () => {
+      const reminder = {
+        id: 'r1',
+        tenantEmail: 'a@example.com',
+        amount: 100,
+        daysBefore: 7,
+        dueDate: new Date('2026-07-01T00:00:00.000Z'),
+        agreementId: 'agreement-1',
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      emailService.sendNotificationEmail.mockResolvedValue(undefined);
+      reminderRepository.save.mockResolvedValue(reminder);
+
+      await service.sendReminder(reminder);
+
+      const [, subject] = emailService.sendNotificationEmail.mock.calls[0];
+      expect(subject).toContain('Rent Reminder');
+      expect(subject).toContain('7 day(s)');
+    });
+  });
+
+  describe('getReminders', () => {
+    it('queries by agreement id ordered by due date then days-before descending', async () => {
+      reminderRepository.find.mockResolvedValue([]);
+
+      await service.getReminders('agreement-1');
+
+      expect(reminderRepository.find).toHaveBeenCalledWith({
+        where: { agreementId: 'agreement-1' },
+        order: { dueDate: 'ASC', daysBefore: 'DESC' },
+      });
+    });
+
+    it('returns the reminders found for the agreement', async () => {
+      const reminders = [{ id: 'r1' }, { id: 'r2' }] as RentReminder[];
+      reminderRepository.find.mockResolvedValue(reminders);
+
+      const result = await service.getReminders('agreement-1');
+
+      expect(result).toEqual(reminders);
+    });
+  });
+
+  describe('cancelReminder', () => {
+    it('throws NotFoundException when the reminder does not exist', async () => {
+      reminderRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.cancelReminder('missing-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('marks an existing reminder as CANCELLED and saves it', async () => {
+      const reminder = {
+        id: 'r1',
+        status: ReminderStatus.PENDING,
+      } as RentReminder;
+
+      reminderRepository.findOne.mockResolvedValue(reminder);
+      reminderRepository.save.mockResolvedValue({
+        ...reminder,
+        status: ReminderStatus.CANCELLED,
+      } as RentReminder);
+
+      const result = await service.cancelReminder('r1');
+
+      expect(reminder.status).toBe(ReminderStatus.CANCELLED);
+      expect(reminderRepository.save).toHaveBeenCalledWith(reminder);
+      expect(result.status).toBe(ReminderStatus.CANCELLED);
+    });
+  });
+});

--- a/backend/src/modules/rent/rent.controller.ts
+++ b/backend/src/modules/rent/rent.controller.ts
@@ -9,123 +9,14 @@ import {
   HttpStatus,
   ParseUUIDPipe,
 } from '@nestjs/common';
-import {
-  IsNumber,
-  IsOptional,
-  IsDateString,
-  IsString,
-  IsEmail,
-  Min,
-} from 'class-validator';
-import { Type } from 'class-transformer';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiProperty,
-  ApiPropertyOptional,
-} from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { RentService } from './rent.service';
 import { RentReminderService } from './rent-reminder.service';
-
-// ─── DTOs ────────────────────────────────────────────────────────────────────
-
-export class CalculateLateFeeDto {
-  @ApiProperty({
-    example: 1500.0,
-    description: 'Monthly rent amount',
-    minimum: 0,
-  })
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  monthlyRent: number;
-
-  @ApiProperty({
-    example: 10,
-    description: 'Number of days the payment is late',
-    minimum: 0,
-  })
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  daysLate: number;
-
-  @ApiPropertyOptional({
-    example: 5,
-    description: 'Grace period in days before late fees apply',
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  gracePeriodDays?: number;
-
-  @ApiPropertyOptional({
-    example: 0.05,
-    description: 'Daily late fee rate as a decimal (e.g., 0.05 = 5% per day)',
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  lateFeeRate?: number;
-}
-
-export class CalculateProratedRentDto {
-  @ApiProperty({
-    example: 1500.0,
-    description: 'Full monthly rent amount',
-    minimum: 0,
-  })
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  monthlyRent: number;
-
-  @ApiProperty({
-    example: '2026-06-15',
-    description: 'Move-in date for proration calculation (ISO 8601)',
-  })
-  @IsDateString()
-  moveInDate: string;
-}
-
-export class CreateRemindersDto {
-  @ApiProperty({
-    example: '123e4567-e89b-12d3-a456-426614174000',
-    description: 'UUID of the rent agreement',
-  })
-  @IsString()
-  agreementId: string;
-
-  @ApiProperty({
-    example: '123e4567-e89b-12d3-a456-426614174000',
-    description: 'UUID of the tenant',
-  })
-  @IsString()
-  tenantId: string;
-
-  @ApiProperty({
-    example: 'tenant@example.com',
-    description: 'Tenant email address for reminder delivery',
-  })
-  @IsEmail()
-  tenantEmail: string;
-
-  @ApiProperty({
-    example: '2026-07-01',
-    description: 'Rent due date (ISO 8601)',
-  })
-  @IsDateString()
-  dueDate: string;
-
-  @ApiProperty({ example: 1500.0, description: 'Rent amount due', minimum: 0 })
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  amount: number;
-}
+import {
+  CalculateLateFeeDto,
+  CalculateProratedRentDto,
+  CreateRemindersDto,
+} from './dto';
 
 // ─── Controller ──────────────────────────────────────────────────────────────
 

--- a/backend/src/modules/rent/rent.service.spec.ts
+++ b/backend/src/modules/rent/rent.service.spec.ts
@@ -1,0 +1,274 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RentService } from './rent.service';
+import { RentAgreement } from './entities/rent-contract.entity';
+import { Payment } from './entities/payment.entity';
+import { AgreementNotFoundError } from '../../common/errors/domain-errors';
+
+describe('RentService', () => {
+  let service: RentService;
+  let agreementRepository: jest.Mocked<Repository<RentAgreement>>;
+  let paymentRepository: jest.Mocked<Repository<Payment>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RentService,
+        {
+          provide: getRepositoryToken(RentAgreement),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(Payment),
+          useValue: { find: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RentService>(RentService);
+    agreementRepository = module.get(getRepositoryToken(RentAgreement));
+    paymentRepository = module.get(getRepositoryToken(Payment));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('calculateMonthlyRent', () => {
+    it('returns the base rent when no tax or fees are given', () => {
+      expect(service.calculateMonthlyRent(1000)).toBe(1000);
+    });
+
+    it('applies a tax rate on top of the base rent', () => {
+      // 1000 + (1000 * 0.1) = 1100
+      expect(service.calculateMonthlyRent(1000, 0.1)).toBe(1100);
+    });
+
+    it('adds flat fees on top of rent and tax', () => {
+      // 1000 + (1000 * 0.1) + 50 = 1150
+      expect(service.calculateMonthlyRent(1000, 0.1, 50)).toBe(1150);
+    });
+
+    it('rounds the result to two decimal places', () => {
+      // 999.99 * 1.075 = 1074.98925 -> rounds to 1074.99
+      expect(service.calculateMonthlyRent(999.99, 0.075)).toBe(1074.99);
+    });
+
+    it('handles a zero base rent', () => {
+      expect(service.calculateMonthlyRent(0, 0.1, 10)).toBe(10);
+    });
+  });
+
+  describe('calculateLateFee', () => {
+    it('returns zero when the payment is within the default grace period', () => {
+      expect(service.calculateLateFee(1500, 5)).toBe(0);
+    });
+
+    it('returns zero when the payment is exactly on the grace period boundary', () => {
+      expect(service.calculateLateFee(1500, 3, 3)).toBe(0);
+    });
+
+    it('charges a fee for the first day past the grace period', () => {
+      // grace=5, daysLate=6 -> 1 additional day
+      // flatFee = 1500 * 0.05 = 75; dailyPenalty = 1500 * 0.001 * 1 = 1.5
+      expect(service.calculateLateFee(1500, 6)).toBe(76.5);
+    });
+
+    it('uses the default 5-day grace period and 5% rate when not specified', () => {
+      // daysLate=10 -> 5 additional days
+      // flatFee = 1500 * 0.05 = 75; dailyPenalty = 1500 * 0.001 * 5 = 7.5
+      expect(service.calculateLateFee(1500, 10)).toBe(82.5);
+    });
+
+    it('honors a custom grace period', () => {
+      // grace=10, daysLate=10 -> within grace, no fee
+      expect(service.calculateLateFee(1500, 10, 10)).toBe(0);
+    });
+
+    it('honors a custom late fee rate', () => {
+      // grace=5, daysLate=6, rate=0.1 -> flatFee=150, dailyPenalty=1.5
+      expect(service.calculateLateFee(1500, 6, 5, 0.1)).toBe(151.5);
+    });
+
+    it('rounds the computed fee to two decimal places', () => {
+      const fee = service.calculateLateFee(999.99, 7);
+      expect(fee).toBe(Math.round(fee * 100) / 100);
+    });
+
+    it('returns zero for zero days late', () => {
+      expect(service.calculateLateFee(1500, 0)).toBe(0);
+    });
+  });
+
+  describe('calculateProratedRent', () => {
+    it('prorates rent for a move-in mid-month in a 31-day month', () => {
+      // January has 31 days; moving in on the 15th leaves 17 remaining days
+      // (31 - 15 + 1 = 17). dailyRate = 1500/31; prorated = dailyRate * 17
+      const result = service.calculateProratedRent(
+        1500,
+        new Date(2026, 0, 15),
+      );
+      const expected = Math.round((1500 / 31) * 17 * 100) / 100;
+      expect(result).toBe(expected);
+    });
+
+    it('returns the full monthly rent when moving in on the 1st', () => {
+      const result = service.calculateProratedRent(1500, new Date(2026, 0, 1));
+      expect(result).toBe(1500);
+    });
+
+    it('handles February in a non-leap year (28 days)', () => {
+      // 2026 is not a leap year
+      const result = service.calculateProratedRent(
+        2800,
+        new Date(2026, 1, 28),
+      );
+      // Last day of the month: remainingDays = 1
+      const expected = Math.round((2800 / 28) * 1 * 100) / 100;
+      expect(result).toBe(expected);
+    });
+
+    it('handles February in a leap year (29 days)', () => {
+      // 2028 is a leap year
+      const result = service.calculateProratedRent(
+        2900,
+        new Date(2028, 1, 29),
+      );
+      const expected = Math.round((2900 / 29) * 1 * 100) / 100;
+      expect(result).toBe(expected);
+    });
+
+    it('handles a move-in on the last day of a 30-day month', () => {
+      // April has 30 days
+      const result = service.calculateProratedRent(
+        3000,
+        new Date(2026, 3, 30),
+      );
+      const expected = Math.round((3000 / 30) * 1 * 100) / 100;
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('generatePaymentSchedule', () => {
+    it('generates a single entry when start and end date are the same month', () => {
+      const start = new Date(2026, 0, 1);
+      const end = new Date(2026, 0, 1);
+      const schedule = service.generatePaymentSchedule(
+        'agreement-1',
+        1000,
+        start,
+        end,
+      );
+
+      expect(schedule).toHaveLength(1);
+      expect(schedule[0]).toMatchObject({
+        paymentNumber: 1,
+        amount: 1000,
+        agreementId: 'agreement-1',
+      });
+    });
+
+    it('generates one entry per month across the date range, inclusive', () => {
+      const start = new Date(2026, 0, 1);
+      const end = new Date(2026, 2, 1); // Jan 1 -> Mar 1: 3 entries
+      const schedule = service.generatePaymentSchedule(
+        'agreement-1',
+        1000,
+        start,
+        end,
+      );
+
+      expect(schedule).toHaveLength(3);
+      expect(schedule.map((s) => s.paymentNumber)).toEqual([1, 2, 3]);
+    });
+
+    it('carries the agreement id and amount on every entry', () => {
+      const start = new Date(2026, 0, 1);
+      const end = new Date(2026, 1, 1);
+      const schedule = service.generatePaymentSchedule(
+        'agreement-xyz',
+        2500,
+        start,
+        end,
+      );
+
+      for (const entry of schedule) {
+        expect(entry.agreementId).toBe('agreement-xyz');
+        expect(entry.amount).toBe(2500);
+      }
+    });
+
+    it('rolls over year boundaries correctly (Dec -> Jan)', () => {
+      const start = new Date(2026, 11, 1); // Dec 1, 2026
+      const end = new Date(2027, 0, 1); // Jan 1, 2027
+      const schedule = service.generatePaymentSchedule(
+        'agreement-1',
+        1000,
+        start,
+        end,
+      );
+
+      expect(schedule).toHaveLength(2);
+      expect(schedule[0].dueDate.getFullYear()).toBe(2026);
+      expect(schedule[1].dueDate.getFullYear()).toBe(2027);
+    });
+
+    it('returns an empty schedule when start date is after end date', () => {
+      const start = new Date(2026, 5, 1);
+      const end = new Date(2026, 0, 1);
+      const schedule = service.generatePaymentSchedule(
+        'agreement-1',
+        1000,
+        start,
+        end,
+      );
+
+      expect(schedule).toHaveLength(0);
+    });
+  });
+
+  describe('getRentHistory', () => {
+    it('throws AgreementNotFoundError when the agreement does not exist', async () => {
+      agreementRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getRentHistory('missing-id')).rejects.toThrow(
+        AgreementNotFoundError,
+      );
+      expect(paymentRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('returns payments ordered by payment date descending', async () => {
+      const agreement = { id: 'agreement-1' } as RentAgreement;
+      const payments = [
+        { id: 'p1', paymentDate: new Date(2026, 1, 1) },
+        { id: 'p2', paymentDate: new Date(2026, 0, 1) },
+      ] as Payment[];
+
+      agreementRepository.findOne.mockResolvedValue(agreement);
+      paymentRepository.find.mockResolvedValue(payments);
+
+      const result = await service.getRentHistory('agreement-1');
+
+      expect(agreementRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'agreement-1' },
+      });
+      expect(paymentRepository.find).toHaveBeenCalledWith({
+        where: { agreementId: 'agreement-1' },
+        order: { paymentDate: 'DESC' },
+      });
+      expect(result).toEqual(payments);
+    });
+
+    it('returns an empty array when the agreement has no payments', async () => {
+      agreementRepository.findOne.mockResolvedValue({
+        id: 'agreement-1',
+      } as RentAgreement);
+      paymentRepository.find.mockResolvedValue([]);
+
+      const result = await service.getRentHistory('agreement-1');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/backend/src/modules/search/dto/index.ts
+++ b/backend/src/modules/search/dto/index.ts
@@ -1,0 +1,4 @@
+export * from './search-properties.dto';
+export * from './search-users.dto';
+export * from './search-documents.dto';
+export * from './suggest.dto';

--- a/backend/src/modules/search/dto/search-documents.dto.ts
+++ b/backend/src/modules/search/dto/search-documents.dto.ts
@@ -1,0 +1,126 @@
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsDateString,
+  Min,
+  Max,
+  MaxLength,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { AgreementStatus } from '../../rent/entities/rent-contract.entity';
+
+/** Trims a string and strips ASCII / unicode control characters. */
+function sanitizeString(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value.trim().replace(/\p{Cc}/gu, '');
+}
+
+/**
+ * Fields SearchService.searchDocuments() is allowed to sort by. Kept in
+ * sync with the `allowedSortFields` allowlist in search.service.ts.
+ */
+export const DOCUMENT_SEARCH_SORT_FIELDS = [
+  'createdAt',
+  'startDate',
+  'endDate',
+  'monthlyRent',
+  'status',
+] as const;
+
+export class SearchDocumentsDto {
+  @ApiPropertyOptional({ description: 'Full-text search query', maxLength: 200 })
+  @IsOptional()
+  @Transform(({ value }) => sanitizeString(value))
+  @IsString()
+  @MaxLength(200)
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by agreement status', enum: AgreementStatus })
+  @IsOptional()
+  @IsEnum(AgreementStatus)
+  status?: AgreementStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by property UUID' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(36)
+  propertyId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by tenant/user UUID' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(36)
+  userId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by admin UUID' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(36)
+  adminId?: string;
+
+  @ApiPropertyOptional({ description: 'Minimum monthly rent', minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  minRent?: number;
+
+  @ApiPropertyOptional({ description: 'Maximum monthly rent', minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  maxRent?: number;
+
+  @ApiPropertyOptional({ description: 'Inclusive start date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Inclusive end date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Field to sort by',
+    enum: DOCUMENT_SEARCH_SORT_FIELDS,
+    default: 'createdAt',
+  })
+  @IsOptional()
+  @IsIn(DOCUMENT_SEARCH_SORT_FIELDS)
+  sortBy?: (typeof DOCUMENT_SEARCH_SORT_FIELDS)[number];
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: ['asc', 'desc'],
+    default: 'desc',
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc';
+}

--- a/backend/src/modules/search/dto/search-properties.dto.ts
+++ b/backend/src/modules/search/dto/search-properties.dto.ts
@@ -1,0 +1,184 @@
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsNumber,
+  IsBoolean,
+  IsArray,
+  Min,
+  Max,
+  MaxLength,
+  ArrayMaxSize,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  PropertyType,
+  ListingStatus,
+} from '../../properties/entities/property.entity';
+
+/** Trims a string and strips ASCII / unicode control characters. */
+function sanitizeString(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  // \p{Cc} = Unicode "Control" category (covers NUL, BEL, DEL, etc.)
+  // The 'u' flag is required for Unicode property escapes.
+  return value.trim().replace(/\p{Cc}/gu, '');
+}
+
+/** Converts the common 'true'/'false' query string values to a boolean. */
+function toBoolean(value: unknown): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+}
+
+export class SearchPropertiesDto {
+  @ApiPropertyOptional({
+    description: 'Full-text search query',
+    maxLength: 200,
+  })
+  @IsOptional()
+  @Transform(({ value }) => sanitizeString(value))
+  @IsString()
+  @MaxLength(200)
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by city', maxLength: 100 })
+  @IsOptional()
+  @Transform(({ value }) => sanitizeString(value))
+  @IsString()
+  @MaxLength(100)
+  city?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by state', maxLength: 100 })
+  @IsOptional()
+  @Transform(({ value }) => sanitizeString(value))
+  @IsString()
+  @MaxLength(100)
+  state?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by country', maxLength: 100 })
+  @IsOptional()
+  @Transform(({ value }) => sanitizeString(value))
+  @IsString()
+  @MaxLength(100)
+  country?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by property type', enum: PropertyType })
+  @IsOptional()
+  @IsEnum(PropertyType)
+  type?: PropertyType;
+
+  @ApiPropertyOptional({ description: 'Filter by listing status', enum: ListingStatus })
+  @IsOptional()
+  @IsEnum(ListingStatus)
+  status?: ListingStatus;
+
+  @ApiPropertyOptional({ description: 'Minimum price', minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  minPrice?: number;
+
+  @ApiPropertyOptional({ description: 'Maximum price', minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  maxPrice?: number;
+
+  @ApiPropertyOptional({ description: 'Minimum bedrooms', minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  bedrooms?: number;
+
+  @ApiPropertyOptional({ description: 'Minimum bathrooms', minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  bathrooms?: number;
+
+  @ApiPropertyOptional({ description: 'Filter by furnished status' })
+  @IsOptional()
+  @Transform(({ value }) => toBoolean(value))
+  @IsBoolean()
+  furnished?: boolean;
+
+  @ApiPropertyOptional({ description: 'Filter by parking availability' })
+  @IsOptional()
+  @Transform(({ value }) => toBoolean(value))
+  @IsBoolean()
+  parking?: boolean;
+
+  @ApiPropertyOptional({ description: 'Filter by pets-allowed status' })
+  @IsOptional()
+  @Transform(({ value }) => toBoolean(value))
+  @IsBoolean()
+  petsAllowed?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Filter by amenity names (comma-separated or repeated param)',
+    type: [String],
+  })
+  @IsOptional()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.split(',').map((a) => a.trim()) : value,
+  )
+  @IsArray()
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  @MaxLength(100, { each: true })
+  amenities?: string[];
+
+  @ApiPropertyOptional({ description: 'Latitude for proximity search', minimum: -90, maximum: 90 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat?: number;
+
+  @ApiPropertyOptional({ description: 'Longitude for proximity search', minimum: -180, maximum: 180 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng?: number;
+
+  @ApiPropertyOptional({ description: 'Search radius in kilometres', minimum: 0.1, maximum: 500 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0.1)
+  @Max(500)
+  radiusKm?: number;
+
+  @ApiPropertyOptional({
+    description: 'Page number',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/modules/search/dto/search-users.dto.ts
+++ b/backend/src/modules/search/dto/search-users.dto.ts
@@ -1,0 +1,102 @@
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsIn,
+  IsBoolean,
+  IsNumber,
+  Min,
+  Max,
+  MaxLength,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole } from '../../users/entities/user.entity';
+
+/** Trims a string and strips ASCII / unicode control characters. */
+function sanitizeString(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value.trim().replace(/\p{Cc}/gu, '');
+}
+
+function toBoolean(value: unknown): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+}
+
+/**
+ * Fields SearchService.searchUsers() is allowed to sort by. Kept in sync
+ * with the `allowedSortFields` allowlist in search.service.ts.
+ */
+export const USER_SEARCH_SORT_FIELDS = [
+  'createdAt',
+  'firstName',
+  'lastName',
+  'email',
+  'role',
+] as const;
+
+export class SearchUsersDto {
+  @ApiPropertyOptional({ description: 'Full-text search query', maxLength: 200 })
+  @IsOptional()
+  @Transform(({ value }) => sanitizeString(value))
+  @IsString()
+  @MaxLength(200)
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by role', enum: UserRole })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @ApiPropertyOptional({ description: 'Filter by active status' })
+  @IsOptional()
+  @Transform(({ value }) => toBoolean(value))
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({ description: 'Filter by KYC verification status' })
+  @IsOptional()
+  @Transform(({ value }) => toBoolean(value))
+  @IsBoolean()
+  kycVerified?: boolean;
+
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Field to sort by',
+    enum: USER_SEARCH_SORT_FIELDS,
+    default: 'createdAt',
+  })
+  @IsOptional()
+  @IsIn(USER_SEARCH_SORT_FIELDS)
+  sortBy?: (typeof USER_SEARCH_SORT_FIELDS)[number];
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: ['asc', 'desc'],
+    default: 'desc',
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc';
+}

--- a/backend/src/modules/search/dto/suggest.dto.ts
+++ b/backend/src/modules/search/dto/suggest.dto.ts
@@ -1,0 +1,23 @@
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+/** Trims a string and strips ASCII / unicode control characters. */
+function sanitizeString(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value.trim().replace(/\p{Cc}/gu, '');
+}
+
+export class SuggestDto {
+  @ApiProperty({
+    description: 'Partial query to generate autocomplete suggestions for',
+    minLength: 1,
+    maxLength: 100,
+  })
+  @Transform(({ value }) => sanitizeString(value))
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  q: string;
+}

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import {
   SearchService,
   SearchFilters,
@@ -7,12 +7,11 @@ import {
   DocumentSearchFilters,
 } from './search.service';
 import {
-  PropertyType,
-  ListingStatus,
-} from '../properties/entities/property.entity';
-import { UserRole } from '../users/entities/user.entity';
-import { AgreementStatus } from '../rent/entities/rent-contract.entity';
-import {} from '../../common/constants/business-rules.constants';
+  SearchPropertiesDto,
+  SearchUsersDto,
+  SearchDocumentsDto,
+  SuggestDto,
+} from './dto';
 
 @ApiTags('Search')
 @Controller('search')
@@ -21,162 +20,73 @@ export class SearchController {
 
   @Get('properties')
   @ApiOperation({ summary: 'Full-text property search with faceted filtering' })
-  @ApiQuery({ name: 'q', required: false })
-  @ApiQuery({ name: 'city', required: false })
-  @ApiQuery({ name: 'type', required: false, enum: PropertyType })
-  @ApiQuery({ name: 'minPrice', required: false })
-  @ApiQuery({ name: 'maxPrice', required: false })
-  @ApiQuery({ name: 'bedrooms', required: false })
-  @ApiQuery({ name: 'lat', required: false })
-  @ApiQuery({ name: 'lng', required: false })
-  @ApiQuery({ name: 'radiusKm', required: false })
-  @ApiQuery({ name: 'amenities', required: false, isArray: true })
-  @ApiQuery({ name: 'page', required: false })
-  @ApiQuery({ name: 'limit', required: false })
-  async searchProperties(
-    @Query('q') query?: string,
-    @Query('city') city?: string,
-    @Query('state') state?: string,
-    @Query('country') country?: string,
-    @Query('type') type?: PropertyType,
-    @Query('status') status?: ListingStatus,
-    @Query('minPrice') minPrice?: string,
-    @Query('maxPrice') maxPrice?: string,
-    @Query('bedrooms') bedrooms?: string,
-    @Query('bathrooms') bathrooms?: string,
-    @Query('furnished') furnished?: string,
-    @Query('parking') parking?: string,
-    @Query('petsAllowed') petsAllowed?: string,
-    @Query('amenities') amenities?: string | string[],
-    @Query('lat') lat?: string,
-    @Query('lng') lng?: string,
-    @Query('radiusKm') radiusKm?: string,
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
-  ) {
-    const amenityList = amenities
-      ? Array.isArray(amenities)
-        ? amenities
-        : amenities.split(',').map((a) => a.trim())
-      : undefined;
-
+  async searchProperties(@Query() query: SearchPropertiesDto) {
     const filters: SearchFilters = {
-      query,
-      city,
-      state,
-      country,
-      type,
-      status,
-      minPrice: minPrice ? parseFloat(minPrice) : undefined,
-      maxPrice: maxPrice ? parseFloat(maxPrice) : undefined,
-      bedrooms: bedrooms ? parseInt(bedrooms) : undefined,
-      bathrooms: bathrooms ? parseInt(bathrooms) : undefined,
-      isFurnished: furnished !== undefined ? furnished === 'true' : undefined,
-      hasParking: parking !== undefined ? parking === 'true' : undefined,
-      petsAllowed:
-        petsAllowed !== undefined ? petsAllowed === 'true' : undefined,
-      amenities: amenityList,
-      lat: lat ? parseFloat(lat) : undefined,
-      lng: lng ? parseFloat(lng) : undefined,
-      radiusKm: radiusKm ? parseFloat(radiusKm) : undefined,
+      query: query.q,
+      city: query.city,
+      state: query.state,
+      country: query.country,
+      type: query.type,
+      status: query.status,
+      minPrice: query.minPrice,
+      maxPrice: query.maxPrice,
+      bedrooms: query.bedrooms,
+      bathrooms: query.bathrooms,
+      isFurnished: query.furnished,
+      hasParking: query.parking,
+      petsAllowed: query.petsAllowed,
+      amenities: query.amenities,
+      lat: query.lat,
+      lng: query.lng,
+      radiusKm: query.radiusKm,
     };
     return this.searchService.searchProperties(
       filters,
-      page ? parseInt(page) : 1,
-      limit ? Math.min(parseInt(limit), 100) : 20,
+      query.page,
+      query.limit,
     );
   }
 
   @Get('users')
   @ApiOperation({ summary: 'Search users with filters' })
-  @ApiQuery({ name: 'q', required: false })
-  @ApiQuery({ name: 'role', required: false, enum: UserRole })
-  @ApiQuery({ name: 'isActive', required: false })
-  @ApiQuery({ name: 'kycVerified', required: false })
-  @ApiQuery({ name: 'page', required: false })
-  @ApiQuery({ name: 'limit', required: false })
-  @ApiQuery({ name: 'sortBy', required: false })
-  @ApiQuery({ name: 'sortOrder', required: false, enum: ['asc', 'desc'] })
-  async searchUsers(
-    @Query('q') query?: string,
-    @Query('role') role?: UserRole,
-    @Query('isActive') isActive?: string,
-    @Query('kycVerified') kycVerified?: string,
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
-    @Query('sortBy') sortBy?: string,
-    @Query('sortOrder') sortOrder?: 'asc' | 'desc',
-  ) {
+  async searchUsers(@Query() query: SearchUsersDto) {
     const filters: UserSearchFilters = {
-      query,
-      role,
-      isActive: isActive !== undefined ? isActive === 'true' : undefined,
-      kycVerified:
-        kycVerified !== undefined ? kycVerified === 'true' : undefined,
-      sortBy,
-      sortOrder,
+      query: query.q,
+      role: query.role,
+      isActive: query.isActive,
+      kycVerified: query.kycVerified,
+      sortBy: query.sortBy,
+      sortOrder: query.sortOrder,
     };
-    return this.searchService.searchUsers(
-      filters,
-      page ? parseInt(page) : 1,
-      limit ? Math.min(parseInt(limit), 100) : 20,
-    );
+    return this.searchService.searchUsers(filters, query.page, query.limit);
   }
 
   @Get('documents')
   @ApiOperation({ summary: 'Search documents (agreements) with filters' })
-  @ApiQuery({ name: 'q', required: false })
-  @ApiQuery({ name: 'status', required: false, enum: AgreementStatus })
-  @ApiQuery({ name: 'propertyId', required: false })
-  @ApiQuery({ name: 'userId', required: false })
-  @ApiQuery({ name: 'adminId', required: false })
-  @ApiQuery({ name: 'minRent', required: false })
-  @ApiQuery({ name: 'maxRent', required: false })
-  @ApiQuery({ name: 'dateFrom', required: false })
-  @ApiQuery({ name: 'dateTo', required: false })
-  @ApiQuery({ name: 'page', required: false })
-  @ApiQuery({ name: 'limit', required: false })
-  @ApiQuery({ name: 'sortBy', required: false })
-  @ApiQuery({ name: 'sortOrder', required: false, enum: ['asc', 'desc'] })
-  async searchDocuments(
-    @Query('q') query?: string,
-    @Query('status') status?: AgreementStatus,
-    @Query('propertyId') propertyId?: string,
-    @Query('userId') userId?: string,
-    @Query('adminId') adminId?: string,
-    @Query('minRent') minRent?: string,
-    @Query('maxRent') maxRent?: string,
-    @Query('dateFrom') dateFrom?: string,
-    @Query('dateTo') dateTo?: string,
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
-    @Query('sortBy') sortBy?: string,
-    @Query('sortOrder') sortOrder?: 'asc' | 'desc',
-  ) {
+  async searchDocuments(@Query() query: SearchDocumentsDto) {
     const filters: DocumentSearchFilters = {
-      query,
-      status,
-      propertyId,
-      userId,
-      adminId,
-      minRent: minRent ? parseFloat(minRent) : undefined,
-      maxRent: maxRent ? parseFloat(maxRent) : undefined,
-      dateFrom,
-      dateTo,
-      sortBy,
-      sortOrder,
+      query: query.q,
+      status: query.status,
+      propertyId: query.propertyId,
+      userId: query.userId,
+      adminId: query.adminId,
+      minRent: query.minRent,
+      maxRent: query.maxRent,
+      dateFrom: query.dateFrom,
+      dateTo: query.dateTo,
+      sortBy: query.sortBy,
+      sortOrder: query.sortOrder,
     };
     return this.searchService.searchDocuments(
       filters,
-      page ? parseInt(page) : 1,
-      limit ? Math.min(parseInt(limit), 100) : 20,
+      query.page,
+      query.limit,
     );
   }
 
   @Get('suggest')
   @ApiOperation({ summary: 'Autocomplete suggestions for search' })
-  @ApiQuery({ name: 'q', required: true })
-  async suggest(@Query('q') q: string) {
-    return this.searchService.suggest(q);
+  async suggest(@Query() query: SuggestDto) {
+    return this.searchService.suggest(query.q);
   }
 }

--- a/backend/src/modules/security/dto/anchor-audit-logs.dto.ts
+++ b/backend/src/modules/security/dto/anchor-audit-logs.dto.ts
@@ -1,0 +1,18 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min, Max } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AnchorAuditLogsDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of un-anchored audit logs to anchor',
+    default: 100,
+    minimum: 1,
+    maximum: 1000,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  batchSize?: number = 100;
+}

--- a/backend/src/modules/security/dto/index.ts
+++ b/backend/src/modules/security/dto/index.ts
@@ -1,0 +1,6 @@
+export * from './query-security-events.dto';
+export * from './query-user-security-events.dto';
+export * from './query-threats.dto';
+export * from './query-compliance-report.dto';
+export * from './resolve-incident.dto';
+export * from './anchor-audit-logs.dto';

--- a/backend/src/modules/security/dto/query-compliance-report.dto.ts
+++ b/backend/src/modules/security/dto/query-compliance-report.dto.ts
@@ -1,0 +1,25 @@
+import { IsDateString, IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Shared query shape for the GDPR / SOC2 / PCI-DSS compliance report
+ * endpoints. Both bounds are optional ISO 8601 dates; the controller
+ * defaults `to` to now and `from` to 30 days before `to` when omitted.
+ */
+export class QueryComplianceReportDto {
+  @ApiPropertyOptional({
+    description: 'Inclusive report start date (ISO 8601)',
+    example: '2026-07-01',
+  })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({
+    description: 'Inclusive report end date (ISO 8601)',
+    example: '2026-08-01',
+  })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+}

--- a/backend/src/modules/security/dto/query-security-events.dto.ts
+++ b/backend/src/modules/security/dto/query-security-events.dto.ts
@@ -1,0 +1,31 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class QuerySecurityEventsDto {
+  @ApiPropertyOptional({
+    description: 'Look-back window in hours',
+    default: 24,
+    minimum: 1,
+    maximum: 720,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(720)
+  hours?: number = 24;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of events to return',
+    default: 100,
+    minimum: 1,
+    maximum: 500,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number = 100;
+}

--- a/backend/src/modules/security/dto/query-threats.dto.ts
+++ b/backend/src/modules/security/dto/query-threats.dto.ts
@@ -1,0 +1,33 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min, Max } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class QueryThreatsDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of threat events to return',
+    default: 50,
+    minimum: 1,
+    maximum: 500,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number = 50;
+}
+
+export class QueryThreatStatsDto {
+  @ApiPropertyOptional({
+    description: 'Look-back window in hours',
+    default: 24,
+    minimum: 1,
+    maximum: 720,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(720)
+  hours?: number = 24;
+}

--- a/backend/src/modules/security/dto/query-user-security-events.dto.ts
+++ b/backend/src/modules/security/dto/query-user-security-events.dto.ts
@@ -1,0 +1,29 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min, Max } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class QueryUserSecurityEventsDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of events to return',
+    default: 100,
+    minimum: 1,
+    maximum: 500,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number = 100;
+
+  @ApiPropertyOptional({
+    description: 'Number of events to skip',
+    default: 0,
+    minimum: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/backend/src/modules/security/dto/resolve-incident.dto.ts
+++ b/backend/src/modules/security/dto/resolve-incident.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ResolveIncidentDto {
+  @ApiPropertyOptional({
+    description: 'Free-text resolution note for the incident',
+    example: 'Rotated credentials and blocked offending IP range.',
+    maxLength: 2000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  resolution?: string;
+}

--- a/backend/src/modules/security/security.controller.ts
+++ b/backend/src/modules/security/security.controller.ts
@@ -8,8 +8,7 @@ import {
   Body,
   Res,
   UseGuards,
-  ParseIntPipe,
-  DefaultValuePipe,
+  ParseUUIDPipe,
   HttpCode,
   HttpStatus,
   UseInterceptors,
@@ -20,7 +19,6 @@ import {
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
-  ApiQuery,
   ApiParam,
 } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
@@ -37,6 +35,15 @@ import { UserRole } from '../users/entities/user.entity';
 import { AuditLog } from '../audit/decorators/audit-log.decorator';
 import { AuditAction, AuditLevel } from '../audit/entities/audit-log.entity';
 import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
+import {
+  QuerySecurityEventsDto,
+  QueryUserSecurityEventsDto,
+  QueryThreatsDto,
+  QueryThreatStatsDto,
+  QueryComplianceReportDto,
+  ResolveIncidentDto,
+  AnchorAuditLogsDto,
+} from './dto';
 
 @ApiTags('Security')
 @Controller()
@@ -104,14 +111,12 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get recent security events' })
-  @ApiQuery({ name: 'hours', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiResponse({ status: 200, description: 'Security events retrieved' })
-  async getSecurityEvents(
-    @Query('hours', new DefaultValuePipe(24), ParseIntPipe) hours: number,
-    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit: number,
-  ) {
-    return this.securityEventsService.getRecentEvents(hours, limit);
+  async getSecurityEvents(@Query() query: QuerySecurityEventsDto) {
+    return this.securityEventsService.getRecentEvents(
+      query.hours,
+      query.limit,
+    );
   }
 
   @Get('security/events/user/:userId')
@@ -121,11 +126,14 @@ export class SecurityController {
   @ApiOperation({ summary: 'Get security events for a specific user' })
   @ApiParam({ name: 'userId', type: String })
   async getUserEvents(
-    @Param('userId') userId: string,
-    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit: number,
-    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query() query: QueryUserSecurityEventsDto,
   ) {
-    return this.securityEventsService.getUserEvents(userId, limit, offset);
+    return this.securityEventsService.getUserEvents(
+      userId,
+      query.limit,
+      query.offset,
+    );
   }
 
   @Get('security/events/suspicious/:userId')
@@ -133,7 +141,7 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Check for suspicious activity on a user account' })
-  async detectSuspicious(@Param('userId') userId: string) {
+  async detectSuspicious(@Param('userId', ParseUUIDPipe) userId: string) {
     const suspicious =
       await this.securityEventsService.detectSuspiciousActivity(userId);
     return { userId, suspicious };
@@ -146,11 +154,8 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get recent threat events' })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  async getThreats(
-    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
-  ) {
-    return this.threatDetectionService.getRecentThreats(limit);
+  async getThreats(@Query() query: QueryThreatsDto) {
+    return this.threatDetectionService.getRecentThreats(query.limit);
   }
 
   @Get('security/threats/stats')
@@ -158,11 +163,8 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get threat detection statistics' })
-  @ApiQuery({ name: 'hours', required: false, type: Number })
-  async getThreatStats(
-    @Query('hours', new DefaultValuePipe(24), ParseIntPipe) hours: number,
-  ) {
-    return this.threatDetectionService.getThreatStats(hours);
+  async getThreatStats(@Query() query: QueryThreatStatsDto) {
+    return this.threatDetectionService.getThreatStats(query.hours);
   }
 
   @Patch('security/threats/:id/false-positive')
@@ -177,7 +179,7 @@ export class SecurityController {
     level: AuditLevel.SECURITY,
     includeNewValues: true,
   })
-  async markFalsePositive(@Param('id') threatId: string) {
+  async markFalsePositive(@Param('id', ParseUUIDPipe) threatId: string) {
     await this.threatDetectionService.markFalsePositive(threatId);
   }
 
@@ -214,11 +216,11 @@ export class SecurityController {
   })
   async resolveIncident(
     @Param('id') incidentId: string,
-    @Body('resolution') resolution: string,
+    @Body() dto: ResolveIncidentDto,
   ) {
     return this.incidentService.resolveIncident(
       incidentId,
-      resolution ?? 'Resolved by admin',
+      dto.resolution ?? 'Resolved by admin',
     );
   }
 
@@ -247,25 +249,10 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate GDPR compliance report' })
-  @ApiQuery({
-    name: 'from',
-    required: false,
-    type: String,
-    description: 'ISO date',
-  })
-  @ApiQuery({
-    name: 'to',
-    required: false,
-    type: String,
-    description: 'ISO date',
-  })
-  async getGdprReport(
-    @Query('from') fromStr?: string,
-    @Query('to') toStr?: string,
-  ) {
-    const to = toStr ? new Date(toStr) : new Date();
-    const from = fromStr
-      ? new Date(fromStr)
+  async getGdprReport(@Query() query: QueryComplianceReportDto) {
+    const to = query.to ? new Date(query.to) : new Date();
+    const from = query.from
+      ? new Date(query.from)
       : new Date(to.getTime() - 30 * 24 * 3600 * 1000);
     return this.complianceService.generateGdprReport(from, to);
   }
@@ -275,15 +262,10 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate SOC2 Type II compliance report' })
-  @ApiQuery({ name: 'from', required: false, type: String })
-  @ApiQuery({ name: 'to', required: false, type: String })
-  async getSoc2Report(
-    @Query('from') fromStr?: string,
-    @Query('to') toStr?: string,
-  ) {
-    const to = toStr ? new Date(toStr) : new Date();
-    const from = fromStr
-      ? new Date(fromStr)
+  async getSoc2Report(@Query() query: QueryComplianceReportDto) {
+    const to = query.to ? new Date(query.to) : new Date();
+    const from = query.from
+      ? new Date(query.from)
       : new Date(to.getTime() - 30 * 24 * 3600 * 1000);
     return this.complianceService.generateSoc2Report(from, to);
   }
@@ -293,15 +275,10 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate PCI-DSS compliance report' })
-  @ApiQuery({ name: 'from', required: false, type: String })
-  @ApiQuery({ name: 'to', required: false, type: String })
-  async getPciDssReport(
-    @Query('from') fromStr?: string,
-    @Query('to') toStr?: string,
-  ) {
-    const to = toStr ? new Date(toStr) : new Date();
-    const from = fromStr
-      ? new Date(fromStr)
+  async getPciDssReport(@Query() query: QueryComplianceReportDto) {
+    const to = query.to ? new Date(query.to) : new Date();
+    const from = query.from
+      ? new Date(query.from)
       : new Date(to.getTime() - 30 * 24 * 3600 * 1000);
     return this.complianceService.generatePciDssReport(from, to);
   }
@@ -348,19 +325,16 @@ export class SecurityController {
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Anchor latest audit log batch to blockchain' })
-  @ApiQuery({ name: 'batchSize', required: false, type: Number })
   @AuditLog({
     action: AuditAction.BLOCKCHAIN_TX_SUBMITTED,
     entityType: 'AuditBatch',
     level: AuditLevel.SECURITY,
     includeNewValues: true,
   })
-  async anchorAuditLogs(
-    @Query('batchSize', new DefaultValuePipe(100), ParseIntPipe)
-    batchSize: number,
-  ) {
-    const result =
-      await this.blockchainAuditService.anchorAuditBatch(batchSize);
+  async anchorAuditLogs(@Query() query: AnchorAuditLogsDto) {
+    const result = await this.blockchainAuditService.anchorAuditBatch(
+      query.batchSize,
+    );
     if (!result) return { message: 'No un-anchored audit logs found' };
     return result;
   }


### PR DESCRIPTION
## Summary
Adds request DTOs (class-validator, matching the pattern already used in `bookings/`, `properties/`, `payments/`, `stellar/`, etc.) to the security, search, and rent controllers, and adds unit tests for the two rent services that had none. No behavioral changes beyond validating/bounding input that was previously unchecked.

closes #1578
closes #1577
closes #1576
closes #1575

## Changes

- **#1578 — security controller has no DTO validation**: Added `security/dto/` with DTOs for every endpoint that takes query/body input (`QuerySecurityEventsDto`, `QueryUserSecurityEventsDto`, `QueryThreatsDto`, `QueryThreatStatsDto`, `QueryComplianceReportDto`, `ResolveIncidentDto`, `AnchorAuditLogsDto`) and wired them into `SecurityController`. Also switched `:userId`/`:id` params backed by real UUID primary keys (`User`, `ThreatEvent`) to `ParseUUIDPipe`. Left `:id` for security incidents as a plain string since `SecurityIncidentService` keys incidents by a composite string built from the threat event, not a UUID — coercing it would have silently broken that lookup. The security controller has no enum-typed request fields to begin with, so the "enum fields reject unknown values" acceptance criterion doesn't add anything concrete beyond the `IsEnum`/`IsIn` allowlists already used for query params.

- **#1577 — search module has no DTOs**: Added `search/dto/` (`SearchPropertiesDto`, `SearchUsersDto`, `SearchDocumentsDto`, `SuggestDto`) and wired them into `SearchController`. `limit` is capped at 100 everywhere, `page` at >= 1, and free-text fields are length-bounded. For the users/documents endpoints, `sortBy` is restricted via `IsIn` to the exact allowlist `SearchService` already enforces internally (`USER_SEARCH_SORT_FIELDS` / `DOCUMENT_SEARCH_SORT_FIELDS`, exported as named consts so the DTO and service can't silently drift apart). The properties endpoint doesn't expose `sortBy` at all — `SearchService.searchProperties` hardcodes `createdAt DESC` — so no allowlist was needed there. Note: the issue mentions Elasticsearch specifically, but `SearchController` doesn't call `ElasticsearchService` directly (it goes through `SearchService`, which queries Postgres via TypeORM); `ElasticsearchService` exists but isn't wired into this controller's request path in the current code, so there was no ES query construction here to harden beyond the shared filter/pagination surface.

- **#1576 — rent controller has no DTOs**: This one was already partially fixed — `RentController` already had `CalculateLateFeeDto`, `CalculateProratedRentDto`, and `CreateRemindersDto` with full `class-validator` decorators, they just lived inline in the controller file instead of `rent/dto/` like every other module. Extracted them to `rent/dto/` with an `index.ts` barrel (matching `stellar/dto`, `security/dto`), no behavioral change. All GET endpoints on this controller only take a `:id` path param, already guarded by `ParseUUIDPipe`.

- **#1575 — rent module untested**: Added `rent.service.spec.ts` (calculateMonthlyRent; calculateLateFee incl. grace-period boundary, custom rate/grace period, rounding; calculateProratedRent incl. mid-month, month-start, non-leap Feb, leap Feb, 30-day month; generatePaymentSchedule incl. single/multi-month, year rollover, inverted date range; getRentHistory incl. not-found, ordering, empty result) and `rent-reminder.service.spec.ts` (createRemindersForAgreement incl. offset set and default status/type; processPendingReminders incl. due vs. not-yet-due by send-date math, partial-failure continuation, empty input; sendReminder incl. success/failure status transitions and subject line per days-before sign; getReminders; cancelReminder incl. not-found and happy path). All numeric fee/proration expectations were computed by hand against the real implementation before being hardcoded into assertions.

## Test plan
Sandboxed environment — could not run `pnpm install` / `nest build` / `jest` locally. Verified by hand:
- Every modified controller file re-read in full after edits; no leftover references to removed imports (`ApiQuery`, `ParseIntPipe`, `DefaultValuePipe`) confirmed via grep.
- Cross-checked every DTO field name against the corresponding service's filter interface (`SearchFilters`, `UserSearchFilters`, `DocumentSearchFilters`) and controller usage to avoid silently dropping a param.
- Confirmed `User.id` and `ThreatEvent.id` are `@PrimaryGeneratedColumn('uuid')` before adding `ParseUUIDPipe` to those params.
- Hand-computed expected values for `calculateLateFee` and `calculateProratedRent` (grace boundaries, leap/non-leap February, 30/31-day months) in a scratch Node REPL against the exact algorithm in `rent.service.ts` before writing them into test assertions.
- Traced `processPendingReminders`' send-date math (`dueDate - daysBefore` vs. `now`) by hand for the due/not-yet-due test cases.

## Caveats
- None of this was run through the actual test suite, linter, or TypeScript compiler — please run CI and flag anything that doesn't type-check or pass, I'll fix promptly.
- `main.ts` already has `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true })` globally, so these DTOs plug directly into existing infrastructure — no wiring changes needed there.