### PR TITLE
feat: Implement package size monitoring (#1473)

### DIFF
--- a/frontend/__tests__/scripts/check-bundle-size.test.ts
+++ b/frontend/__tests__/scripts/check-bundle-size.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// Do not mock 'fs' globally like this, use vi.spyOn later
+
+const { getRouteChunks, getRouteSizeBytes, statusLabel } = require('../../scripts/check-bundle-size.js');
+
+describe('check-bundle-size script', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('getRouteChunks', () => {
+    it('returns chunks from appBuildManifest if exact match', () => {
+      const appBuildManifest = {
+        pages: {
+          '/dashboard': ['static/chunks/app/dashboard.js'],
+        },
+      };
+      
+      const chunks = getRouteChunks('/dashboard', {}, appBuildManifest);
+      expect(chunks).toEqual(['static/chunks/app/dashboard.js']);
+    });
+
+    it('returns chunks from appBuildManifest with /page suffix', () => {
+      const appBuildManifest = {
+        pages: {
+          '/dashboard/page': ['static/chunks/app/dashboard/page.js'],
+        },
+      };
+      
+      const chunks = getRouteChunks('/dashboard', {}, appBuildManifest);
+      expect(chunks).toEqual(['static/chunks/app/dashboard/page.js']);
+    });
+
+    it('returns chunks from buildManifest if found there', () => {
+      const buildManifest = {
+        pages: {
+          '/login': ['static/chunks/pages/login.js'],
+        },
+      };
+      
+      const chunks = getRouteChunks('/login', buildManifest, {});
+      expect(chunks).toEqual(['static/chunks/pages/login.js']);
+    });
+
+    it('returns empty array if not found in either', () => {
+      const chunks = getRouteChunks('/unknown', { pages: {} }, { pages: {} });
+      expect(chunks).toEqual([]);
+    });
+  });
+
+  describe('getRouteSizeBytes', () => {
+    it('calculates sum of unique JS chunk sizes', () => {
+      const buildManifest = {
+        pages: {
+          '/': ['chunk1.js', 'chunk2.js', 'chunk1.js', 'style.css'],
+        },
+      };
+      
+      const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+        const p = filePath.toString();
+        if (p.endsWith('chunk1.js')) return { size: 1024 } as any;
+        if (p.endsWith('chunk2.js')) return { size: 2048 } as any;
+        throw new Error('Not found');
+      });
+
+      const size = getRouteSizeBytes('/', buildManifest, null, '/build-dir');
+      
+      // chunk1 is added once, chunk2 is added once. style.css is ignored
+      expect(size).toBe(1024 + 2048);
+      expect(statSpy).toHaveBeenCalledTimes(2);
+    });
+    
+    it('handles missing files gracefully', () => {
+      const buildManifest = {
+        pages: {
+          '/': ['chunk1.js', 'missing.js'],
+        },
+      };
+      
+      vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+        const p = filePath.toString();
+        if (p.endsWith('chunk1.js')) return { size: 1024 } as any;
+        throw new Error('ENOENT');
+      });
+
+      const size = getRouteSizeBytes('/', buildManifest, null, '/build-dir');
+      expect(size).toBe(1024);
+    });
+  });
+
+  describe('statusLabel', () => {
+    const budget = { maxKB: 500, warnKB: 400 };
+
+    it('returns PASS ✓ when size is below warn limit', () => {
+      expect(statusLabel(300, budget)).toBe('PASS ✓');
+    });
+
+    it('returns WARN ⚠ when size is above warn limit but below max limit', () => {
+      expect(statusLabel(450, budget)).toBe('WARN ⚠');
+    });
+
+    it('returns FAIL ✗ when size is above max limit', () => {
+      expect(statusLabel(550, budget)).toBe('FAIL ✗');
+    });
+  });
+});

--- a/frontend/scripts/check-bundle-size.js
+++ b/frontend/scripts/check-bundle-size.js
@@ -88,6 +88,43 @@ function collectRouteChunks() {
   return { totalStaticBytes };
 }
 
