### PR TITLE
feat(backend): refresh-token reuse detection, cleanup dry-run/cap, evidence content validation, and feature-flag TTL cache

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { ReferralModule } from '../referral/referral.module';
 import { AuditModule } from '../audit/audit.module';
+import { SecurityModule } from '../security/security.module';
 import { QueuesModule } from '../queues/queues.module';
 import { JWT_ACCESS_TOKEN_EXPIRY } from '../../common/constants/business-rules.constants';
 import { AuthService } from './auth.service';
@@ -50,6 +51,7 @@ import { OAuthAccount } from './oauth/entities/oauth-account.entity';
     NotificationsModule,
     ReferralModule,
     AuditModule,
+    SecurityModule,
     // Excluded during static OpenAPI generation (no Redis available there),
     // matching how QueuesModule is already gated in app.module.ts.
     ...(process.env.OPENAPI_GENERATE !== 'true' ? [QueuesModule] : []),

--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -28,6 +28,11 @@ import { LockService } from '../../common/lock';
 import { QueueManagementService } from '../queues/services/queue-management.service';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { EncryptedCacheService } from '../../common/cache/encrypted-cache.service';
+import { SecurityEventsService } from '../security/security-events.service';
+import {
+  SecurityEventType,
+  SecurityEventSeverity,
+} from '../security/entities/security-event.entity';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -82,6 +87,10 @@ describe('AuthService', () => {
     addDataSyncJob: jest
       .fn()
       .mockImplementation(() => Promise.resolve(makeQueueJob())),
+  };
+
+  const mockSecurityEventsService = {
+    createEvent: jest.fn().mockResolvedValue(undefined),
   };
 
   const mockConfigService = {
@@ -184,6 +193,10 @@ describe('AuthService', () => {
             set: jest.fn(),
             del: jest.fn(),
           },
+        },
+        {
+          provide: SecurityEventsService,
+          useValue: mockSecurityEventsService,
         },
       ],
     }).compile();
@@ -731,6 +744,127 @@ describe('AuthService', () => {
       // Both emails carry the identical token — no request clobbered the other.
       expect(emailCalls[0][1]).toBe(emailCalls[1][1]);
       expect(unverifiedUser.verificationToken).toBe(emailCalls[0][1]);
+    });
+  });
+
+  describe('refreshToken rotation and reuse detection', () => {
+    const refreshPayload = {
+      sub: mockUser.id,
+      email: mockUser.email,
+      role: mockUser.role,
+      type: 'refresh',
+    };
+
+    it('rotates tokens for a valid current refresh token', async () => {
+      mockJwtService.verify.mockReturnValue(refreshPayload);
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: 'stored-hash',
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('new-hash' as never);
+      mockJwtService.sign
+        .mockReturnValueOnce('new-access-token')
+        .mockReturnValueOnce('new-refresh-token');
+
+      const result = await service.refreshToken({
+        refreshToken: 'current-refresh-token',
+      });
+
+      expect(result.accessToken).toBe('new-access-token');
+      expect(result.refreshToken).toBe('new-refresh-token');
+      // Old token invalidated by storing the new hash (rotation).
+      expect(mockUserRepository.update).toHaveBeenCalledWith(mockUser.id, {
+        refreshToken: 'new-hash',
+      });
+      expect(mockSecurityEventsService.createEvent).not.toHaveBeenCalled();
+    });
+
+    it('revokes the token family when a consumed token is replayed', async () => {
+      mockJwtService.verify.mockReturnValue(refreshPayload);
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: 'hash-of-newer-token',
+      });
+      // Signature-valid token that does not match the stored hash: replay.
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await expect(
+        service.refreshToken({ refreshToken: 'stolen-old-token' }),
+      ).rejects.toThrow(AuthenticationError);
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        { id: mockUser.id },
+        { refreshToken: null },
+      );
+      expect(mockSecurityEventsService.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: mockUser.id,
+          eventType: SecurityEventType.SUSPICIOUS_ACTIVITY,
+          severity: SecurityEventSeverity.CRITICAL,
+          success: false,
+          details: expect.objectContaining({
+            reason: 'refresh_token_reuse',
+            action: 'token_family_revoked',
+          }),
+        }),
+      );
+    });
+
+    it('rejects the whole family: a replay then blocks the newest token too', async () => {
+      mockJwtService.verify.mockReturnValue(refreshPayload);
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: 'hash-of-newer-token',
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+      await expect(
+        service.refreshToken({ refreshToken: 'stolen-old-token' }),
+      ).rejects.toThrow(AuthenticationError);
+
+      // After revocation the stored token is null, so even the legitimate
+      // newest token is refused until the user logs in again.
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: null,
+      });
+      await expect(
+        service.refreshToken({ refreshToken: 'newest-legit-token' }),
+      ).rejects.toThrow(AuthenticationError);
+    });
+
+    it('does not revoke the family for a token with an invalid signature', async () => {
+      mockJwtService.verify.mockImplementation(() => {
+        throw new Error('invalid signature');
+      });
+
+      await expect(
+        service.refreshToken({ refreshToken: 'garbage-token' }),
+      ).rejects.toThrow(AuthenticationError);
+
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+      expect(mockSecurityEventsService.createEvent).not.toHaveBeenCalled();
+    });
+
+    it('still revokes the family if recording the security event fails', async () => {
+      mockJwtService.verify.mockReturnValue(refreshPayload);
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        refreshToken: 'hash-of-newer-token',
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+      mockSecurityEventsService.createEvent.mockRejectedValueOnce(
+        new Error('monitoring down'),
+      );
+
+      await expect(
+        service.refreshToken({ refreshToken: 'stolen-old-token' }),
+      ).rejects.toThrow(AuthenticationError);
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        { id: mockUser.id },
+        { refreshToken: null },
+      );
     });
   });
 

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -35,6 +35,11 @@ import {
 } from '../../common/errors/domain-errors';
 import { ErrorCode } from '../../common/errors/error-codes';
 import { ValidationUtils } from '../../common/utils/validation/validation.utils';
