### PR TITLE
feat(backend): document signing coverage, favorites pagination, queue metrics, and review booking verification

### DIFF
--- a/backend/src/migrations/1930000000000-AddDocumentSignatures.ts
+++ b/backend/src/migrations/1930000000000-AddDocumentSignatures.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDocumentSignatures1930000000000 implements MigrationInterface {
+  name = 'AddDocumentSignatures1930000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "documents"
+      ADD COLUMN "signatures" text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "documents"
+      DROP COLUMN "signatures"
+    `);
+  }
+}

--- a/backend/src/modules/documents/document.controller.ts
+++ b/backend/src/modules/documents/document.controller.ts
@@ -23,6 +23,8 @@ import {
   CreateDocumentDto,
   UpdateDocumentDto,
   ShareDocumentDto,
+  SignDocumentDto,
+  SignatureVerificationDto,
   DocumentFilterDto,
   DocumentResponseDto,
 } from './dto/document.dto';
@@ -121,6 +123,36 @@ export class DocumentController {
     return this.toResponse(doc);
   }
 
+  @Post(':id/sign')
+  @ApiOperation({ summary: 'Sign a document as one of its parties' })
+  @ApiResponse({ status: 200, type: DocumentResponseDto })
+  @ApiResponse({ status: 403, description: 'Not a party to the document' })
+  @ApiResponse({ status: 409, description: 'Already signed by this user' })
+  async sign(
+    @Param('id') id: string,
+    @Body() dto: SignDocumentDto,
+    @Req() req: { user: { id: string } },
+  ) {
+    const doc = await this.documentService.sign(
+      id,
+      req.user.id,
+      dto.signatureData,
+    );
+    return this.toResponse(doc);
+  }
+
+  @Get(':id/signatures')
+  @ApiOperation({
+    summary: 'Verify the integrity of all signatures on a document',
+  })
+  @ApiResponse({ status: 200, type: SignatureVerificationDto })
+  async verifySignatures(
+    @Param('id') id: string,
+    @Req() req: { user: { id: string } },
+  ) {
+    return this.documentService.verifySignatures(id, req.user.id);
+  }
+
   @Get(':id/download')
   @ApiOperation({ summary: 'Get document download URL' })
   @ApiResponse({ status: 200, description: 'Download URL' })
@@ -147,6 +179,12 @@ export class DocumentController {
       ownerId: doc.ownerId,
       description: doc.description,
       sharedWith: doc.sharedWith,
+      // Expose who signed and when, but never the raw signature payloads.
+      signatures:
+        doc.signatures?.map(({ signerId, signedAt }) => ({
+          signerId,
+          signedAt,
+        })) ?? null,
       createdAt: doc.createdAt.toISOString(),
       updatedAt: doc.updatedAt.toISOString(),
     };

--- a/backend/src/modules/documents/document.entity.ts
+++ b/backend/src/modules/documents/document.entity.ts
@@ -9,11 +9,19 @@ import {
 
 export type DocumentStatus = 'ACTIVE' | 'ARCHIVED' | 'EXPIRED';
 export type DocumentType =
-  | 'LEASE'
-  | 'INSPECTION'
-  | 'RECEIPT'
-  | 'CONTRACT'
-  | 'OTHER';
+  'LEASE' | 'INSPECTION' | 'RECEIPT' | 'CONTRACT' | 'OTHER';
+
+/**
+ * A captured signature. `payloadHash` binds the signature to the document
+ * content identifiers at signing time, so any later change to the underlying
+ * file is detectable as a hash mismatch.
+ */
+export interface DocumentSignature {
+  signerId: string;
+  signedAt: string;
+  signatureData: string;
+  payloadHash: string;
+}
 
 @Entity('documents')
 export class Document {
@@ -55,6 +63,9 @@ export class Document {
 
   @Column({ type: 'simple-array', nullable: true })
   sharedWith: string[] | null;
+
+  @Column({ type: 'simple-json', nullable: true })
+  signatures: DocumentSignature[] | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/modules/documents/document.service.spec.ts
+++ b/backend/src/modules/documents/document.service.spec.ts
@@ -22,6 +22,7 @@ describe('DocumentService', () => {
     ownerId: 'user-1',
     description: 'Test document',
     sharedWith: null,
+    signatures: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     deletedAt: null,
@@ -173,6 +174,189 @@ describe('DocumentService', () => {
     it('finds documents shared with a user', async () => {
       const result = await service.findSharedWithUser('tenant-1');
       expect(result).toEqual([mockDoc]);
+    });
+  });
+
+  describe('retrieval authorization', () => {
+    it('allows the owner to retrieve the document', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({ ...mockDoc });
+      await expect(service.findOne('doc-1', 'user-1')).resolves.toBeDefined();
+    });
+
+    it('allows a shared user to retrieve the document', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        sharedWith: ['tenant-9'],
+      });
+      const result = await service.findOne('doc-1', 'tenant-9');
+      expect(result.id).toBe('doc-1');
+    });
+
+    it('allows the document tenant to retrieve the document', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        tenantId: 'tenant-5',
+      });
+      const result = await service.findOne('doc-1', 'tenant-5');
+      expect(result.id).toBe('doc-1');
+    });
+
+    it('denies retrieval to a user who is not a party', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        tenantId: 'tenant-5',
+        sharedWith: ['tenant-9'],
+      });
+      await expect(service.findOne('doc-1', 'stranger')).rejects.toThrow(
+        'Access denied',
+      );
+    });
+  });
+
+  describe('sign', () => {
+    it('captures a signature from a party with a payload hash', async () => {
+      const doc = {
+        ...mockDoc,
+        status: 'ACTIVE',
+        tenantId: 'tenant-5',
+        signatures: null,
+      };
+      mockRepo.findOne.mockResolvedValueOnce(doc);
+      mockRepo.save.mockImplementationOnce((d: Document) => Promise.resolve(d));
+
+      const result = await service.sign('doc-1', 'tenant-5', 'sig-payload');
+
+      expect(result.signatures).toHaveLength(1);
+      const signature = result.signatures![0];
+      expect(signature.signerId).toBe('tenant-5');
+      expect(signature.signatureData).toBe('sig-payload');
+      expect(signature.payloadHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ signatures: [signature] }),
+      );
+    });
+
+    it('rejects a signer who is not a party to the document', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        status: 'ACTIVE',
+        signatures: null,
+      });
+      await expect(
+        service.sign('doc-1', 'stranger', 'sig-payload'),
+      ).rejects.toThrow('Only parties to the document can sign it');
+    });
+
+    it('rejects a duplicate signature from the same signer', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        status: 'ACTIVE',
+        signatures: null,
+      });
+      mockRepo.save.mockImplementationOnce((d: Document) => Promise.resolve(d));
+      const signed = await service.sign('doc-1', 'user-1', 'sig-payload');
+
+      mockRepo.findOne.mockResolvedValueOnce(signed);
+      await expect(
+        service.sign('doc-1', 'user-1', 'sig-payload-2'),
+      ).rejects.toThrow('Document already signed by this user');
+    });
+
+    it('rejects signing an archived document', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        status: 'ARCHIVED',
+        signatures: null,
+      });
+      await expect(
+        service.sign('doc-1', 'user-1', 'sig-payload'),
+      ).rejects.toThrow('Only active documents can be signed');
+    });
+
+    it('throws NotFoundException for a missing document', async () => {
+      mockRepo.findOne.mockResolvedValueOnce(null);
+      await expect(
+        service.sign('missing', 'user-1', 'sig-payload'),
+      ).rejects.toThrow('Document not found');
+    });
+  });
+
+  describe('signature payload integrity', () => {
+    async function signedDocument(): Promise<Document> {
+      const doc = {
+        ...mockDoc,
+        status: 'ACTIVE',
+        signatures: null,
+      } as Document;
+      mockRepo.findOne.mockResolvedValueOnce(doc);
+      mockRepo.save.mockImplementationOnce((d: Document) => Promise.resolve(d));
+      return service.sign('doc-1', 'user-1', 'sig-payload');
+    }
+
+    it('verifies an untampered signature as valid', async () => {
+      const doc = await signedDocument();
+      mockRepo.findOne.mockResolvedValueOnce(doc);
+
+      const verification = await service.verifySignatures('doc-1', 'user-1');
+
+      expect(verification.signatureCount).toBe(1);
+      expect(verification.allValid).toBe(true);
+      expect(verification.signatures[0]).toEqual(
+        expect.objectContaining({ signerId: 'user-1', valid: true }),
+      );
+    });
+
+    it('detects tampering when the file reference changes after signing', async () => {
+      const doc = await signedDocument();
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...doc,
+        fileKey: 'docs/user/swapped.pdf',
+      });
+
+      const verification = await service.verifySignatures('doc-1', 'user-1');
+
+      expect(verification.allValid).toBe(false);
+      expect(verification.signatures[0].valid).toBe(false);
+    });
+
+    it('detects tampering with the stored signature payload', async () => {
+      const doc = await signedDocument();
+      const tampered = {
+        ...doc,
+        signatures: [
+          { ...doc.signatures![0], signatureData: 'forged-payload' },
+        ],
+      };
+      mockRepo.findOne.mockResolvedValueOnce(tampered);
+
+      const verification = await service.verifySignatures('doc-1', 'user-1');
+
+      expect(verification.allValid).toBe(false);
+      expect(verification.signatures[0].valid).toBe(false);
+    });
+
+    it('reports an unsigned document as not fully signed', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        status: 'ACTIVE',
+        signatures: null,
+      });
+
+      const verification = await service.verifySignatures('doc-1', 'user-1');
+
+      expect(verification.signatureCount).toBe(0);
+      expect(verification.allValid).toBe(false);
+    });
+
+    it('denies verification to a user who is not a party', async () => {
+      mockRepo.findOne.mockResolvedValueOnce({
+        ...mockDoc,
+        status: 'ACTIVE',
+        signatures: null,
+      });
+      await expect(
+        service.verifySignatures('doc-1', 'stranger'),
+      ).rejects.toThrow('Access denied');
     });
   });
 });

--- a/backend/src/modules/documents/document.service.ts
+++ b/backend/src/modules/documents/document.service.ts
@@ -2,15 +2,18 @@ import {
   Injectable,
   NotFoundException,
   ForbiddenException,
+  ConflictException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createHash } from 'crypto';
 import { Document, DocumentType } from './document.entity';
 import {
   CreateDocumentDto,
   UpdateDocumentDto,
   DocumentFilterDto,
+  SignatureVerificationDto,
 } from './dto/document.dto';
 
 @Injectable()
@@ -88,15 +91,25 @@ export class DocumentService {
     return { documents, total, page, limit };
   }
 
-  async findOne(id: string, ownerId: string): Promise<Document> {
+  /**
+   * The parties to a document: its owner, the tenant it concerns, and any
+   * user it has been explicitly shared with. Only parties may retrieve or
+   * sign the document.
+   */
+  private isParty(doc: Document, userId: string): boolean {
+    return (
+      doc.ownerId === userId ||
+      doc.tenantId === userId ||
+      (doc.sharedWith ?? []).includes(userId)
+    );
+  }
+
+  async findOne(id: string, userId: string): Promise<Document> {
     const doc = await this.documentRepo.findOne({ where: { id } });
     if (!doc) {
       throw new NotFoundException('Document not found');
     }
-    if (
-      doc.ownerId !== ownerId &&
-      (!doc.sharedWith || !doc.sharedWith.includes(ownerId))
-    ) {
+    if (!this.isParty(doc, userId)) {
       throw new ForbiddenException('Access denied');
     }
     return doc;
@@ -161,5 +174,106 @@ export class DocumentService {
       .where('doc.sharedWith LIKE :userId', { userId: `%${userId}%` })
       .orderBy('doc.createdAt', 'DESC')
       .getMany();
+  }
+
+  /**
+   * Capture a signature from one of the document's parties.
+   *
+   * The stored `payloadHash` binds the signature payload to the document's
+   * content identifiers (`fileKey`, `fileSize`, `fileType`) at signing time;
+   * `verifySignatures` recomputes it to detect tampering.
+   */
+  async sign(
+    id: string,
+    signerId: string,
+    signatureData: string,
+  ): Promise<Document> {
+    const doc = await this.documentRepo.findOne({ where: { id } });
+    if (!doc) {
+      throw new NotFoundException('Document not found');
+    }
+    if (!this.isParty(doc, signerId)) {
+      throw new ForbiddenException('Only parties to the document can sign it');
+    }
+    if (doc.status !== 'ACTIVE') {
+      throw new ConflictException('Only active documents can be signed');
+    }
+
+    const signatures = doc.signatures ?? [];
+    if (signatures.some((s) => s.signerId === signerId)) {
+      throw new ConflictException('Document already signed by this user');
+    }
+
+    const signedAt = new Date().toISOString();
+    signatures.push({
+      signerId,
+      signedAt,
+      signatureData,
+      payloadHash: this.computeSignatureHash(
+        doc,
+        signerId,
+        signedAt,
+        signatureData,
+      ),
+    });
+    doc.signatures = signatures;
+
+    this.logger.log(`Document ${id} signed by ${signerId}`);
+    return this.documentRepo.save(doc);
+  }
+
+  /**
+   * Verify the integrity of every captured signature. A signature is valid
+   * only if its stored hash matches a hash recomputed from the document's
+   * current content identifiers — so any post-signing change to the file
+   * reference invalidates it.
+   */
+  async verifySignatures(
+    id: string,
+    userId: string,
+  ): Promise<SignatureVerificationDto> {
+    const doc = await this.findOne(id, userId);
+    const signatures = doc.signatures ?? [];
+
+    const results = signatures.map((signature) => ({
+      signerId: signature.signerId,
+      signedAt: signature.signedAt,
+      valid:
+        signature.payloadHash ===
+        this.computeSignatureHash(
+          doc,
+          signature.signerId,
+          signature.signedAt,
+          signature.signatureData,
+        ),
+    }));
+
+    return {
+      documentId: doc.id,
+      signatureCount: results.length,
+      allValid: results.length > 0 && results.every((r) => r.valid),
+      signatures: results,
+    };
+  }
+
+  private computeSignatureHash(
+    doc: Document,
+    signerId: string,
+    signedAt: string,
+    signatureData: string,
+  ): string {
+    return createHash('sha256')
+      .update(
+        [
+          doc.id,
+          doc.fileKey,
+          String(doc.fileSize),
+          doc.fileType,
+          signerId,
+          signedAt,
+          signatureData,
+        ].join('|'),
+      )
+      .digest('hex');
   }
 }

--- a/backend/src/modules/documents/dto/document.dto.ts
+++ b/backend/src/modules/documents/dto/document.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsString,
+  IsNotEmpty,
   IsOptional,
   IsEnum,
   IsNumber,
@@ -83,6 +84,49 @@ export class ShareDocumentDto {
   tenantId: string;
 }
 
+export class SignDocumentDto {
+  @ApiProperty({
+    description:
+      'Captured signature payload (e.g. base64 signature image or typed name attestation)',
+    example: 'data:image/png;base64,iVBORw0...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100000)
+  signatureData: string;
+}
+
+export class SignatureStatusDto {
+  @ApiProperty()
+  signerId: string;
+
+  @ApiProperty()
+  signedAt: string;
+
+  @ApiProperty({
+    description:
+      'False when the document content changed after signing (tamper detected)',
+  })
+  valid: boolean;
+}
+
+export class SignatureVerificationDto {
+  @ApiProperty()
+  documentId: string;
+
+  @ApiProperty()
+  signatureCount: number;
+
+  @ApiProperty({
+    description:
+      'True when at least one signature exists and every signature hash still matches the document content',
+  })
+  allValid: boolean;
+
+  @ApiProperty({ type: [SignatureStatusDto] })
+  signatures: SignatureStatusDto[];
+}
+
 export class DocumentFilterDto {
   @ApiPropertyOptional()
   @IsOptional()
@@ -159,6 +203,9 @@ export class DocumentResponseDto {
 
   @ApiProperty({ nullable: true })
   sharedWith: string[] | null;
+
+  @ApiProperty({ type: [SignatureStatusDto], nullable: true })
+  signatures: { signerId: string; signedAt: string }[] | null;
 
   @ApiProperty()
   createdAt: string;

--- a/backend/src/modules/favorites/dtos/favorite.dto.ts
+++ b/backend/src/modules/favorites/dtos/favorite.dto.ts
@@ -1,6 +1,12 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
 import { Property } from '../../properties/entities/property.entity';
+
+/** Page size applied when the client omits `limit`. */
+export const DEFAULT_FAVORITES_PAGE_SIZE = 20;
+/** Hard cap on `limit`; larger values are rejected. */
+export const MAX_FAVORITES_PAGE_SIZE = 100;
 
 export class FavoriteItemDto {
   @ApiProperty({
@@ -37,6 +43,51 @@ export class AddFavoriteDto {
   })
   @IsUUID()
   propertyId: string;
+}
+
+export class FavoritesQueryDto {
+  @ApiPropertyOptional({
+    description: '1-based page number',
+    example: 1,
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: `Page size (default ${DEFAULT_FAVORITES_PAGE_SIZE}, max ${MAX_FAVORITES_PAGE_SIZE})`,
+    example: DEFAULT_FAVORITES_PAGE_SIZE,
+    default: DEFAULT_FAVORITES_PAGE_SIZE,
+    minimum: 1,
+    maximum: MAX_FAVORITES_PAGE_SIZE,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(MAX_FAVORITES_PAGE_SIZE)
+  limit?: number;
+}
+
+export class PaginatedFavoritesDto {
+  @ApiProperty({ type: [FavoriteItemDto], description: 'Page of favorites' })
+  data: FavoriteItemDto[];
+
+  @ApiProperty({ description: 'Total favorites for the user', example: 42 })
+  total: number;
+
+  @ApiProperty({ description: '1-based page number', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: 'Page size used', example: 20 })
+  limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 3 })
+  totalPages: number;
 }
 
 export class FavoriteStatusDto {

--- a/backend/src/modules/favorites/favorites.controller.ts
+++ b/backend/src/modules/favorites/favorites.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Param,
   Body,
+  Query,
   UseGuards,
   HttpCode,
   HttpStatus,
@@ -25,6 +26,8 @@ import {
   AddFavoriteDto,
   FavoriteItemDto,
   FavoriteStatusDto,
+  FavoritesQueryDto,
+  PaginatedFavoritesDto,
 } from './dtos/favorite.dto';
 
 @ApiTags('favorites')
@@ -39,16 +42,20 @@ export class FavoritesController {
   @ApiOperation({
     summary: "Get current user's favorited properties",
     description:
-      'Retrieves a list of all properties favorited by the current user.',
+      'Retrieves a paginated list of properties favorited by the current user.',
   })
   @ApiResponse({
     status: 200,
-    description: 'List of favorited properties',
-    type: [FavoriteItemDto],
+    description: 'Paginated list of favorited properties',
+    type: PaginatedFavoritesDto,
   })
+  @ApiResponse({ status: 400, description: 'Invalid pagination parameters' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getFavorites(@CurrentUser() user: User): Promise<FavoriteItemDto[]> {
-    return this.favoritesService.getFavorites(user.id);
+  async getFavorites(
+    @CurrentUser() user: User,
+    @Query() query: FavoritesQueryDto,
+  ): Promise<PaginatedFavoritesDto> {
+    return this.favoritesService.getFavorites(user.id, query.page, query.limit);
   }
 
   @Get(':propertyId')

--- a/backend/src/modules/favorites/favorites.service.spec.ts
+++ b/backend/src/modules/favorites/favorites.service.spec.ts
@@ -45,6 +45,7 @@ describe('FavoritesService', () => {
           provide: getRepositoryToken(Favorite),
           useValue: {
             find: jest.fn(),
+            findAndCount: jest.fn(),
             findOne: jest.fn(),
             create: jest.fn(),
             save: jest.fn(),
@@ -70,27 +71,84 @@ describe('FavoritesService', () => {
   });
 
   describe('getFavorites', () => {
-    it('should return user favorites ordered by creation date', async () => {
-      const mockFavorites = [mockFavorite];
-      jest.spyOn(favoriteRepository, 'find').mockResolvedValue(mockFavorites);
+    it('should return a page of favorites ordered by creation date', async () => {
+      jest
+        .spyOn(favoriteRepository, 'findAndCount')
+        .mockResolvedValue([[mockFavorite], 1]);
 
       const result = await service.getFavorites(mockUserId);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].propertyId).toBe(mockPropertyId);
-      expect(favoriteRepository.find).toHaveBeenCalledWith({
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].propertyId).toBe(mockPropertyId);
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+      expect(favoriteRepository.findAndCount).toHaveBeenCalledWith({
         where: { userId: mockUserId },
         relations: ['property'],
         order: { createdAt: 'DESC' },
+        skip: 0,
+        take: 20,
       });
     });
 
-    it('should return empty array if user has no favorites', async () => {
-      jest.spyOn(favoriteRepository, 'find').mockResolvedValue([]);
+    it('should apply the default page size when limit is omitted', async () => {
+      jest.spyOn(favoriteRepository, 'findAndCount').mockResolvedValue([[], 0]);
 
       const result = await service.getFavorites(mockUserId);
 
-      expect(result).toEqual([]);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(favoriteRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 20 }),
+      );
+    });
+
+    it('should translate page and limit into skip/take', async () => {
+      jest
+        .spyOn(favoriteRepository, 'findAndCount')
+        .mockResolvedValue([[], 45]);
+
+      const result = await service.getFavorites(mockUserId, 3, 10);
+
+      expect(result.page).toBe(3);
+      expect(result.limit).toBe(10);
+      expect(result.totalPages).toBe(5);
+      expect(favoriteRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 20, take: 10 }),
+      );
+    });
+
+    it('should clamp the limit to the maximum page size', async () => {
+      jest.spyOn(favoriteRepository, 'findAndCount').mockResolvedValue([[], 0]);
+
+      const result = await service.getFavorites(mockUserId, 1, 5000);
+
+      expect(result.limit).toBe(100);
+      expect(favoriteRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+
+    it('should clamp non-positive page and limit values', async () => {
+      jest.spyOn(favoriteRepository, 'findAndCount').mockResolvedValue([[], 0]);
+
+      const result = await service.getFavorites(mockUserId, 0, -5);
+
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(1);
+      expect(favoriteRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 1 }),
+      );
+    });
+
+    it('should return an empty page if user has no favorites', async () => {
+      jest.spyOn(favoriteRepository, 'findAndCount').mockResolvedValue([[], 0]);
+
+      const result = await service.getFavorites(mockUserId);
+
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.totalPages).toBe(0);
     });
   });
 

--- a/backend/src/modules/favorites/favorites.service.ts
+++ b/backend/src/modules/favorites/favorites.service.ts
@@ -3,7 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Favorite } from './entities/favorite.entity';
 import { Property } from '../properties/entities/property.entity';
-import { FavoriteItemDto, FavoriteStatusDto } from './dtos/favorite.dto';
+import {
+  DEFAULT_FAVORITES_PAGE_SIZE,
+  FavoriteStatusDto,
+  MAX_FAVORITES_PAGE_SIZE,
+  PaginatedFavoritesDto,
+} from './dtos/favorite.dto';
 
 @Injectable()
 export class FavoritesService {
@@ -14,19 +19,39 @@ export class FavoritesService {
     private readonly propertyRepository: Repository<Property>,
   ) {}
 
-  async getFavorites(userId: string): Promise<FavoriteItemDto[]> {
-    const favorites = await this.favoriteRepository.find({
+  async getFavorites(
+    userId: string,
+    page?: number,
+    limit?: number,
+  ): Promise<PaginatedFavoritesDto> {
+    // Defensive clamping so a large favorites list can never produce an
+    // unbounded payload, even if a caller bypasses DTO validation.
+    const safePage = Math.max(1, Math.floor(page ?? 1));
+    const safeLimit = Math.min(
+      MAX_FAVORITES_PAGE_SIZE,
+      Math.max(1, Math.floor(limit ?? DEFAULT_FAVORITES_PAGE_SIZE)),
+    );
+
+    const [favorites, total] = await this.favoriteRepository.findAndCount({
       where: { userId },
       relations: ['property'],
       order: { createdAt: 'DESC' },
+      skip: (safePage - 1) * safeLimit,
+      take: safeLimit,
     });
 
-    return favorites.map((fav) => ({
-      id: fav.id,
-      propertyId: fav.propertyId,
-      property: fav.property,
-      createdAt: fav.createdAt.toISOString(),
-    }));
+    return {
+      data: favorites.map((fav) => ({
+        id: fav.id,
+        propertyId: fav.propertyId,
+        property: fav.property,
+        createdAt: fav.createdAt.toISOString(),
+      })),
+      total,
+      page: safePage,
+      limit: safeLimit,
+      totalPages: Math.ceil(total / safeLimit),
+    };
   }
 
   async getFavoriteStatus(

--- a/backend/src/modules/monitoring/metrics.service.spec.ts
+++ b/backend/src/modules/monitoring/metrics.service.spec.ts
@@ -99,4 +99,52 @@ describe('MetricsService', () => {
       ).not.toThrow();
     });
   });
+
+  describe('Queue metrics', () => {
+    it('exposes per-queue gauges on the metrics endpoint output', async () => {
+      service.setQueueMetrics('email', {
+        depth: 12,
+        oldestJobAgeSeconds: 480,
+        active: 2,
+        failed: 3,
+        paused: false,
+        stalled: true,
+      });
+
+      const output = await service.getMetrics();
+
+      expect(output).toContain('queue_depth{queue="email"} 12');
+      expect(output).toContain(
+        'queue_oldest_job_age_seconds{queue="email"} 480',
+      );
+      expect(output).toContain('queue_active_jobs{queue="email"} 2');
+      expect(output).toContain('queue_failed_jobs{queue="email"} 3');
+      expect(output).toContain('queue_paused{queue="email"} 0');
+      expect(output).toContain('queue_stalled{queue="email"} 1');
+    });
+
+    it('clears the stalled gauge on recovery', async () => {
+      service.setQueueMetrics('email', {
+        depth: 12,
+        oldestJobAgeSeconds: 480,
+        active: 0,
+        failed: 0,
+        paused: false,
+        stalled: true,
+      });
+      service.setQueueMetrics('email', {
+        depth: 0,
+        oldestJobAgeSeconds: 0,
+        active: 0,
+        failed: 0,
+        paused: false,
+        stalled: false,
+      });
+
+      const output = await service.getMetrics();
+
+      expect(output).toContain('queue_stalled{queue="email"} 0');
+      expect(output).toContain('queue_depth{queue="email"} 0');
+    });
+  });
 });

--- a/backend/src/modules/monitoring/metrics.service.ts
+++ b/backend/src/modules/monitoring/metrics.service.ts
@@ -148,6 +148,48 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  private readonly queueDepth = new Gauge({
+    name: 'queue_depth',
+    help: 'Jobs waiting or delayed in the queue',
+    labelNames: ['queue'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly queueOldestJobAgeSeconds = new Gauge({
+    name: 'queue_oldest_job_age_seconds',
+    help: 'Age in seconds of the oldest waiting job in the queue',
+    labelNames: ['queue'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly queueActiveJobs = new Gauge({
+    name: 'queue_active_jobs',
+    help: 'Jobs currently being processed in the queue',
+    labelNames: ['queue'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly queueFailedJobs = new Gauge({
+    name: 'queue_failed_jobs',
+    help: 'Jobs in the failed state for the queue',
+    labelNames: ['queue'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly queuePaused = new Gauge({
+    name: 'queue_paused',
+    help: 'Whether the queue is paused (1) or running (0)',
+    labelNames: ['queue'] as const,
+    registers: [this.registry],
+  });
+
+  private readonly queueStalledState = new Gauge({
+    name: 'queue_stalled',
+    help: 'Whether the queue is considered stalled (1): jobs are waiting longer than the stall threshold',
+    labelNames: ['queue'] as const,
+    registers: [this.registry],
+  });
+
   private readonly rentPayments = new Counter({
     name: 'rent_payments_total',
     help: 'Total rent payment attempts',
@@ -287,6 +329,30 @@ export class MetricsService implements OnModuleInit {
     this.cacheHitRatio.set(
       this.cacheTotal > 0 ? this.cacheHits / this.cacheTotal : 0,
     );
+  }
+
+  /**
+   * Export per-queue gauges so a stalled or backed-up background processor
+   * is visible on the Prometheus metrics endpoint before user-facing
+   * symptoms appear.
+   */
+  setQueueMetrics(
+    queue: string,
+    metrics: {
+      depth: number;
+      oldestJobAgeSeconds: number;
+      active: number;
+      failed: number;
+      paused: boolean;
+      stalled: boolean;
+    },
+  ): void {
+    this.queueDepth.set({ queue }, metrics.depth);
+    this.queueOldestJobAgeSeconds.set({ queue }, metrics.oldestJobAgeSeconds);
+    this.queueActiveJobs.set({ queue }, metrics.active);
+    this.queueFailedJobs.set({ queue }, metrics.failed);
+    this.queuePaused.set({ queue }, metrics.paused ? 1 : 0);
+    this.queueStalledState.set({ queue }, metrics.stalled ? 1 : 0);
   }
 
   recordRentPayment(status: 'success' | 'failed'): void {

--- a/backend/src/modules/queues/services/queue-monitoring.service.spec.ts
+++ b/backend/src/modules/queues/services/queue-monitoring.service.spec.ts
@@ -1,0 +1,286 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
+import { MetricsService } from '../../monitoring/metrics.service';
+import { AlertService } from '../../monitoring/alert.service';
+import {
+  DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS,
+  QueueMonitoringService,
+} from './queue-monitoring.service';
+
+type MockQueue = {
+  getJobCounts: jest.Mock;
+  isPaused: jest.Mock;
+  getWaiting: jest.Mock;
+};
+
+const healthyCounts = {
+  active: 0,
+  wait: 0,
+  delayed: 0,
+  failed: 0,
+  completed: 0,
+};
+
+function makeQueue(): MockQueue {
+  return {
+    getJobCounts: jest.fn().mockResolvedValue({ ...healthyCounts }),
+    isPaused: jest.fn().mockResolvedValue(false),
+    getWaiting: jest.fn().mockResolvedValue([]),
+  };
+}
+
+describe('QueueMonitoringService', () => {
+  let service: QueueMonitoringService;
+  let emailQueue: MockQueue;
+  let metricsService: { setQueueMetrics: jest.Mock };
+  let alertService: { handleAlert: jest.Mock };
+  let configGet: jest.Mock;
+
+  async function buildService(): Promise<void> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueMonitoringService,
+        { provide: getQueueToken('email'), useValue: emailQueue },
+        { provide: getQueueToken('documents'), useValue: makeQueue() },
+        { provide: getQueueToken('blockchain'), useValue: makeQueue() },
+        { provide: getQueueToken('data-sync'), useValue: makeQueue() },
+        { provide: MetricsService, useValue: metricsService },
+        { provide: AlertService, useValue: alertService },
+        { provide: ConfigService, useValue: { get: configGet } },
+      ],
+    }).compile();
+
+    service = module.get(QueueMonitoringService);
+  }
+
+  beforeEach(async () => {
+    emailQueue = makeQueue();
+    metricsService = { setQueueMetrics: jest.fn() };
+    alertService = { handleAlert: jest.fn().mockResolvedValue(undefined) };
+    configGet = jest.fn((_key: string, defaultValue?: unknown) => defaultValue);
+    await buildService();
+  });
+
+  it('exports depth, oldest-job age, active and failed gauges per queue', async () => {
+    const now = Date.now();
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 2,
+      wait: 3,
+      delayed: 1,
+      failed: 4,
+      completed: 10,
+    });
+    emailQueue.getWaiting.mockResolvedValue([
+      { timestamp: now - 20_000 },
+      { timestamp: now - 45_000 },
+    ]);
+
+    await service.collectMetrics();
+
+    expect(metricsService.setQueueMetrics).toHaveBeenCalledWith(
+      'email',
+      expect.objectContaining({
+        depth: 4, // waiting (3) + delayed (1)
+        active: 2,
+        failed: 4,
+        paused: false,
+        stalled: false,
+      }),
+    );
+    const emailCall = metricsService.setQueueMetrics.mock.calls.find(
+      ([queue]) => queue === 'email',
+    );
+    expect(emailCall[1].oldestJobAgeSeconds).toBeGreaterThanOrEqual(44);
+    expect(emailCall[1].oldestJobAgeSeconds).toBeLessThanOrEqual(46);
+
+    // Every configured queue is exported on the metrics endpoint path.
+    const exported = metricsService.setQueueMetrics.mock.calls.map(
+      ([queue]) => queue,
+    );
+    expect(exported).toEqual(
+      expect.arrayContaining(['email', 'documents', 'blockchain', 'data-sync']),
+    );
+  });
+
+  it('accepts the alternative `waiting` job-count key', async () => {
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 0,
+      waiting: 7,
+      delayed: 0,
+      failed: 0,
+      completed: 0,
+    });
+
+    await service.collectMetrics();
+
+    expect(metricsService.setQueueMetrics).toHaveBeenCalledWith(
+      'email',
+      expect.objectContaining({ depth: 7 }),
+    );
+  });
+
+  it('reports zero oldest-job age when nothing is waiting', async () => {
+    await service.collectMetrics();
+
+    expect(metricsService.setQueueMetrics).toHaveBeenCalledWith(
+      'email',
+      expect.objectContaining({ oldestJobAgeSeconds: 0, depth: 0 }),
+    );
+  });
+
+  it('fires a QueueStalled alert when the oldest job exceeds the threshold', async () => {
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 0,
+      wait: 5,
+      delayed: 0,
+      failed: 0,
+      completed: 0,
+    });
+    emailQueue.getWaiting.mockResolvedValue([
+      {
+        timestamp:
+          Date.now() - (DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS + 60) * 1000,
+      },
+    ]);
+
+    await service.collectMetrics();
+
+    expect(metricsService.setQueueMetrics).toHaveBeenCalledWith(
+      'email',
+      expect.objectContaining({ stalled: true }),
+    );
+    expect(alertService.handleAlert).toHaveBeenCalledTimes(1);
+    expect(alertService.handleAlert).toHaveBeenCalledWith({
+      alerts: [
+        expect.objectContaining({
+          status: 'firing',
+          labels: expect.objectContaining({
+            alertname: 'QueueStalled',
+            severity: 'critical',
+            queue: 'email',
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('does not re-fire while the queue remains stalled', async () => {
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 0,
+      wait: 5,
+      delayed: 0,
+      failed: 0,
+      completed: 0,
+    });
+    emailQueue.getWaiting.mockResolvedValue([
+      {
+        timestamp:
+          Date.now() - (DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS + 60) * 1000,
+      },
+    ]);
+
+    await service.collectMetrics();
+    await service.collectMetrics();
+
+    const firing = alertService.handleAlert.mock.calls.filter(
+      ([payload]) => payload.alerts[0].status === 'firing',
+    );
+    expect(firing).toHaveLength(1);
+  });
+
+  it('resolves the alert when the queue drains', async () => {
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 0,
+      wait: 5,
+      delayed: 0,
+      failed: 0,
+      completed: 0,
+    });
+    emailQueue.getWaiting.mockResolvedValue([
+      {
+        timestamp:
+          Date.now() - (DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS + 60) * 1000,
+      },
+    ]);
+    await service.collectMetrics();
+
+    emailQueue.getJobCounts.mockResolvedValue({ ...healthyCounts });
+    emailQueue.getWaiting.mockResolvedValue([]);
+    await service.collectMetrics();
+
+    expect(alertService.handleAlert).toHaveBeenLastCalledWith({
+      alerts: [
+        expect.objectContaining({
+          status: 'resolved',
+          labels: expect.objectContaining({
+            alertname: 'QueueStalled',
+            queue: 'email',
+          }),
+        }),
+      ],
+    });
+    expect(metricsService.setQueueMetrics).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.objectContaining({ stalled: false }),
+    );
+  });
+
+  it('does not alert for a healthy queue', async () => {
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 1,
+      wait: 2,
+      delayed: 0,
+      failed: 0,
+      completed: 5,
+    });
+    emailQueue.getWaiting.mockResolvedValue([
+      { timestamp: Date.now() - 10_000 },
+    ]);
+
+    await service.collectMetrics();
+
+    expect(alertService.handleAlert).not.toHaveBeenCalled();
+  });
+
+  it('honours a configured stall threshold', async () => {
+    configGet = jest.fn((key: string, def?: unknown) =>
+      key === 'STALLED_QUEUE_THRESHOLD_SECONDS' ? 30 : def,
+    );
+    await buildService();
+
+    emailQueue.getJobCounts.mockResolvedValue({
+      active: 0,
+      wait: 1,
+      delayed: 0,
+      failed: 0,
+      completed: 0,
+    });
+    // 60s old: beyond the configured 30s but far below the 300s default.
+    emailQueue.getWaiting.mockResolvedValue([
+      { timestamp: Date.now() - 60_000 },
+    ]);
+
+    await service.collectMetrics();
+
+    expect(alertService.handleAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alerts: [expect.objectContaining({ status: 'firing' })],
+      }),
+    );
+  });
+
+  it('keeps collecting for other queues when one queue errors', async () => {
+    emailQueue.getJobCounts.mockRejectedValue(new Error('redis down'));
+
+    await service.collectMetrics();
+
+    const exported = metricsService.setQueueMetrics.mock.calls.map(
+      ([queue]) => queue,
+    );
+    expect(exported).not.toContain('email');
+    expect(exported).toEqual(
+      expect.arrayContaining(['documents', 'blockchain', 'data-sync']),
+    );
+  });
+});

--- a/backend/src/modules/queues/services/queue-monitoring.service.ts
+++ b/backend/src/modules/queues/services/queue-monitoring.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
 import { Queue } from 'bull';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { MetricsService } from '../../monitoring/metrics.service';
+import { AlertService } from '../../monitoring/alert.service';
 
 export interface QueueMetrics {
   timestamp: Date;
@@ -12,20 +15,46 @@ export interface QueueMetrics {
   failed: number;
   completed: number;
   paused: boolean;
+  /** Waiting plus delayed jobs. */
+  depth: number;
+  /** Age in seconds of the oldest waiting job (0 when nothing waits). */
+  oldestJobAgeSeconds: number;
 }
+
+/** Default age (seconds) a waiting job may reach before the queue counts as stalled. */
+export const DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS = 300;
+
+/** How many waiting jobs to sample when looking for the oldest one. */
+const OLDEST_JOB_SAMPLE_SIZE = 50;
 
 @Injectable()
 export class QueueMonitoringService {
   private readonly logger = new Logger(QueueMonitoringService.name);
   private metrics: Map<string, QueueMetrics[]> = new Map();
   private readonly maxMetricsPerQueue = 1000; // Keep last 1000 metrics per queue
+  /** Queues currently flagged as stalled, so alerts fire only on transitions. */
+  private readonly stalledQueues = new Set<string>();
+  private readonly stalledThresholdSeconds: number;
 
   constructor(
     @InjectQueue('email') private emailQueue: Queue,
     @InjectQueue('documents') private documentsQueue: Queue,
     @InjectQueue('blockchain') private blockchainQueue: Queue,
     @InjectQueue('data-sync') private dataSyncQueue: Queue,
+    private readonly metricsService: MetricsService,
+    private readonly alertService: AlertService,
+    configService: ConfigService,
   ) {
+    const configured = Number(
+      configService.get(
+        'STALLED_QUEUE_THRESHOLD_SECONDS',
+        DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS,
+      ),
+    );
+    this.stalledThresholdSeconds =
+      Number.isFinite(configured) && configured > 0
+        ? configured
+        : DEFAULT_STALLED_QUEUE_THRESHOLD_SECONDS;
     this.initializeMetrics();
   }
 
@@ -52,15 +81,21 @@ export class QueueMonitoringService {
       try {
         const counts = await queue.getJobCounts();
         const isPaused = await queue.isPaused();
+        // Bull reports the waiting count as `waiting`; some Redis providers
+        // surface it as `wait`, so accept either.
+        const waiting = (counts as any).wait ?? (counts as any).waiting ?? 0;
+        const oldestJobAgeSeconds = await this.getOldestWaitingJobAge(queue);
         const metric: QueueMetrics = {
           timestamp: new Date(),
           queueName: name,
           active: counts.active,
-          waiting: (counts as any).wait || 0,
+          waiting,
           delayed: counts.delayed,
           failed: counts.failed,
           completed: counts.completed,
           paused: isPaused,
+          depth: waiting + counts.delayed,
+          oldestJobAgeSeconds,
         };
 
         const queueMetrics = this.metrics.get(name) || [];
@@ -73,6 +108,16 @@ export class QueueMonitoringService {
 
         this.metrics.set(name, queueMetrics);
 
+        const stalled = this.evaluateStalledState(metric);
+        this.metricsService.setQueueMetrics(name, {
+          depth: metric.depth,
+          oldestJobAgeSeconds,
+          active: counts.active,
+          failed: counts.failed,
+          paused: isPaused,
+          stalled,
+        });
+
         // Log warning if queue has too many failed jobs
         if (counts.failed > 10) {
           this.logger.warn(`Queue ${name} has ${counts.failed} failed jobs`);
@@ -83,6 +128,82 @@ export class QueueMonitoringService {
           error instanceof Error ? error.stack : 'Unknown error',
         );
       }
+    }
+  }
+
+  /**
+   * Age in seconds of the oldest job in the waiting list, sampled over the
+   * first [`OLDEST_JOB_SAMPLE_SIZE`] entries. Returns 0 when nothing waits.
+   */
+  private async getOldestWaitingJobAge(queue: Queue): Promise<number> {
+    const waitingJobs = await queue.getWaiting(0, OLDEST_JOB_SAMPLE_SIZE - 1);
+    if (!waitingJobs || waitingJobs.length === 0) {
+      return 0;
+    }
+    const oldestTimestamp = waitingJobs.reduce(
+      (oldest, job) => Math.min(oldest, job.timestamp),
+      Number.POSITIVE_INFINITY,
+    );
+    if (!Number.isFinite(oldestTimestamp)) {
+      return 0;
+    }
+    return Math.max(0, Math.floor((Date.now() - oldestTimestamp) / 1000));
+  }
+
+  /**
+   * A queue is stalled when jobs are waiting and the oldest of them has
+   * exceeded the configured threshold. Fires a `QueueStalled` alert on the
+   * transition into the stalled state and resolves it on recovery, so a
+   * stalled processor is surfaced before user-facing symptoms appear.
+   */
+  private evaluateStalledState(metric: QueueMetrics): boolean {
+    const stalled =
+      metric.depth > 0 &&
+      metric.oldestJobAgeSeconds >= this.stalledThresholdSeconds;
+    const wasStalled = this.stalledQueues.has(metric.queueName);
+
+    if (stalled && !wasStalled) {
+      this.stalledQueues.add(metric.queueName);
+      this.logger.error(
+        `Queue ${metric.queueName} is stalled: oldest waiting job is ${metric.oldestJobAgeSeconds}s old (threshold ${this.stalledThresholdSeconds}s)`,
+      );
+      void this.fireStalledAlert(metric, 'firing');
+    } else if (!stalled && wasStalled) {
+      this.stalledQueues.delete(metric.queueName);
+      this.logger.log(`Queue ${metric.queueName} recovered from stall`);
+      void this.fireStalledAlert(metric, 'resolved');
+    }
+    return stalled;
+  }
+
+  private async fireStalledAlert(
+    metric: QueueMetrics,
+    status: 'firing' | 'resolved',
+  ): Promise<void> {
+    try {
+      await this.alertService.handleAlert({
+        alerts: [
+          {
+            status,
+            labels: {
+              alertname: 'QueueStalled',
+              severity: 'critical',
+              queue: metric.queueName,
+            },
+            annotations: {
+              summary: `Queue ${metric.queueName} is stalled`,
+              description: `Oldest waiting job in queue "${metric.queueName}" is ${metric.oldestJobAgeSeconds}s old with a depth of ${metric.depth} (threshold ${this.stalledThresholdSeconds}s).`,
+            },
+            startsAt: metric.timestamp.toISOString(),
+            generatorURL: '',
+          },
+        ],
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to dispatch ${status} QueueStalled alert for ${metric.queueName}`,
+        error instanceof Error ? error.stack : 'Unknown error',
+      );
     }
   }
 