+function getRouteChunks(routeKey, buildManifest, appBuildManifest) {
+  // check app directory
+  if (appBuildManifest && appBuildManifest.pages) {
+    if (appBuildManifest.pages[routeKey]) return appBuildManifest.pages[routeKey];
+    const asPage = routeKey === '/' ? '/page' : `${routeKey}/page`;
+    if (appBuildManifest.pages[asPage]) return appBuildManifest.pages[asPage];
+  }
+  
+  // check pages directory
+  if (buildManifest && buildManifest.pages) {
+    if (buildManifest.pages[routeKey]) return buildManifest.pages[routeKey];
+  }
+  
+  return [];
+}
+
+function getRouteSizeBytes(routeKey, buildManifest, appBuildManifest, buildDir) {
+  const chunks = getRouteChunks(routeKey, buildManifest, appBuildManifest);
+  let sizeBytes = 0;
+  const seen = new Set();
+
+  for (const chunk of chunks) {
+    if (seen.has(chunk)) continue;
+    seen.add(chunk);
+    
+    if (!chunk.endsWith('.js')) continue;
+
+    try {
+      sizeBytes += fs.statSync(path.join(buildDir, chunk)).size;
+    } catch {
+      // ignore
+    }
+  }
+
+  return sizeBytes;
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 function main() {
@@ -112,7 +149,13 @@ function main() {
 
   const budgets = budgetConfig.routes;
   const baselines = budgetConfig.baseline || {};
+  
   const BUILD_MANIFEST = path.join(BUILD_DIR, 'build-manifest.json');
+  const APP_BUILD_MANIFEST = path.join(BUILD_DIR, 'app-build-manifest.json');
+  
+  const buildManifest = readJson(BUILD_MANIFEST) || {};
+  const appBuildManifest = readJson(APP_BUILD_MANIFEST) || {};
+  
   const { totalStaticBytes } = collectRouteChunks();
 
   const COL = {
@@ -142,35 +185,30 @@ function main() {
   const results = [];
   const deltaSummary = [];
 
-  const buildManifest = readJson(BUILD_MANIFEST) || {};
-  const rootMainFiles = buildManifest.rootMainFiles || [];
-  let rootMainBytes = 0;
-  for (const f of rootMainFiles) {
-    try {
-      rootMainBytes += fs.statSync(path.join(BUILD_DIR, f)).size;
-    } catch {
-      // ignore
-    }
-  }
-
   for (const [routeKey, budget] of Object.entries(budgets)) {
     let sizeKB = 0;
     if (routeKey === 'shared-chunks') {
       sizeKB = toKB(totalStaticBytes);
     } else {
-      sizeKB = toKB(rootMainBytes || totalStaticBytes * 0.15);
+      const bytes = getRouteSizeBytes(routeKey, buildManifest, appBuildManifest, BUILD_DIR);
+      if (bytes > 0) {
+        sizeKB = toKB(bytes);
+      } else {
+        // Fallback for empty/missing routes if strictly requested, but we'll report 0 to highlight they are missing.
+        sizeKB = 0;
+      }
     }
 
     const baselineKB = baselines[routeKey];
     const delta = formatDelta(sizeKB, baselineKB);
-    const label = statusLabel(sizeKB, budget);
+    const label = sizeKB === 0 ? 'MISSING' : statusLabel(sizeKB, budget);
 
     if (label.startsWith('FAIL')) failed = true;
     if (label.startsWith('WARN')) warned = true;
 
     results.push({ routeKey, sizeKB, baselineKB, delta, budget, label });
 
-    if (typeof baselineKB === 'number') {
+    if (typeof baselineKB === 'number' && sizeKB > 0) {
       deltaSummary.push({
         routeKey,
         sizeKB,
@@ -181,15 +219,15 @@ function main() {
   }
 
   results.sort((a, b) => {
-    const order = { 'FAIL ✗': 0, 'WARN ⚠': 1, 'PASS ✓': 2 };
-    return (order[a.label] ?? 3) - (order[b.label] ?? 3);
+    const order = { 'MISSING': 0, 'FAIL ✗': 1, 'WARN ⚠': 2, 'PASS ✓': 3 };
+    return (order[a.label] ?? 4) - (order[b.label] ?? 4);
   });
 
   for (const { routeKey, sizeKB, delta, budget, label } of results) {
-    const color = statusColor(label);
+    const color = label === 'MISSING' ? '\x1b[31m' : statusColor(label);
     console.log(
       pad(routeKey, COL.route) +
-        pad(sizeKB.toFixed(1), COL.size) +
+        pad(sizeKB > 0 ? sizeKB.toFixed(1) : 'N/A', COL.size) +
         pad(delta, COL.delta) +
         pad(budget.maxKB, COL.budget) +
         pad(budget.warnKB, COL.warn) +
@@ -236,4 +274,12 @@ function main() {
   process.exit(0);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  getRouteChunks,
+  getRouteSizeBytes,
+  statusLabel,
+};


### PR DESCRIPTION
## Description
Closes #1473 

Bundle size was growing unchecked, and performance regressions were going unnoticed because the per-route size monitoring script was using a hardcoded placeholder calculation (`0.15 * totalStaticBytes`) instead of actually reading the Next.js build manifests.

This PR implements the missing logic to correctly calculate and track exact JS bundle sizes for each route during the build pipeline.

## Changes Made
- **Implemented Manifest Parsing**: Rewrote `frontend/scripts/check-bundle-size.js` to accurately parse both `app-build-manifest.json` (for App Router) and `build-manifest.json` (for Pages Router).
- **Accurate Size Calculation**: The script now properly aggregates unique JS chunk sizes specifically required for each defined route, effectively replacing the previous placeholder math.
- **Improved Edge Case Handling**: Added fallback handling for routes that may be missing files or renamed gracefully.
- **Unit Testing**: Introduced comprehensive Vitest tests in `frontend/__tests__/scripts/check-bundle-size.test.ts` to cover manifest parsing, chunk aggregations, and edge cases, ensuring strict type and lint compliance. 

## Testing Instructions
1. Run `pnpm run build` in the `frontend` directory to generate fresh `.next` build files.
2. Run `pnpm run size:check` to execute the newly updated size monitoring script.
3. Verify that the output lists the accurate sizes for each route rather than placeholder estimates, and appropriately warns or fails according to `bundle-budgets.json`.
4. Run `pnpm run test scripts/check-bundle-size` in the `frontend` directory to verify the new unit tests pass successfully.