+import { SecurityEventsService } from '../security/security-events.service';
+import {
+  SecurityEventType,
+  SecurityEventSeverity,
+} from '../security/entities/security-event.entity';
 
 import {
   BCRYPT_SALT_ROUNDS,
@@ -69,6 +74,8 @@ export class AuthService {
     private readonly encryptedCache: EncryptedCacheService,
     @Optional()
     private readonly queueManagementService?: QueueManagementService,
+    @Optional()
+    private readonly securityEventsService?: SecurityEventsService,
   ) {}
 
   @Logging({ service: 'AuthService' })
@@ -274,7 +281,11 @@ export class AuthService {
       );
 
       if (!isValidRefreshToken) {
-        this.logger.warn(`Invalid refresh token for user: ${user.id}`);
+        // The token's signature verified, so we issued it — but it is not
+        // the currently stored one. That means a rotated (already-consumed)
+        // refresh token is being replayed: the classic signal of a stolen
+        // token. Revoke the whole token family and record a security event.
+        await this.handleRefreshTokenReuse(user.id);
         throw new AuthenticationError(
           ErrorCode.AUTH_TOKEN_INVALID,
           'Invalid refresh token',
@@ -299,6 +310,40 @@ export class AuthService {
       throw new AuthenticationError(
         ErrorCode.AUTH_TOKEN_INVALID,
         'Invalid or expired refresh token',
+      );
+    }
+  }
+
+  /**
+   * Reuse detection: a signature-valid refresh token that no longer matches
+   * the stored hash was already consumed by a previous rotation. Presenting
+   * it again indicates token theft, so the entire token family (the user's
+   * current refresh session) is revoked — forcing re-authentication — and a
+   * critical security event is emitted for monitoring.
+   */
+  private async handleRefreshTokenReuse(userId: string): Promise<void> {
+    this.logger.warn(
+      `Refresh token reuse detected for user: ${userId} — revoking token family`,
+    );
+    await this.userRepository.update({ id: userId }, { refreshToken: null });
+
+    try {
+      await this.securityEventsService?.createEvent({
+        userId,
+        eventType: SecurityEventType.SUSPICIOUS_ACTIVITY,
+        severity: SecurityEventSeverity.CRITICAL,
+        success: false,
+        errorMessage: 'Consumed refresh token replayed',
+        details: {
+          reason: 'refresh_token_reuse',
+          action: 'token_family_revoked',
+        },
+      });
+    } catch (eventError) {
+      // Never let monitoring failures mask the revocation itself.
+      this.logger.error(
+        `Failed to record refresh token reuse event for user: ${userId}`,
+        eventError instanceof Error ? eventError.stack : String(eventError),
       );
     }
   }

--- a/backend/src/modules/cleanup/cleanup.controller.ts
+++ b/backend/src/modules/cleanup/cleanup.controller.ts
@@ -1,5 +1,12 @@
-import { Controller, Get, Post, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Post,
+  HttpCode,
+  HttpStatus,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { join } from 'path';
 import { CodeQualityAnalysisService } from './code-quality-analysis.service';
 import { AutomatedRefactoringService } from './automated-refactoring.service';
@@ -35,12 +42,23 @@ export class CleanupController {
   @ApiOperation({
     summary:
       'Scan for orphaned database records and delete them if ORPHAN_CLEANUP_DELETE_ENABLED is set',
+    description:
+      'Pass dryRun=true to report candidate counts and sample ids without deleting anything. Deletions are capped per run by ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN; a run that would exceed the cap aborts and raises an alert.',
+  })
+  @ApiQuery({
+    name: 'dryRun',
+    required: false,
+    description: 'When true, log and return the candidate set without mutating',
   })
   @ApiResponse({
     status: 200,
     description: 'Orphaned records scan completed successfully',
   })
-  async runOrphanedRecordsCleanup(): Promise<OrphanedRecordsCleanupStats> {
-    return this.orphanedRecordsCleanupService.runCleanup();
+  async runOrphanedRecordsCleanup(
+    @Query('dryRun') dryRun?: string,
+  ): Promise<OrphanedRecordsCleanupStats> {
+    return this.orphanedRecordsCleanupService.runCleanup(
+      dryRun === undefined ? undefined : { dryRun: dryRun === 'true' },
+    );
   }
 }

--- a/backend/src/modules/cleanup/cleanup.module.ts
+++ b/backend/src/modules/cleanup/cleanup.module.ts
@@ -11,6 +11,7 @@ import { DataArchivalService } from './data-archival.service';
 import { SecurityPatchManagementService } from './security-patch-management.service';
 import { DatabaseMaintenanceService } from './database-maintenance.service';
 import { OrphanedRecordsCleanupService } from './orphaned-records-cleanup.service';
+import { MonitoringModule } from '../monitoring/monitoring.module';
 import { TenantScreeningRequest } from '../screening/entities/tenant-screening-request.entity';
 import { TenantScreeningReport } from '../screening/entities/tenant-screening-report.entity';
 import { TenantScreeningConsent } from '../screening/entities/tenant-screening-consent.entity';
@@ -23,6 +24,7 @@ import { TenantScreeningConsent } from '../screening/entities/tenant-screening-c
       TenantScreeningConsent,
     ]),
     ScheduleModule.forRoot(),
+    MonitoringModule,
   ],
   controllers: [CleanupController, DataArchivalController],
   providers: [

--- a/backend/src/modules/cleanup/orphaned-records-cleanup.service.spec.ts
+++ b/backend/src/modules/cleanup/orphaned-records-cleanup.service.spec.ts
@@ -1,0 +1,212 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import { AlertService } from '../monitoring/alert.service';
+import {
+  DEFAULT_MAX_DELETIONS_PER_RUN,
+  OrphanedRecordsCleanupService,
+  SAMPLE_ID_LIMIT,
+} from './orphaned-records-cleanup.service';
+
+describe('OrphanedRecordsCleanupService', () => {
+  let service: OrphanedRecordsCleanupService;
+  let query: jest.Mock;
+  let alertService: { handleAlert: jest.Mock };
+  let config: Record<string, string>;
+
+  /**
+   * Queue of results for successive SELECT queries (one per orphan check);
+   * exhausted entries return no orphans. DELETE queries resolve undefined.
+   */
+  function primeSelects(batches: string[][]): void {
+    let selectCall = 0;
+    query.mockImplementation((sql: string) => {
+      if (sql.trim().startsWith('DELETE')) {
+        return Promise.resolve(undefined);
+      }
+      const ids = batches[selectCall] ?? [];
+      selectCall++;
+      return Promise.resolve(ids.map((id) => ({ id })));
+    });
+  }
+
+  function deleteCalls(): unknown[][] {
+    return query.mock.calls.filter(([sql]) =>
+      String(sql).trim().startsWith('DELETE'),
+    );
+  }
+
+  beforeEach(async () => {
+    query = jest.fn();
+    alertService = { handleAlert: jest.fn().mockResolvedValue(undefined) };
+    config = {};
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrphanedRecordsCleanupService,
+        {
+          provide: DataSource,
+          useValue: { options: { type: 'postgres' }, query },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(
+              (key: string, defaultValue?: unknown) =>
+                config[key] ?? defaultValue,
+            ),
+          },
+        },
+        { provide: AlertService, useValue: alertService },
+      ],
+    }).compile();
+
+    service = module.get(OrphanedRecordsCleanupService);
+  });
+
+  describe('dry-run mode', () => {
+    it('reports counts and sample ids without mutating', async () => {
+      config['ORPHAN_CLEANUP_DELETE_ENABLED'] = 'true';
+      primeSelects([['a-1', 'a-2', 'a-3']]);
+
+      const stats = await service.runCleanup({ dryRun: true });
+
+      expect(stats.dryRun).toBe(true);
+      expect(stats.totalOrphaned).toBe(3);
+      expect(stats.totalDeleted).toBe(0);
+      expect(stats.aborted).toBe(false);
+      expect(stats.results[0].orphanedCount).toBe(3);
+      expect(stats.results[0].sampleIds).toEqual(['a-1', 'a-2', 'a-3']);
+      expect(stats.results[0].deleted).toBe(false);
+      // No DELETE statement was ever issued.
+      expect(deleteCalls()).toHaveLength(0);
+    });
+
+    it('caps the sample id list', async () => {
+      const ids = Array.from({ length: 25 }, (_, i) => `row-${i}`);
+      primeSelects([ids]);
+
+      const stats = await service.runCleanup({ dryRun: true });
+
+      expect(stats.results[0].orphanedCount).toBe(25);
+      expect(stats.results[0].sampleIds).toHaveLength(SAMPLE_ID_LIMIT);
+    });
+
+    it('can be enabled via configuration', async () => {
+      config['ORPHAN_CLEANUP_DELETE_ENABLED'] = 'true';
+      config['ORPHAN_CLEANUP_DRY_RUN'] = 'true';
+      primeSelects([['a-1']]);
+
+      const stats = await service.runCleanup();
+
+      expect(stats.dryRun).toBe(true);
+      expect(deleteCalls()).toHaveLength(0);
+    });
+  });
+
+  describe('deletion cap', () => {
+    it('deletes normally under the cap', async () => {
+      config['ORPHAN_CLEANUP_DELETE_ENABLED'] = 'true';
+      primeSelects([['a-1', 'a-2'], ['b-1']]);
+
+      const stats = await service.runCleanup();
+
+      expect(stats.totalDeleted).toBe(3);
+      expect(stats.aborted).toBe(false);
+      expect(stats.maxDeletionsPerRun).toBe(DEFAULT_MAX_DELETIONS_PER_RUN);
+      expect(deleteCalls()).toHaveLength(2);
+      expect(alertService.handleAlert).not.toHaveBeenCalled();
+    });
+
+    it('aborts before a batch that would exceed the cap and raises an alert', async () => {
+      config['ORPHAN_CLEANUP_DELETE_ENABLED'] = 'true';
+      config['ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN'] = '5';
+      primeSelects([
+        ['a-1', 'a-2', 'a-3'],
+        ['b-1', 'b-2', 'b-3', 'b-4'],
+        ['c-1'],
+      ]);
+
+      const stats = await service.runCleanup();
+
+      // First batch (3) deleted; second batch (4) would exceed the cap of 5.
+      expect(stats.totalDeleted).toBe(3);
+      expect(stats.aborted).toBe(true);
+      expect(stats.abortReason).toMatch(/cap of 5/);
+      expect(deleteCalls()).toHaveLength(1);
+      // The run stopped: the third check was never scanned.
+      expect(stats.results).toHaveLength(2);
+
+      expect(alertService.handleAlert).toHaveBeenCalledWith({
+        alerts: [
+          expect.objectContaining({
+            status: 'firing',
+            labels: expect.objectContaining({
+              alertname: 'OrphanCleanupCapExceeded',
+              severity: 'critical',
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('aborts immediately when a single batch alone exceeds the cap', async () => {
+      config['ORPHAN_CLEANUP_DELETE_ENABLED'] = 'true';
+      config['ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN'] = '10';
+      primeSelects([Array.from({ length: 11 }, (_, i) => `x-${i}`)]);
+
+      const stats = await service.runCleanup();
+
+      expect(stats.totalDeleted).toBe(0);
+      expect(stats.aborted).toBe(true);
+      expect(deleteCalls()).toHaveLength(0);
+      expect(alertService.handleAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the default cap on invalid configuration', async () => {
+      config['ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN'] = 'not-a-number';
+      primeSelects([]);
+
+      const stats = await service.runCleanup();
+
+      expect(stats.maxDeletionsPerRun).toBe(DEFAULT_MAX_DELETIONS_PER_RUN);
+    });
+  });
+
+  describe('scan-only default', () => {
+    it('counts orphans without deleting when deletion is not enabled', async () => {
+      primeSelects([['a-1', 'a-2']]);
+
+      const stats = await service.runCleanup();
+
+      expect(stats.dryRun).toBe(false);
+      expect(stats.deletionEnabled).toBe(false);
+      expect(stats.totalOrphaned).toBe(2);
+      expect(stats.totalDeleted).toBe(0);
+      expect(deleteCalls()).toHaveLength(0);
+    });
+  });
+
+  it('skips entirely on non-postgres databases', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrphanedRecordsCleanupService,
+        {
+          provide: DataSource,
+          useValue: { options: { type: 'sqlite' }, query },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((_k, d) => d) },
+        },
+        { provide: AlertService, useValue: alertService },
+      ],
+    }).compile();
+
+    const sqliteService = module.get(OrphanedRecordsCleanupService);
+    const stats = await sqliteService.runCleanup();
+
+    expect(stats.results).toHaveLength(0);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/cleanup/orphaned-records-cleanup.service.ts
+++ b/backend/src/modules/cleanup/orphaned-records-cleanup.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
+import { AlertService } from '../monitoring/alert.service';
 
 interface OrphanCheck {
   label: string;
@@ -16,16 +17,30 @@ export interface OrphanCheckResult {
   childTable: string;
   childColumn: string;
   orphanedCount: number;
+  /** Up to [`SAMPLE_ID_LIMIT`] candidate row ids, for review before deletion. */
+  sampleIds: string[];
   deleted: boolean;
 }
 
 export interface OrphanedRecordsCleanupStats {
   checkedAt: string;
   deletionEnabled: boolean;
+  /** True when this run only reported candidates without mutating. */
+  dryRun: boolean;
+  /** Per-run deletion ceiling in effect. */
+  maxDeletionsPerRun: number;
+  /** True when the run stopped early because the cap would be exceeded. */
+  aborted: boolean;
+  abortReason?: string;
   results: OrphanCheckResult[];
   totalOrphaned: number;
   totalDeleted: number;
 }
+
+/** Default per-run deletion ceiling; configurable via env. */
+export const DEFAULT_MAX_DELETIONS_PER_RUN = 500;
+/** How many candidate ids each check reports for inspection. */
+export const SAMPLE_ID_LIMIT = 10;
 
 /**
  * These child tables reference a parent (users/properties/bookings/
@@ -224,27 +239,49 @@ export class OrphanedRecordsCleanupService {
   constructor(
     private readonly dataSource: DataSource,
     private readonly configService: ConfigService,
+    @Optional() private readonly alertService?: AlertService,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)
   async runScheduledCleanup(): Promise<void> {
     const stats = await this.runCleanup();
     this.logger.log(
-      `Orphaned records cleanup completed: totalOrphaned=${stats.totalOrphaned}, totalDeleted=${stats.totalDeleted}, deletionEnabled=${stats.deletionEnabled}`,
+      `Orphaned records cleanup completed: totalOrphaned=${stats.totalOrphaned}, totalDeleted=${stats.totalDeleted}, deletionEnabled=${stats.deletionEnabled}, dryRun=${stats.dryRun}, aborted=${stats.aborted}`,
     );
   }
 
-  async runCleanup(): Promise<OrphanedRecordsCleanupStats> {
+  /**
+   * Scan (and optionally delete) orphaned rows.
+   *
+   * - `dryRun` (explicit option, or `ORPHAN_CLEANUP_DRY_RUN=true`) reports
+   *   candidate counts and sample ids without mutating anything, regardless
+   *   of `ORPHAN_CLEANUP_DELETE_ENABLED`.
+   * - Deletions are capped per run by `ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN`
+   *   (default 500): the run aborts before any batch that would push the
+   *   total over the cap and raises a critical alert, so a bad predicate
+   *   cannot silently remove a large amount of data in one pass.
+   */
+  async runCleanup(options?: {
+    dryRun?: boolean;
+  }): Promise<OrphanedRecordsCleanupStats> {
     const databaseType = String(this.dataSource.options.type);
     const deletionEnabled =
       this.configService.get<string>(
         'ORPHAN_CLEANUP_DELETE_ENABLED',
         'false',
       ) === 'true';
+    const dryRun =
+      options?.dryRun ??
+      this.configService.get<string>('ORPHAN_CLEANUP_DRY_RUN', 'false') ===
+        'true';
+    const maxDeletionsPerRun = this.getMaxDeletionsPerRun();
 
     const stats: OrphanedRecordsCleanupStats = {
       checkedAt: new Date().toISOString(),
       deletionEnabled,
+      dryRun,
+      maxDeletionsPerRun,
+      aborted: false,
       results: [],
       totalOrphaned: 0,
       totalDeleted: 0,
@@ -259,12 +296,55 @@ export class OrphanedRecordsCleanupService {
 
     for (const check of ORPHAN_CHECKS) {
       try {
-        const result = await this.runCheck(check, deletionEnabled);
+        const orphanIds = await this.findOrphanIds(check);
+        const orphanedCount = orphanIds.length;
+        const result: OrphanCheckResult = {
+          label: check.label,
+          childTable: check.childTable,
+          childColumn: check.childColumn,
+          orphanedCount,
+          sampleIds: orphanIds.slice(0, SAMPLE_ID_LIMIT),
+          deleted: false,
+        };
         stats.results.push(result);
-        stats.totalOrphaned += result.orphanedCount;
-        if (result.deleted) {
-          stats.totalDeleted += result.orphanedCount;
+        stats.totalOrphaned += orphanedCount;
+
+        if (orphanedCount === 0) {
+          continue;
         }
+
+        this.logger.warn(
+          `Found ${orphanedCount} orphaned row(s) for ${check.label}`,
+        );
+
+        if (dryRun) {
+          this.logger.log(
+            `[DRY RUN] Would delete ${orphanedCount} row(s) from "${check.childTable}" (${check.label}); sample ids: ${result.sampleIds.join(', ')}`,
+          );
+          continue;
+        }
+
+        if (!deletionEnabled) {
+          continue;
+        }
+
+        if (stats.totalDeleted + orphanedCount > maxDeletionsPerRun) {
+          stats.aborted = true;
+          stats.abortReason = `Deleting ${orphanedCount} row(s) for "${check.label}" would exceed the per-run cap of ${maxDeletionsPerRun} (already deleted ${stats.totalDeleted}). Run aborted before this batch.`;
+          this.logger.error(stats.abortReason);
+          await this.raiseCapExceededAlert(stats, check.label, orphanedCount);
+          break;
+        }
+
+        await this.dataSource.query(
+          `DELETE FROM "${check.childTable}" WHERE id = ANY($1::uuid[])`,
+          [orphanIds],
+        );
+        result.deleted = true;
+        stats.totalDeleted += orphanedCount;
+        this.logger.log(
+          `Deleted ${orphanedCount} orphaned row(s) from "${check.childTable}" (${check.label})`,
+        );
       } catch (error) {
         this.logger.warn(
           `Orphan check "${check.label}" failed: ${(error as Error).message}`,
@@ -275,13 +355,9 @@ export class OrphanedRecordsCleanupService {
     return stats;
   }
 
-  private async runCheck(
-    check: OrphanCheck,
-    deletionEnabled: boolean,
-  ): Promise<OrphanCheckResult> {
+  private async findOrphanIds(check: OrphanCheck): Promise<string[]> {
     const parentColumn = check.parentColumn ?? 'id';
-
-    const orphanIds: Array<{ id: string }> = await this.dataSource.query(
+    const rows: Array<{ id: string }> = await this.dataSource.query(
       `
         SELECT id FROM "${check.childTable}"
         WHERE "${check.childColumn}" IS NOT NULL
@@ -290,39 +366,49 @@ export class OrphanedRecordsCleanupService {
           )
       `,
     );
+    return rows.map((row) => row.id);
+  }
 
-    const orphanedCount = orphanIds.length;
-
-    if (orphanedCount === 0) {
-      return {
-        label: check.label,
-        childTable: check.childTable,
-        childColumn: check.childColumn,
-        orphanedCount: 0,
-        deleted: false,
-      };
-    }
-
-    this.logger.warn(
-      `Found ${orphanedCount} orphaned row(s) for ${check.label}`,
+  private getMaxDeletionsPerRun(): number {
+    const configured = Number(
+      this.configService.get(
+        'ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN',
+        DEFAULT_MAX_DELETIONS_PER_RUN,
+      ),
     );
+    return Number.isFinite(configured) && configured > 0
+      ? configured
+      : DEFAULT_MAX_DELETIONS_PER_RUN;
+  }
 
-    if (deletionEnabled) {
-      await this.dataSource.query(
-        `DELETE FROM "${check.childTable}" WHERE id = ANY($1::uuid[])`,
-        [orphanIds.map((row) => row.id)],
-      );
-      this.logger.log(
-        `Deleted ${orphanedCount} orphaned row(s) from "${check.childTable}" (${check.label})`,
+  private async raiseCapExceededAlert(
+    stats: OrphanedRecordsCleanupStats,
+    checkLabel: string,
+    batchSize: number,
+  ): Promise<void> {
+    try {
+      await this.alertService?.handleAlert({
+        alerts: [
+          {
+            status: 'firing',
+            labels: {
+              alertname: 'OrphanCleanupCapExceeded',
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Orphaned records cleanup aborted at deletion cap',
+              description: `Check "${checkLabel}" produced ${batchSize} candidate deletions; with ${stats.totalDeleted} already deleted this run, the cap of ${stats.maxDeletionsPerRun} would be exceeded. The run aborted without deleting the batch — review the candidate set (a bad predicate may be selecting far too many rows).`,
+            },
+            startsAt: stats.checkedAt,
+            generatorURL: '',
+          },
+        ],
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to dispatch OrphanCleanupCapExceeded alert',
+        error instanceof Error ? error.stack : String(error),
       );
     }
-
-    return {
-      label: check.label,
-      childTable: check.childTable,
-      childColumn: check.childColumn,
-      orphanedCount,
-      deleted: deletionEnabled,
-    };
   }
 }

--- a/backend/src/modules/disputes/__tests__/disputes.resolution.spec.ts
+++ b/backend/src/modules/disputes/__tests__/disputes.resolution.spec.ts
@@ -305,7 +305,9 @@ describe('DisputesService — resolution, evidence, comments, agreements', () =>
       jest
         .spyOn(service as any, 'checkDisputePermission')
         .mockResolvedValue(undefined);
-      jest.spyOn(service as any, 'validateFile').mockReturnValue(undefined);
+      jest
+        .spyOn(service as any, 'validateFile')
+        .mockReturnValue('application/pdf');
 
       mockEvidenceRepository.create.mockReturnValue(mockEvidence);
       mockEvidenceRepository.save.mockResolvedValue(mockEvidence);
@@ -332,7 +334,9 @@ describe('DisputesService — resolution, evidence, comments, agreements', () =>
       jest
         .spyOn(service as any, 'checkDisputePermission')
         .mockResolvedValue(undefined);
-      jest.spyOn(service as any, 'validateFile').mockReturnValue(undefined);
+      jest
+        .spyOn(service as any, 'validateFile')
+        .mockReturnValue('application/pdf');
 
       mockEvidenceRepository.create.mockReturnValue({
         ...mockEvidence,

--- a/backend/src/modules/disputes/__tests__/evidence-file-validation.spec.ts
+++ b/backend/src/modules/disputes/__tests__/evidence-file-validation.spec.ts
@@ -1,0 +1,240 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import { DisputesService } from '../disputes.service';
+import { Dispute } from '../entities/dispute.entity';
+import { DisputeEvidence } from '../entities/dispute-evidence.entity';
+import { DisputeComment } from '../entities/dispute-comment.entity';
+import { RentAgreement } from '../../rent/entities/rent-contract.entity';
+import { User } from '../../users/entities/user.entity';
+import { Payment as GeneralPayment } from '../../payments/entities/payment.entity';
+import { Payment as RentPayment } from '../../rent/entities/payment.entity';
+import { AuditService } from '../../audit/audit.service';
+import { LockService } from '../../../common/lock';
+import { IdempotencyService } from '../../../common/idempotency';
+import { ValidationError } from '../../../common/errors/domain-errors';
+import {
+  DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES,
+  sniffEvidenceFileType,
+  validateEvidenceFile,
+} from '../utils/evidence-file-validation.util';
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function pngBuffer(extraBytes = 16): Buffer {
+  return Buffer.from([...PNG_MAGIC, ...Array(extraBytes).fill(0x01)]);
+}
+
+describe('evidence file validation util', () => {
+  describe('sniffEvidenceFileType', () => {
+    it.each([
+      ['image/jpeg', Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00])],
+      ['image/png', pngBuffer()],
+      ['image/gif', Buffer.from('GIF89a-rest-of-file')],
+      ['image/gif', Buffer.from('GIF87a-rest-of-file')],
+      ['application/pdf', Buffer.from('%PDF-1.7 rest')],
+      [
+        'application/msword',
+        Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1, 0x00]),
+      ],
+      [
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00]),
+      ],
+      ['text/plain', Buffer.from('Just a plain text statement.\n')],
+    ])('detects %s by content', (expected, buffer) => {
+      expect(sniffEvidenceFileType(buffer)).toBe(expected);
+    });
+
+    it.each([
+      ['windows executable', Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03])],
+      ['elf binary', Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01])],
+      [
+        'random binary',
+        Buffer.from([0x00, 0x01, 0x02, 0x03, 0xde, 0xad, 0xbe, 0xef]),
+      ],
+      ['empty file', Buffer.alloc(0)],
+    ])('rejects %s content', (_label, buffer) => {
+      expect(sniffEvidenceFileType(buffer)).toBeNull();
+    });
+  });
+
+  describe('validateEvidenceFile', () => {
+    it('rejects a disallowed type even with an allowed declared MIME', () => {
+      // An .exe uploaded with a forged image/png content type header.
+      const file = {
+        buffer: Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00]),
+        mimetype: 'image/png',
+        size: 6,
+      };
+      const result = validateEvidenceFile(file);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/invalid file type/i);
+    });
+
+    it('accepts an allowed type regardless of a bogus declared MIME', () => {
+      const file = {
+        buffer: pngBuffer(),
+        mimetype: 'application/x-msdownload',
+        size: 24,
+      };
+      const result = validateEvidenceFile(file);
+      expect(result.isValid).toBe(true);
+      expect(result.detectedType).toBe('image/png');
+    });
+
+    it('enforces the default size cap', () => {
+      const file = {
+        buffer: pngBuffer(),
+        size: DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES + 1,
+      };
+      const result = validateEvidenceFile(file);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/size too large/i);
+    });
+
+    it('enforces a custom size cap', () => {
+      const file = { buffer: pngBuffer(), size: 2_048 };
+      expect(validateEvidenceFile(file, 1_024).isValid).toBe(false);
+      expect(validateEvidenceFile(file, 4_096).isValid).toBe(true);
+    });
+
+    it('rejects files whose content is unavailable', () => {
+      expect(validateEvidenceFile({ size: 10 }).isValid).toBe(false);
+      expect(
+        validateEvidenceFile({ buffer: Buffer.alloc(0), size: 0 }).isValid,
+      ).toBe(false);
+    });
+
+    it('rejects text files containing NUL bytes', () => {
+      const file = {
+        buffer: Buffer.from('looks like text\x00but is binary'),
+        size: 30,
+      };
+      expect(validateEvidenceFile(file).isValid).toBe(false);
+    });
+  });
+});
+
+describe('DisputesService evidence upload enforcement', () => {
+  let service: DisputesService;
+  let evidenceRepository: { create: jest.Mock; save: jest.Mock };
+  let configGet: jest.Mock;
+
+  const openDispute = { id: 1, disputeId: 'dispute-uuid-1' };
+
+  async function buildService(): Promise<void> {
+    evidenceRepository = {
+      create: jest.fn().mockImplementation((data) => data),
+      save: jest.fn().mockImplementation((data) => Promise.resolve(data)),
+    };
+
+    const emptyRepo = () => ({ findOne: jest.fn(), find: jest.fn() });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DisputesService,
+        { provide: getRepositoryToken(Dispute), useValue: emptyRepo() },
+        {
+          provide: getRepositoryToken(DisputeEvidence),
+          useValue: evidenceRepository,
+        },
+        { provide: getRepositoryToken(DisputeComment), useValue: emptyRepo() },
+        { provide: getRepositoryToken(RentAgreement), useValue: emptyRepo() },
+        { provide: getRepositoryToken(User), useValue: emptyRepo() },
+        { provide: getRepositoryToken(GeneralPayment), useValue: emptyRepo() },
+        { provide: getRepositoryToken(RentPayment), useValue: emptyRepo() },
+        { provide: AuditService, useValue: { log: jest.fn() } },
+        { provide: DataSource, useValue: {} },
+        {
+          provide: LockService,
+          useValue: {
+            withLock: jest.fn(
+              async (_k: string, _ttl: number, fn: () => Promise<unknown>) =>
+                fn(),
+            ),
+          },
+        },
+        { provide: IdempotencyService, useValue: {} },
+        { provide: ConfigService, useValue: { get: configGet } },
+      ],
+    }).compile();
+
+    service = module.get(DisputesService);
+    jest
+      .spyOn(service, 'findByDisputeId')
+      .mockResolvedValue(openDispute as never);
+    jest
+      .spyOn(
+        service as never as { checkDisputePermission: () => unknown },
+        'checkDisputePermission' as never,
+      )
+      .mockResolvedValue(undefined as never);
+  }
+
+  beforeEach(async () => {
+    configGet = jest.fn((_key: string, defaultValue?: unknown) => defaultValue);
+    await buildService();
+  });
+
+  it('stores the sniffed content type, not the declared MIME', async () => {
+    const file = {
+      originalname: 'evidence.png',
+      mimetype: 'application/pdf', // forged declaration
+      buffer: pngBuffer(),
+      size: 24,
+    };
+
+    const evidence = await service.addEvidence('dispute-uuid-1', file, 'u-1');
+
+    expect(evidence.fileType).toBe('image/png');
+    expect(evidenceRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ fileType: 'image/png' }),
+    );
+  });
+
+  it('rejects disallowed content regardless of declared MIME', async () => {
+    const file = {
+      originalname: 'evidence.pdf',
+      mimetype: 'application/pdf',
+      buffer: Buffer.from([0x4d, 0x5a, 0x90, 0x00]), // MZ executable
+      size: 4,
+    };
+
+    await expect(
+      service.addEvidence('dispute-uuid-1', file, 'u-1'),
+    ).rejects.toThrow(ValidationError);
+    expect(evidenceRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('honours the configurable size cap', async () => {
+    configGet = jest.fn((key: string, def?: unknown) =>
+      key === 'DISPUTE_EVIDENCE_MAX_FILE_SIZE_BYTES' ? 1_024 : def,
+    );
+    await buildService();
+
+    const file = {
+      originalname: 'evidence.png',
+      mimetype: 'image/png',
+      buffer: pngBuffer(),
+      size: 2_048,
+    };
+
+    await expect(
+      service.addEvidence('dispute-uuid-1', file, 'u-1'),
+    ).rejects.toThrow(/size too large/i);
+  });
+
+  it('rejects uploads with no readable content', async () => {
+    const file = {
+      originalname: 'evidence.pdf',
+      mimetype: 'application/pdf',
+      size: 512,
+    };
+
+    await expect(
+      service.addEvidence('dispute-uuid-1', file, 'u-1'),
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/backend/src/modules/disputes/disputes.service.ts
+++ b/backend/src/modules/disputes/disputes.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource, In } from 'typeorm';
 import { Dispute, DisputeStatus } from './entities/dispute.entity';
@@ -31,6 +32,10 @@ import {
   DisputeNotFoundError,
   ValidationError,
 } from '../../common/errors/domain-errors';
+import {
+  DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES,
+  validateEvidenceFile,
+} from './utils/evidence-file-validation.util';
 
 @Injectable()
 export class DisputesService {
@@ -53,6 +58,7 @@ export class DisputesService {
     private readonly dataSource: DataSource,
     private readonly lockService: LockService,
     private readonly idempotencyService: IdempotencyService,
+    @Optional() private readonly configService?: ConfigService,
   ) {}
 
   /**
@@ -493,8 +499,8 @@ export class DisputesService {
     // Check permissions
     await this.checkDisputePermission(dispute, userId, 'add_evidence');
 
-    // Validate file
-    this.validateFile(file);
+    // Validate file content (magic bytes), never the declared MIME header
+    const detectedType = this.validateFile(file);
 
     // Create evidence record
     const evidence = this.evidenceRepository.create({
@@ -502,7 +508,8 @@ export class DisputesService {
       uploadedBy: userId,
       fileUrl: file.path, // This would be replaced with actual file storage URL
       fileName: file.originalname,
-      fileType: file.mimetype,
+      // Store the sniffed content type, not the client-declared one.
+      fileType: detectedType,
       fileSize: file.size,
       description: dto?.description,
     });
@@ -707,28 +714,33 @@ export class DisputesService {
   /**
    * Validate uploaded file
    */
-  private validateFile(file: any): void {
-    const allowedTypes = [
-      'image/jpeg',
-      'image/png',
-      'image/gif',
-      'application/pdf',
-      'text/plain',
-      'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    ];
-
-    const maxSize = 10 * 1024 * 1024; // 10MB
-
-    if (!allowedTypes.includes(file.mimetype)) {
+  /**
+   * Validate an evidence upload by sniffing its content (magic bytes) —
+   * the client-declared MIME type is ignored — and by enforcing the
+   * configurable size cap (`DISPUTE_EVIDENCE_MAX_FILE_SIZE_BYTES`).
+   *
+   * Returns the detected content type on success.
+   */
+  private validateFile(file: any): string {
+    const result = validateEvidenceFile(file, this.getEvidenceMaxSizeBytes());
+    if (!result.isValid || !result.detectedType) {
       throw new ValidationError(
-        'Invalid file type. Only images, PDFs, and documents are allowed',
+        result.error ?? 'Evidence file failed validation',
       );
     }
+    return result.detectedType;
+  }
 
-    if (file.size > maxSize) {
-      throw new ValidationError('File size too large. Maximum size is 10MB');
-    }
+  private getEvidenceMaxSizeBytes(): number {
+    const configured = Number(
+      this.configService?.get(
+        'DISPUTE_EVIDENCE_MAX_FILE_SIZE_BYTES',
+        DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES,
+      ) ?? DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES,
+    );
+    return Number.isFinite(configured) && configured > 0
+      ? configured
+      : DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES;
   }
 
   /**

--- a/backend/src/modules/disputes/utils/evidence-file-validation.util.ts
+++ b/backend/src/modules/disputes/utils/evidence-file-validation.util.ts
@@ -1,0 +1,141 @@
+/**
+ * Content-based validation for dispute evidence uploads.
+ *
+ * The client-declared MIME type is never trusted: the actual file content is
+ * sniffed by magic bytes and must match one of the allowed evidence types.
+ */
+
+/** Default maximum evidence file size (10MB); configurable via env. */
+export const DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** MIME types accepted as dispute evidence. */
+export const ALLOWED_EVIDENCE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/pdf',
+  'text/plain',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+] as const;
+
+type SniffedType = (typeof ALLOWED_EVIDENCE_MIME_TYPES)[number];
+
+interface MagicSignature {
+  mime: SniffedType;
+  bytes: number[];
+  offset?: number;
+}
+
+const MAGIC_SIGNATURES: MagicSignature[] = [
+  { mime: 'image/jpeg', bytes: [0xff, 0xd8, 0xff] },
+  {
+    mime: 'image/png',
+    bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  },
+  // GIF87a
+  { mime: 'image/gif', bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] },
+  // GIF89a
+  { mime: 'image/gif', bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] },
+  // %PDF
+  { mime: 'application/pdf', bytes: [0x25, 0x50, 0x44, 0x46] },
+  // Legacy OLE2 container (.doc)
+  {
+    mime: 'application/msword',
+    bytes: [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1],
+  },
+  // ZIP container (.docx) — PK\x03\x04
+  {
+    mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    bytes: [0x50, 0x4b, 0x03, 0x04],
+  },
+];
+
+function matchesSignature(buffer: Buffer, signature: MagicSignature): boolean {
+  const offset = signature.offset ?? 0;
+  if (buffer.length < offset + signature.bytes.length) {
+    return false;
+  }
+  return signature.bytes.every((byte, i) => buffer[offset + i] === byte);
+}
+
+/**
+ * Heuristic for `text/plain`, which has no magic bytes: the sample must not
+ * contain NUL bytes and must be predominantly printable/whitespace.
+ */
+function looksLikePlainText(buffer: Buffer): boolean {
+  if (buffer.length === 0) {
+    return false;
+  }
+  const sample = buffer.subarray(0, Math.min(buffer.length, 512));
+  let printable = 0;
+  for (const byte of sample) {
+    if (byte === 0x00) {
+      return false;
+    }
+    // Tab, LF, CR, or printable ASCII / extended range.
+    if (byte === 0x09 || byte === 0x0a || byte === 0x0d || byte >= 0x20) {
+      printable++;
+    }
+  }
+  return printable / sample.length > 0.95;
+}
+
+/**
+ * Determine the actual content type of an uploaded buffer from its magic
+ * bytes. Returns `null` when the content matches no allowed evidence type.
+ */
+export function sniffEvidenceFileType(buffer: Buffer): SniffedType | null {
+  for (const signature of MAGIC_SIGNATURES) {
+    if (matchesSignature(buffer, signature)) {
+      return signature.mime;
+    }
+  }
+  return looksLikePlainText(buffer) ? 'text/plain' : null;
+}
+
+export interface EvidenceFileValidationResult {
+  isValid: boolean;
+  /** Content type established by sniffing, when valid. */
+  detectedType?: SniffedType;
+  error?: string;
+}
+
+/**
+ * Validate an uploaded evidence file by content, not by its declared MIME
+ * header. A file passes only when its sniffed content type is allowed and
+ * its size is within the cap.
+ */
+export function validateEvidenceFile(
+  file: {
+    buffer?: Buffer;
+    size?: number;
+  },
+  maxSizeBytes: number = DEFAULT_EVIDENCE_MAX_FILE_SIZE_BYTES,
+): EvidenceFileValidationResult {
+  if (!file || !Buffer.isBuffer(file.buffer) || file.buffer.length === 0) {
+    return {
+      isValid: false,
+      error: 'File content is missing or could not be read for validation',
+    };
+  }
+
+  const size = file.size ?? file.buffer.length;
+  if (size > maxSizeBytes) {
+    return {
+      isValid: false,
+      error: `File size too large. Maximum size is ${Math.floor(maxSizeBytes / (1024 * 1024))}MB`,
+    };
+  }
+
+  const detectedType = sniffEvidenceFileType(file.buffer);
+  if (!detectedType) {
+    return {
+      isValid: false,
+      error:
+        'Invalid file type. Only images, PDFs, and documents are allowed (content did not match an allowed type)',
+    };
+  }
+
+  return { isValid: true, detectedType };
+}

--- a/backend/src/modules/feature-flags/__tests__/feature-flags.controller.spec.ts
+++ b/backend/src/modules/feature-flags/__tests__/feature-flags.controller.spec.ts
@@ -25,13 +25,11 @@ describe('FeatureFlagsController', () => {
       setRolloutPercentage: jest
         .fn()
         .mockResolvedValue({ key: 'test_flag', rolloutPercentage: 25 }),
-      killSwitch: jest
-        .fn()
-        .mockResolvedValue({
-          key: 'test_flag',
-          enabled: false,
-          rolloutPercentage: 0,
-        }),
+      killSwitch: jest.fn().mockResolvedValue({
+        key: 'test_flag',
+        enabled: false,
+        rolloutPercentage: 0,
+      }),
       deleteFlag: jest.fn().mockResolvedValue(undefined),
     };
 

--- a/backend/src/modules/feature-flags/__tests__/feature-flags.service.spec.ts
+++ b/backend/src/modules/feature-flags/__tests__/feature-flags.service.spec.ts
@@ -2,7 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { NotFoundException, ConflictException } from '@nestjs/common';
-import { FeatureFlagsService } from '../feature-flags.service';
+import {
+  DEFAULT_FEATURE_FLAG_CACHE_TTL_MS,
+  FeatureFlagsService,
+} from '../feature-flags.service';
 import { FeatureFlag } from '../entities/feature-flag.entity';
 
 describe('FeatureFlagsService', () => {
@@ -70,6 +73,97 @@ describe('FeatureFlagsService', () => {
         'user-1',
       );
       expect(typeof isEnabled).toBe('boolean');
+    });
+  });
+
+  describe('cache TTL behaviour', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('serves evaluations from cache in the steady state without database hits', async () => {
+      repository.find.mockClear();
+      repository.findOne.mockClear();
+
+      await service.isFeatureEnabled('test_feature', 'user-1');
+      await service.isFeatureEnabled('test_feature', 'user-2');
+      await service.isFeatureEnabled('non_existent_key', 'user-3');
+
+      expect(repository.find).not.toHaveBeenCalled();
+      expect(repository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('refreshes from the database once the TTL has elapsed', async () => {
+      repository.find.mockClear();
+      const realNow = Date.now();
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(realNow + DEFAULT_FEATURE_FLAG_CACHE_TTL_MS + 1);
+
+      await service.isFeatureEnabled('test_feature', 'user-1');
+      expect(repository.find).toHaveBeenCalledTimes(1);
+
+      // The refresh restarts the window: no further loads until it lapses.
+      await service.isFeatureEnabled('test_feature', 'user-1');
+      expect(repository.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('picks up an external flag change within the TTL window', async () => {
+      // The flag is disabled directly in the database (e.g. by another
+      // instance) — no same-process invalidation hook fires.
+      repository.find.mockClear();
+      repository.find.mockResolvedValue([
+        { ...mockFlag, enabled: false, rolloutPercentage: 0 },
+      ]);
+
+      // Within the window the cache is served without consulting the DB.
+      await service.isFeatureEnabled('test_feature', 'user-1');
+      expect(repository.find).not.toHaveBeenCalled();
+
+      const realNow = Date.now();
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(realNow + DEFAULT_FEATURE_FLAG_CACHE_TTL_MS + 1);
+
+      // Once the TTL lapses the change is visible.
+      expect(await service.isFeatureEnabled('test_feature', 'user-1')).toBe(
+        false,
+      );
+      expect(repository.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps serving stale flags for one window when the database is down', async () => {
+      repository.find.mockClear();
+      repository.find.mockRejectedValue(new Error('db down'));
+      const realNow = Date.now();
+      const nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(realNow + DEFAULT_FEATURE_FLAG_CACHE_TTL_MS + 1);
+
+      // Refresh fails but evaluation still answers from the stale cache.
+      expect(
+        typeof (await service.isFeatureEnabled('test_feature', 'user-1')),
+      ).toBe('boolean');
+      expect(repository.find).toHaveBeenCalledTimes(1);
+
+      // No retry storm: the failed refresh also restarted the window.
+      await service.isFeatureEnabled('test_feature', 'user-1');
+      expect(repository.find).toHaveBeenCalledTimes(1);
+      nowSpy.mockRestore();
+    });
+
+    it('applies same-process flag updates immediately', async () => {
+      repository.find.mockClear();
+      await service.updateFlag('test_feature', {
+        enabled: false,
+        rolloutPercentage: 0,
+      });
+
+      expect(await service.isFeatureEnabled('test_feature', 'user-1')).toBe(
+        false,
+      );
+      // Served from the invalidated cache, not a fresh database load.
+      expect(repository.find).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/feature-flags/feature-flags.service.ts
+++ b/backend/src/modules/feature-flags/feature-flags.service.ts
@@ -4,7 +4,9 @@ import {
   ConflictException,
   Logger,
   OnModuleInit,
+  Optional,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FeatureFlag } from './entities/feature-flag.entity';
@@ -15,15 +17,37 @@ import {
   calculateUserBucket,
 } from './utils/bucketing.util';
 
+/**
+ * Default cache TTL. This is the documented window within which a flag
+ * change made outside this process (another instance, direct DB edit) is
+ * guaranteed to take effect. Same-process mutations invalidate immediately.
+ */
+export const DEFAULT_FEATURE_FLAG_CACHE_TTL_MS = 30_000;
+
 @Injectable()
 export class FeatureFlagsService implements OnModuleInit {
   private readonly logger = new Logger(FeatureFlagsService.name);
   private cache: Map<string, FeatureFlag> = new Map();
+  /** Epoch ms of the last cache load; 0 forces a load on first evaluation. */
+  private cacheLoadedAt = 0;
+  private readonly cacheTtlMs: number;
 
   constructor(
     @InjectRepository(FeatureFlag)
     private readonly flagRepository: Repository<FeatureFlag>,
-  ) {}
+    @Optional() configService?: ConfigService,
+  ) {
+    const configured = Number(
+      configService?.get(
+        'FEATURE_FLAG_CACHE_TTL_MS',
+        DEFAULT_FEATURE_FLAG_CACHE_TTL_MS,
+      ) ?? DEFAULT_FEATURE_FLAG_CACHE_TTL_MS,
+    );
+    this.cacheTtlMs =
+      Number.isFinite(configured) && configured > 0
+        ? configured
+        : DEFAULT_FEATURE_FLAG_CACHE_TTL_MS;
+  }
 
   async onModuleInit() {
     await this.refreshCache();
@@ -31,8 +55,13 @@ export class FeatureFlagsService implements OnModuleInit {
 
   /**
    * Refreshes the in-memory flag cache from the database.
+   *
+   * The load timestamp advances even on failure so that a database outage
+   * degrades to serving stale flags for one TTL window instead of retrying
+   * the database on every evaluation.
    */
   async refreshCache(): Promise<void> {
+    this.cacheLoadedAt = Date.now();
     try {
       const flags = await this.flagRepository.find();
       const newCache = new Map<string, FeatureFlag>();
@@ -50,25 +79,27 @@ export class FeatureFlagsService implements OnModuleInit {
     }
   }
 
+  private isCacheStale(): boolean {
+    return Date.now() - this.cacheLoadedAt > this.cacheTtlMs;
+  }
+
   /**
    * Evaluates whether a specific feature flag is enabled for a given user.
+   *
+   * In the steady state this is served entirely from the in-memory cache —
+   * the database is only consulted when the cache has passed its TTL
+   * (`FEATURE_FLAG_CACHE_TTL_MS`, default 30s). Unknown flags default to
+   * disabled without a per-request database lookup.
    *
    * @param flagKey Unique key of the flag
    * @param userId Optional user identifier
    */
   async isFeatureEnabled(flagKey: string, userId?: string): Promise<boolean> {
-    let flag: FeatureFlag | null | undefined = this.cache.get(flagKey);
-
-    if (!flag) {
-      const dbFlag = await this.flagRepository.findOne({
-        where: { key: flagKey },
-      });
-      if (dbFlag) {
-        this.cache.set(dbFlag.key, dbFlag);
-        flag = dbFlag;
-      }
+    if (this.isCacheStale()) {
+      await this.refreshCache();
     }
 
+    const flag = this.cache.get(flagKey);
     if (!flag) {
       // Unknown flags default to disabled for safety
       return false;


### PR DESCRIPTION
## Summary
Fixes four assigned backend issues: refresh-token rotation now detects replayed (already-consumed) tokens and revokes the token family with a security event; the orphaned-records cleanup gains a dry-run mode and a per-run deletion cap with alerting; dispute evidence uploads are validated by magic-byte content sniffing with a configurable size cap; and feature-flag evaluation is served from a TTL cache instead of hitting the database.

closes #1582
closes #1584
closes #1586
closes #1589

## Changes
- **#1582 — refresh token reuse detection**: the flow previously compared the presented token to the stored bcrypt hash and returned a generic error on mismatch. Now, a mismatch on a *signature-valid* refresh token (we provably issued it, but rotation already consumed it) is treated as the classic stolen-token replay signal: the user's stored refresh hash is cleared — revoking the entire token family so even the newest legitimate token is refused until re-login — and a CRITICAL `SUSPICIOUS_ACTIVITY` security event (`reason: refresh_token_reuse`, `action: token_family_revoked`) is recorded through the existing `SecurityEventsService`, which is what the security monitoring endpoints read. Garbage/forged tokens (signature failure) do NOT revoke the family. Monitoring failures are caught so they can never mask the revocation. `SecurityEventsService` is injected `@Optional` (AuthModule now imports SecurityModule; no cycle — SecurityModule never imports AuthModule).
- **#1584 — cleanup dry-run + deletion cap**: `OrphanedRecordsCleanupService.runCleanup` (the scheduled 4AM deleter) now takes a `dryRun` option, also settable via `ORPHAN_CLEANUP_DRY_RUN=true` and exposed as `?dryRun=true` on `POST /cleanup/orphaned-records/run`. Dry-run logs and returns per-check candidate counts plus up to 10 sample row ids without issuing a single DELETE, regardless of `ORPHAN_CLEANUP_DELETE_ENABLED`. Real runs are capped by `ORPHAN_CLEANUP_MAX_DELETIONS_PER_RUN` (default 500, invalid config falls back): before any batch that would push the cumulative total over the cap, the run aborts — the offending batch is never deleted — and a critical `OrphanCleanupCapExceeded` alert is raised through the monitoring `AlertService` escalation pipeline. Stats now include `dryRun`, `maxDeletionsPerRun`, `aborted`, `abortReason`, and per-check `sampleIds`.
- **#1586 — evidence upload content enforcement**: `DisputesService.addEvidence` previously trusted the client-declared `mimetype`. Validation now sniffs the actual buffer: magic-byte signatures for jpeg/png/gif/pdf/doc(OLE2)/docx(zip) and a printable-content heuristic (NUL bytes rejected) for plain text — an `.exe` declared as `application/pdf` is rejected, and a PNG declared as anything is accepted as a PNG. The *sniffed* type is what gets persisted on the evidence record, never the declared header. The size cap is now configurable via `DISPUTE_EVIDENCE_MAX_FILE_SIZE_BYTES` (default 10MB). Validation logic lives in a pure util (`utils/evidence-file-validation.util.ts`).
- **#1589 — feature-flag TTL cache**: the service had an in-memory cache but no TTL, and unknown keys fell through to a `findOne` on every request. Evaluation is now fully cache-served in the steady state: the cache refreshes only when `FEATURE_FLAG_CACHE_TTL_MS` (default 30s — the documented update window) lapses; unknown flags default to disabled with no DB lookup; same-process create/update/kill-switch/delete still invalidate immediately; and a failed refresh (DB outage) serves stale flags for one window instead of retrying on every request.

## Test plan
- 79 tests across the four touched suites, all passing locally; `npx tsc -p tsconfig.build.json --noEmit` clean; eslint/prettier clean on every changed file.
- auth (35): valid rotation stores the new hash with no event; replay revokes the family with the exact security-event payload; a follow-up request with the newest token is also refused post-revocation (family semantics); invalid-signature tokens revoke nothing; event-recording failure still revokes; plus all pre-existing register/login/reset/lockout cases.
- cleanup (9, new suite): dry-run reports counts and sample ids with zero DELETE statements (asserted against the SQL issued), sample list capped at 10, config-driven dry-run, under-cap deletion, abort-before-batch with alert payload and short-circuited remaining checks, single-batch-over-cap aborts with zero deletions, invalid cap fallback, scan-only default, non-postgres skip.
- disputes (22, new suite): sniffing table for all seven allowed types, rejection of MZ/ELF/random binary/empty content, forged-declaration cases both directions, default and custom size caps, missing-buffer rejection, NUL-byte text rejection; service-level tests assert the sniffed type is persisted, `ValidationError` on disallowed content, and the configurable cap.
- feature-flags (13): steady-state evaluation with zero repository calls, TTL-elapsed refresh happens exactly once per window, external DB change visible after the window, DB-outage degradation without a retry storm, immediate same-process update effect, plus pre-existing CRUD/kill-switch cases.

---
Notes: `disputes.service.spec.ts` and `disputes.resolution.spec.ts` fail on a clean checkout of `devv` with a pre-existing DI error (missing `PaymentRepository` provider at index 5) — verified by stashing this change set and re-running; this PR does not touch those suites' wiring, though the `validateFile` spies in `disputes.resolution.spec.ts` were updated to the new return type so they are correct once the DI issue is fixed. `disputes.integration.spec.ts` is skipped upstream. The evidence endpoint uses in-memory multer storage, so nothing is written inside a servable path during validation; persisting to real object storage (the `fileUrl: file.path` placeholder) remains a pre-existing follow-up.