--- a/backend/src/modules/reviews/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/reviews.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { ReviewsService } from './reviews.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Review } from './review.entity';
@@ -24,7 +25,10 @@ describe('ReviewsService', () => {
   let hostReviewRepo: jest.Mocked<
     Pick<Repository<HostReview>, 'findOne' | 'save' | 'create'>
   >;
-  let agreementRepo: jest.Mocked<Pick<Repository<RentAgreement>, 'findOne'>>;
+  let agreementRepo: jest.Mocked<
+    Pick<Repository<RentAgreement>, 'findOne' | 'find'>
+  >;
+  let configService: { get: jest.Mock };
 
   beforeEach(async () => {
     guestReviewRepo = {
@@ -39,6 +43,10 @@ describe('ReviewsService', () => {
     };
     agreementRepo = {
       findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    configService = {
+      get: jest.fn((_key: string, defaultValue?: unknown) => defaultValue),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -59,6 +67,10 @@ describe('ReviewsService', () => {
         {
           provide: getRepositoryToken(RentAgreement),
           useValue: agreementRepo,
+        },
+        {
+          provide: ConfigService,
+          useValue: configService,
         },
       ],
     }).compile();
@@ -104,6 +116,169 @@ describe('ReviewsService', () => {
         comment: 'spam',
       }),
     ).rejects.toThrow('Review contains prohibited language.');
+  });
+
+  describe('create booking verification', () => {
+    const daysAgo = (days: number): Date =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    const expiredAgreement = (completedDaysAgo: number): RentAgreement =>
+      ({
+        id: 'agreement-1',
+        status: AgreementStatus.EXPIRED,
+        userId: 'tenant-1',
+        adminId: 'landlord-1',
+        propertyId: 'property-1',
+        endDate: daysAgo(completedDaysAgo),
+        updatedAt: daysAgo(completedDaysAgo),
+      }) as RentAgreement;
+
+    const reviewPayload = {
+      reviewerId: 'tenant-1',
+      revieweeId: 'landlord-1',
+      propertyId: 'property-1',
+      rating: 5,
+      comment: 'Great landlord',
+    };
+
+    it('rejects a review without a qualifying completed booking', async () => {
+      agreementRepo.find.mockResolvedValue([]);
+
+      await expect(service.create(reviewPayload)).rejects.toThrow(
+        BusinessRuleViolationError,
+      );
+      await expect(service.create(reviewPayload)).rejects.toThrow(
+        /completed booking/i,
+      );
+    });
+
+    it('accepts a review backed by a completed booking within the window', async () => {
+      agreementRepo.find.mockResolvedValue([expiredAgreement(5)]);
+      const created = { id: 'review-1', ...reviewPayload } as Review;
+      jest.spyOn(reviewRepo, 'create').mockReturnValue(created);
+      jest.spyOn(reviewRepo, 'save').mockResolvedValue(created);
+
+      const result = await service.create(reviewPayload);
+
+      expect(result).toBe(created);
+      // Only expired agreements between the two parties qualify.
+      expect(agreementRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.arrayContaining([
+            expect.objectContaining({
+              userId: 'tenant-1',
+              adminId: 'landlord-1',
+              status: AgreementStatus.EXPIRED,
+              propertyId: 'property-1',
+            }),
+            expect.objectContaining({
+              userId: 'landlord-1',
+              adminId: 'tenant-1',
+              status: AgreementStatus.EXPIRED,
+              propertyId: 'property-1',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('rejects a review when the booking completed outside the window', async () => {
+      agreementRepo.find.mockResolvedValue([expiredAgreement(31)]);
+
+      await expect(service.create(reviewPayload)).rejects.toThrow(
+        /review window/i,
+      );
+    });
+
+    it('honours a configured review window', async () => {
+      configService.get.mockImplementation((key: string, def?: unknown) =>
+        key === 'REVIEW_WINDOW_DAYS' ? 5 : def,
+      );
+      agreementRepo.find.mockResolvedValue([expiredAgreement(10)]);
+
+      await expect(service.create(reviewPayload)).rejects.toThrow(
+        /review window of 5 days/i,
+      );
+
+      agreementRepo.find.mockResolvedValue([expiredAgreement(3)]);
+      const created = { id: 'review-2' } as Review;
+      jest.spyOn(reviewRepo, 'create').mockReturnValue(created);
+      jest.spyOn(reviewRepo, 'save').mockResolvedValue(created);
+
+      await expect(service.create(reviewPayload)).resolves.toBe(created);
+    });
+
+    it('falls back to the default window on invalid configuration', async () => {
+      configService.get.mockImplementation((key: string, def?: unknown) =>
+        key === 'REVIEW_WINDOW_DAYS' ? 'not-a-number' : def,
+      );
+      agreementRepo.find.mockResolvedValue([expiredAgreement(5)]);
+      const created = { id: 'review-3' } as Review;
+      jest.spyOn(reviewRepo, 'create').mockReturnValue(created);
+      jest.spyOn(reviewRepo, 'save').mockResolvedValue(created);
+
+      await expect(service.create(reviewPayload)).resolves.toBe(created);
+    });
+
+    it('requires reviewer and reviewee ids', async () => {
+      await expect(
+        service.create({ revieweeId: 'landlord-1', rating: 5 }),
+      ).rejects.toThrow(/reviewerId and revieweeId are required/);
+    });
+  });
+
+  it('rejects guest review when the review window has closed', async () => {
+    const staleDate = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000);
+    agreementRepo.findOne.mockResolvedValue({
+      id: 'booking-1',
+      status: AgreementStatus.EXPIRED,
+      userId: 'guest-1',
+      adminId: 'host-1',
+      endDate: staleDate,
+      updatedAt: staleDate,
+    } as RentAgreement);
+
+    await expect(
+      service.postGuestReview(
+        {
+          bookingId: 'booking-1',
+          cleanliness: 5,
+          communication: 5,
+          respectForRules: 5,
+          comment: 'Too late',
+          wouldHostAgain: true,
+        },
+        'host-1',
+      ),
+    ).rejects.toThrow(/review window/i);
+  });
+
+  it('rejects host review when the review window has closed', async () => {
+    const staleDate = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000);
+    agreementRepo.findOne.mockResolvedValue({
+      id: 'booking-1',
+      status: AgreementStatus.EXPIRED,
+      userId: 'guest-1',
+      adminId: 'host-1',
+      endDate: staleDate,
+      updatedAt: staleDate,
+    } as RentAgreement);
+
+    await expect(
+      service.postHostReview(
+        {
+          bookingId: 'booking-1',
+          accuracy: 5,
+          cleanliness: 5,
+          checkIn: 5,
+          communication: 5,
+          location: 5,
+          value: 5,
+          comment: 'Too late',
+        },
+        'guest-1',
+      ),
+    ).rejects.toThrow(/review window/i);
   });
 
   it('rejects guest review when booking is missing', async () => {

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Review } from './review.entity';
@@ -20,6 +21,9 @@ import {
   AgreementNotFoundError,
 } from '../../common/errors/domain-errors';
 
+/** Days after a booking completes during which reviews are accepted. */
+export const DEFAULT_REVIEW_WINDOW_DAYS = 30;
+
 @Injectable()
 export class ReviewsService {
   constructor(
@@ -31,12 +35,90 @@ export class ReviewsService {
     private readonly hostReviewRepository: Repository<HostReview>,
     @InjectRepository(RentAgreement)
     private readonly agreementRepository: Repository<RentAgreement>,
+    private readonly configService: ConfigService,
   ) {}
+
+  /** Review window in days, configurable via `REVIEW_WINDOW_DAYS`. */
+  private getReviewWindowDays(): number {
+    const configured = Number(
+      this.configService.get('REVIEW_WINDOW_DAYS', DEFAULT_REVIEW_WINDOW_DAYS),
+    );
+    return Number.isFinite(configured) && configured > 0
+      ? configured
+      : DEFAULT_REVIEW_WINDOW_DAYS;
+  }
+
+  /**
+   * Reject reviews for bookings that completed longer than the review
+   * window ago. Agreements without any completion timestamp (legacy rows)
+   * are not window-checked, since there is nothing to measure from.
+   */
+  private assertWithinReviewWindow(agreement: RentAgreement): void {
+    const completedAt = agreement.endDate ?? agreement.updatedAt;
+    if (!completedAt) {
+      return;
+    }
+    const windowDays = this.getReviewWindowDays();
+    const windowMs = windowDays * 24 * 60 * 60 * 1000;
+    if (Date.now() - new Date(completedAt).getTime() > windowMs) {
+      throw new BusinessRuleViolationError(
+        `Review window of ${windowDays} days has closed for this booking`,
+      );
+    }
+  }
+
+  /**
+   * Find the most recent completed (expired) agreement connecting the two
+   * users — in either tenant/landlord direction — optionally scoped to a
+   * property. This is what qualifies someone to post a review.
+   */
+  private async findQualifyingAgreement(
+    reviewerId: string,
+    revieweeId: string,
+    propertyId?: string | null,
+  ): Promise<RentAgreement | null> {
+    const propertyFilter = propertyId ? { propertyId } : {};
+    const agreements = await this.agreementRepository.find({
+      where: [
+        {
+          userId: reviewerId,
+          adminId: revieweeId,
+          status: AgreementStatus.EXPIRED,
+          ...propertyFilter,
+        },
+        {
+          userId: revieweeId,
+          adminId: reviewerId,
+          status: AgreementStatus.EXPIRED,
+          ...propertyFilter,
+        },
+      ],
+      order: { updatedAt: 'DESC' },
+      take: 1,
+    });
+    return agreements[0] ?? null;
+  }
 
   async create(reviewData: Partial<Review>): Promise<Review> {
     if (containsProhibitedLanguage(reviewData.comment ?? '')) {
       throw new Error('Review contains prohibited language.');
     }
+    if (!reviewData.reviewerId || !reviewData.revieweeId) {
+      throw new ValidationError('reviewerId and revieweeId are required');
+    }
+
+    const agreement = await this.findQualifyingAgreement(
+      reviewData.reviewerId,
+      reviewData.revieweeId,
+      reviewData.propertyId,
+    );
+    if (!agreement) {
+      throw new BusinessRuleViolationError(
+        'A completed booking between the reviewer and reviewee is required before submitting a review',
+      );
+    }
+    this.assertWithinReviewWindow(agreement);
+
     const review = this.reviewRepository.create(reviewData);
     return this.reviewRepository.save(review);
   }
@@ -92,6 +174,7 @@ export class ReviewsService {
     if (agreement.status !== AgreementStatus.EXPIRED) {
       throw new BusinessRuleViolationError('Booking must be completed');
     }
+    this.assertWithinReviewWindow(agreement);
 
     if (agreement.adminId !== hostId) {
       throw new AuthorizationError('Not authorized');
@@ -138,6 +221,7 @@ export class ReviewsService {
     if (agreement.status !== AgreementStatus.EXPIRED) {
       throw new BusinessRuleViolationError('Booking must be completed');
     }
+    this.assertWithinReviewWindow(agreement);
 
     if (agreement.userId !== guestId) {
       throw new AuthorizationError('Not authorized');


### PR DESCRIPTION
## Summary
Fixes four assigned backend issues in one batch: adds a tested signature-capture/tamper-detection flow plus retrieval-authorization coverage to the documents module, paginates the favorites list endpoint, exports per-queue depth/job-age Prometheus gauges with stall alerting, and gates review submission behind a completed booking within a configurable review window.

closes #1587
closes #1588
closes #1599
closes #1602

## Changes
- **#1587 — documents signing flow tested (and made testable)**: the module had no signature capture at all, so "signature payload integrity" had nothing to test against. Added a minimal signing flow: `POST /documents/:id/sign` captures a signature from a party (owner, tenant, or shared user) and stores a sha256 `payloadHash` binding the payload to the document's content identifiers (`id`, `fileKey`, `fileSize`, `fileType`, signer, timestamp); `GET /documents/:id/signatures` recomputes the hashes so any post-signing change to the file reference is reported as invalid (tamper detection). Duplicate signatures and signing non-ACTIVE documents are rejected (409). Retrieval authorization now also recognises the document's `tenantId` as a party — previously a tenant named on the document could not retrieve it. New `signatures` simple-json column with migration `1930000000000-AddDocumentSignatures`; the response DTO exposes signer/timestamp but never raw signature payloads.
- **#1588 — favorites pagination**: `GET /favorites` previously returned every favorite in one unbounded payload. It now takes `page`/`limit` query params validated by DTO (`@Min(1)`, `@Max(100)` → 400 on violation) and returns `{ data, total, page, limit, totalPages }`. The service also defensively clamps page ≥ 1 and limit to [1, 100] with a default of 20, so internal callers can't bypass the bound. Uses `findAndCount` with skip/take.
- **#1599 — queue metrics export + stall alerting**: the per-minute Bull queue collector now pushes `queue_depth` (waiting + delayed), `queue_oldest_job_age_seconds` (sampled over the first 50 waiting jobs), `queue_active_jobs`, `queue_failed_jobs`, `queue_paused`, and `queue_stalled` gauges into the existing prom-client registry served at `GET /monitoring/metrics`. A queue whose oldest waiting job exceeds `STALLED_QUEUE_THRESHOLD_SECONDS` (default 300, validated with fallback) fires a critical `QueueStalled` alert through the existing `AlertService` escalation pipeline — on the transition into the stalled state only, with a `resolved` alert on recovery, so a stalled processor can't spam the on-call channel. Also reads Bull's waiting count from either `wait` or `waiting` (the code previously only read `wait`, which reports 0 on standard Bull).
- **#1602 — review booking verification + window**: the generic `POST /reviews` path accepted reviews with no booking check at all, allowing review manipulation on properties the author never stayed at. `create()` now requires an expired (completed) rent agreement linking reviewer and reviewee in either tenant/landlord direction, scoped to the property when `propertyId` is provided, and rejects otherwise with a business-rule error. All three submission paths (`create`, `postGuestReview`, `postHostReview`) now also enforce a review window measured from the agreement's `endDate` (falling back to `updatedAt`): configurable via `REVIEW_WINDOW_DAYS`, default 30, with invalid config falling back to the default. Legacy agreements with no dates are not window-checked, preserving existing behaviour for such rows.

## Test plan
- 84 tests across the 5 touched suites, all passing locally (`npx jest`); `npx tsc -p tsconfig.build.json --noEmit` and `npx eslint` on every changed file are clean.
- documents (27): retrieval authorization for owner / shared user / tenant / stranger, signing by party vs non-party, duplicate and non-ACTIVE rejection, hash format, untampered verification, tamper detection for both a changed file reference and a forged stored payload, unsigned documents, and the pre-existing create/findAll/update/remove/share cases.
- favorites (14): default page size when omitted, page/limit→skip/take translation, max-page-size clamping, non-positive input clamping, empty pages, plus the pre-existing status/add/remove cases.
- reviews (16): rejection without a qualifying booking, acceptance with a completed agreement (asserting the exact either-direction query), out-of-window rejection, configured-window honoured in both directions, invalid config fallback, missing-ids validation, guest and host window rejection, plus the pre-existing moderation/authorization/duplicate cases.
- queue monitoring (9 new spec): gauge export for all four queues, depth arithmetic including the `waiting` key variant, oldest-age computation, stall alert firing/no-refire/resolve, healthy-queue silence, configured threshold, and per-queue error isolation. metrics service (18): queue gauges appear in the `/monitoring/metrics` output and clear on recovery.

---
Notes: the favorites list response shape changed from a bare array to a pagination envelope — API consumers need the `data` field (the endpoint had no pagination contract before, which is what this issue asks to introduce). Full-suite CI is relied on for modules not touched here; only the five affected suites were run locally.