### PR TITLE
feat: mainnet deployment script 

### DIFF
--- a/contract/contracts/agent_registry/src/agent.rs
+++ b/contract/contracts/agent_registry/src/agent.rs
@@ -2,6 +2,7 @@ use soroban_sdk::{Address, Env, String, Vec};
 
 use crate::errors::AgentError;
 use crate::events;
+use crate::rate_limit;
 use crate::storage::DataKey;
 use crate::types::{AgentInfo, AgentTransaction, ContractState};
 
@@ -15,6 +16,9 @@ pub fn register_agent(
     }
 
     agent.require_auth();
+
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &agent, "register_agent")?;
 
     if external_profile_hash.is_empty() {
         return Err(AgentError::InvalidProfileHash);
@@ -60,6 +64,9 @@ pub fn verify_agent(env: &Env, admin: Address, agent: Address) -> Result<(), Age
 
     admin.require_auth();
 
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &admin, "verify_agent")?;
+
     if admin != state.admin {
         return Err(AgentError::Unauthorized);
     }
@@ -98,6 +105,9 @@ pub fn rate_agent(
     }
 
     rater.require_auth();
+
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &rater, "rate_agent")?;
 
     if !(1..=5).contains(&score) {
         return Err(AgentError::InvalidRatingScore);
@@ -186,6 +196,9 @@ pub fn register_transaction(
         return Err(AgentError::NotInitialized);
     }
 
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &agent, "register_transaction")?;
+
     let agent_key = DataKey::Agent(agent.clone());
     if !env.storage().persistent().has(&agent_key) {
         return Err(AgentError::AgentNotFound);
@@ -218,6 +231,9 @@ pub fn complete_transaction(
     if !env.storage().persistent().has(&DataKey::Initialized) {
         return Err(AgentError::NotInitialized);
     }
+
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &agent, "complete_transaction")?;
 
     let txn_key = DataKey::Transaction(transaction_id.clone());
     let mut transaction: AgentTransaction = env

--- a/contract/contracts/agent_registry/src/errors.rs
+++ b/contract/contracts/agent_registry/src/errors.rs
@@ -17,4 +17,6 @@ pub enum AgentError {
     TransactionNotFound = 11,
     NotTransactionParty = 12,
     TransactionNotCompleted = 13,
+    RateLimitExceeded = 14,
+    CooldownNotMet = 15,
 }

--- a/contract/contracts/agent_registry/src/lib.rs
+++ b/contract/contracts/agent_registry/src/lib.rs
@@ -5,12 +5,16 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 mod agent;
 mod errors;
 mod events;
+mod rate_limit;
 mod storage;
 mod types;
 mod upgrade;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod tests_rate_limit;
 
 pub use agent::{
     complete_transaction, get_agent_count, get_agent_info, rate_agent, register_agent,

--- a/contract/contracts/agent_registry/src/rate_limit.rs
+++ b/contract/contracts/agent_registry/src/rate_limit.rs
@@ -1,0 +1,88 @@
+//! Rate limiting module for agent registry functions.
+
+use soroban_sdk::{Address, Env, String};
+
+use crate::errors::AgentError;
+use crate::storage::DataKey;
+use crate::types::{RateLimitConfig, UserCallCount};
+
+const BLOCKS_PER_DAY: u64 = 17280; // Assuming ~5 second blocks
+
+/// Get current rate limit configuration.
+pub fn get_rate_limit_config(env: &Env) -> RateLimitConfig {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RateLimitConfig)
+        .unwrap_or(RateLimitConfig {
+            max_calls_per_block: 10,
+            max_calls_per_user_per_day: 100,
+            cooldown_blocks: 0,
+        })
+}
+
+/// Check and enforce rate limits for a user calling a specific function.
+pub fn check_rate_limit(env: &Env, user: &Address, function_name: &str) -> Result<(), AgentError> {
+    let config = get_rate_limit_config(env);
+    let current_block = env.ledger().sequence() as u64;
+
+    // Get or initialize user call count
+    let key = DataKey::UserCallCount(user.clone(), String::from_str(env, function_name));
+    let mut user_calls: UserCallCount =
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(UserCallCount {
+                user: user.clone(),
+                call_count: 0,
+                last_call_block: 0,
+                daily_count: 0,
+                daily_reset_block: current_block,
+            });
+
+    // Check cooldown period (skip on first call when last_call_block is 0)
+    if config.cooldown_blocks > 0 && user_calls.last_call_block > 0 {
+        let blocks_since_last = current_block.saturating_sub(user_calls.last_call_block);
+        if blocks_since_last < config.cooldown_blocks as u64 {
+            return Err(AgentError::CooldownNotMet);
+        }
+    }
+
+    // Reset daily count if a day has passed
+    let blocks_since_reset = current_block.saturating_sub(user_calls.daily_reset_block);
+    if blocks_since_reset >= BLOCKS_PER_DAY {
+        user_calls.daily_count = 0;
+        user_calls.daily_reset_block = current_block;
+    }
+
+    // Check daily limit
+    if user_calls.daily_count >= config.max_calls_per_user_per_day {
+        return Err(AgentError::RateLimitExceeded);
+    }
+
+    // Check per-block limit
+    let block_key = DataKey::BlockCallCount(current_block, String::from_str(env, function_name));
+    let block_calls: u32 = env.storage().temporary().get(&block_key).unwrap_or(0);
+
+    if block_calls >= config.max_calls_per_block {
+        return Err(AgentError::RateLimitExceeded);
+    }
+
+    // Update counters
+    user_calls.call_count += 1;
+    user_calls.last_call_block = current_block;
+    user_calls.daily_count += 1;
+
+    // Save user call count
+    env.storage().persistent().set(&key, &user_calls);
+    env.storage().persistent().extend_ttl(&key, 500000, 500000);
+
+    // Update block call count
+    env.storage()
+        .temporary()
+        .set(&block_key, &(block_calls + 1));
+    env.storage()
+        .temporary()
+        .extend_ttl(&block_key, BLOCKS_PER_DAY as u32, BLOCKS_PER_DAY as u32);
+
+    Ok(())
+}

--- a/contract/contracts/agent_registry/src/storage.rs
+++ b/contract/contracts/agent_registry/src/storage.rs
@@ -10,4 +10,8 @@ pub enum DataKey {
     Transaction(String),
     AgentRating(Address, Address),
     UpgradeProposal(String),
+    // Rate limiting
+    RateLimitConfig,
+    UserCallCount(Address, String),
+    BlockCallCount(u64, String),
 }

--- a/contract/contracts/agent_registry/src/tests_rate_limit.rs
+++ b/contract/contracts/agent_registry/src/tests_rate_limit.rs
@@ -1,0 +1,161 @@
+use crate::rate_limit;
+use crate::storage::DataKey;
+use crate::types::RateLimitConfig;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+use crate::AgentRegistryContract;
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    let contract_id = env.register(AgentRegistryContract, ());
+    let user = Address::generate(&env);
+    (env, contract_id, user)
+}
+
+fn seed_config(env: &Env, contract_id: &Address, config: &RateLimitConfig) {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::RateLimitConfig, config);
+    });
+}
+
+#[test]
+fn test_rate_limit_config_default() {
+    let (env, contract_id, _user) = setup();
+
+    let config = env.as_contract(&contract_id, || rate_limit::get_rate_limit_config(&env));
+    assert_eq!(config.max_calls_per_block, 10);
+    assert_eq!(config.max_calls_per_user_per_day, 100);
+    assert_eq!(config.cooldown_blocks, 0);
+}
+
+#[test]
+fn test_check_rate_limit_within_limit() {
+    let (env, contract_id, user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 10,
+            max_calls_per_user_per_day: 5,
+            cooldown_blocks: 0,
+        },
+    );
+
+    for _ in 0..3 {
+        let result = env.as_contract(&contract_id, || {
+            rate_limit::check_rate_limit(&env, &user, "register_agent")
+        });
+        assert!(result.is_ok());
+    }
+}
+
+#[test]
+fn test_check_rate_limit_exceed_block() {
+    let (env, contract_id, _user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 2,
+            max_calls_per_user_per_day: 100,
+            cooldown_blocks: 0,
+        },
+    );
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+
+    let r1 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user1, "register_agent")
+    });
+    assert!(r1.is_ok());
+
+    let r2 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user2, "register_agent")
+    });
+    assert!(r2.is_ok());
+
+    let r3 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user3, "register_agent")
+    });
+    assert!(r3.is_err());
+}
+
+#[test]
+fn test_check_rate_limit_exceed_daily() {
+    let (env, contract_id, user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 100,
+            max_calls_per_user_per_day: 2,
+            cooldown_blocks: 0,
+        },
+    );
+
+    let r1 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_agent")
+    });
+    assert!(r1.is_ok());
+
+    env.ledger().with_mut(|li| li.sequence_number += 1);
+
+    let r2 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_agent")
+    });
+    assert!(r2.is_ok());
+
+    env.ledger().with_mut(|li| li.sequence_number += 1);
+
+    let r3 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_agent")
+    });
+    assert!(r3.is_err());
+}
+
+#[test]
+fn test_check_rate_limit_cooldown() {
+    let (env, contract_id, user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 100,
+            max_calls_per_user_per_day: 100,
+            cooldown_blocks: 10,
+        },
+    );
+
+    // Start at block 1 so last_call_block is nonzero after the first call
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let r1 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_agent")
+    });
+    assert!(r1.is_ok());
+
+    // Same block => cooldown not met
+    let r2 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_agent")
+    });
+    assert!(r2.is_err());
+
+    // Advance past cooldown
+    env.ledger().with_mut(|li| li.sequence_number += 10);
+
+    let r3 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_agent")
+    });
+    assert!(r3.is_ok());
+}

--- a/contract/contracts/agent_registry/src/types.rs
+++ b/contract/contracts/agent_registry/src/types.rs
@@ -45,3 +45,21 @@ pub struct AgentTransaction {
     pub parties: Vec<Address>,
     pub completed: bool,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitConfig {
+    pub max_calls_per_block: u32,
+    pub max_calls_per_user_per_day: u32,
+    pub cooldown_blocks: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserCallCount {
+    pub user: Address,
+    pub call_count: u32,
+    pub last_call_block: u64,
+    pub daily_count: u32,
+    pub daily_reset_block: u64,
+}

--- a/contract/contracts/property_registry/src/errors.rs
+++ b/contract/contracts/property_registry/src/errors.rs
@@ -12,4 +12,6 @@ pub enum PropertyError {
     AlreadyVerified = 6,
     InvalidPropertyId = 7,
     InvalidMetadata = 8,
+    RateLimitExceeded = 9,
+    CooldownNotMet = 10,
 }

--- a/contract/contracts/property_registry/src/lib.rs
+++ b/contract/contracts/property_registry/src/lib.rs
@@ -5,12 +5,16 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String};
 mod errors;
 mod events;
 mod property;
+mod rate_limit;
 mod storage;
 mod types;
 mod upgrade;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod tests_rate_limit;
 
 #[cfg(test)]
 mod tests_rbac;

--- a/contract/contracts/property_registry/src/property.rs
+++ b/contract/contracts/property_registry/src/property.rs
@@ -2,6 +2,7 @@ use soroban_sdk::{Address, Env, String};
 
 use crate::errors::PropertyError;
 use crate::events;
+use crate::rate_limit;
 use crate::storage::DataKey;
 use crate::types::{ContractState, PropertyDetails};
 
@@ -16,6 +17,9 @@ pub fn register_property(
     }
 
     landlord.require_auth();
+
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &landlord, "register_property")?;
 
     if property_id.is_empty() {
         return Err(PropertyError::InvalidPropertyId);
@@ -66,6 +70,9 @@ pub fn verify_property(
         .ok_or(PropertyError::NotInitialized)?;
 
     admin.require_auth();
+
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &admin, "verify_property")?;
 
     if admin != state.admin {
         return Err(PropertyError::Unauthorized);
@@ -127,6 +134,9 @@ pub fn transfer_property(
 
     current_landlord.require_auth();
 
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &current_landlord, "transfer_property")?;
+
     let key = DataKey::Property(property_id.clone());
     let mut property: PropertyDetails = env
         .storage()
@@ -164,6 +174,9 @@ pub fn update_property_metadata(
     }
 
     landlord.require_auth();
+
+    // Rate limiting check
+    rate_limit::check_rate_limit(env, &landlord, "update_property_metadata")?;
 
     if new_metadata_hash.is_empty() {
         return Err(PropertyError::InvalidMetadata);

--- a/contract/contracts/property_registry/src/rate_limit.rs
+++ b/contract/contracts/property_registry/src/rate_limit.rs
@@ -1,0 +1,92 @@
+//! Rate limiting module for property registry functions.
+
+use soroban_sdk::{Address, Env, String};
+
+use crate::errors::PropertyError;
+use crate::storage::DataKey;
+use crate::types::{RateLimitConfig, UserCallCount};
+
+const BLOCKS_PER_DAY: u64 = 17280; // Assuming ~5 second blocks
+
+/// Get current rate limit configuration.
+pub fn get_rate_limit_config(env: &Env) -> RateLimitConfig {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RateLimitConfig)
+        .unwrap_or(RateLimitConfig {
+            max_calls_per_block: 10,
+            max_calls_per_user_per_day: 100,
+            cooldown_blocks: 0,
+        })
+}
+
+/// Check and enforce rate limits for a user calling a specific function.
+pub fn check_rate_limit(
+    env: &Env,
+    user: &Address,
+    function_name: &str,
+) -> Result<(), PropertyError> {
+    let config = get_rate_limit_config(env);
+    let current_block = env.ledger().sequence() as u64;
+
+    // Get or initialize user call count
+    let key = DataKey::UserCallCount(user.clone(), String::from_str(env, function_name));
+    let mut user_calls: UserCallCount =
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(UserCallCount {
+                user: user.clone(),
+                call_count: 0,
+                last_call_block: 0,
+                daily_count: 0,
+                daily_reset_block: current_block,
+            });
+
+    // Check cooldown period (skip on first call when last_call_block is 0)
+    if config.cooldown_blocks > 0 && user_calls.last_call_block > 0 {
+        let blocks_since_last = current_block.saturating_sub(user_calls.last_call_block);
+        if blocks_since_last < config.cooldown_blocks as u64 {
+            return Err(PropertyError::CooldownNotMet);
+        }
+    }
+
+    // Reset daily count if a day has passed
+    let blocks_since_reset = current_block.saturating_sub(user_calls.daily_reset_block);
+    if blocks_since_reset >= BLOCKS_PER_DAY {
+        user_calls.daily_count = 0;
+        user_calls.daily_reset_block = current_block;
+    }
+
+    // Check daily limit
+    if user_calls.daily_count >= config.max_calls_per_user_per_day {
+        return Err(PropertyError::RateLimitExceeded);
+    }
+
+    // Check per-block limit
+    let block_key = DataKey::BlockCallCount(current_block, String::from_str(env, function_name));
+    let block_calls: u32 = env.storage().temporary().get(&block_key).unwrap_or(0);
+
+    if block_calls >= config.max_calls_per_block {
+        return Err(PropertyError::RateLimitExceeded);
+    }
+
+    // Update counters
+    user_calls.call_count += 1;
+    user_calls.last_call_block = current_block;
+    user_calls.daily_count += 1;
+
+    // Save user call count
+    env.storage().persistent().set(&key, &user_calls);
+    env.storage().persistent().extend_ttl(&key, 500000, 500000);
+
+    // Update block call count
+    env.storage()
+        .temporary()
+        .set(&block_key, &(block_calls + 1));
+    env.storage()
+        .temporary()
+        .extend_ttl(&block_key, BLOCKS_PER_DAY as u32, BLOCKS_PER_DAY as u32);
+
+    Ok(())
+}

--- a/contract/contracts/property_registry/src/storage.rs
+++ b/contract/contracts/property_registry/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, String};
+use soroban_sdk::{contracttype, Address, String};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -8,4 +8,8 @@ pub enum DataKey {
     Initialized,
     PropertyCount,
     UpgradeProposal(String),
+    // Rate limiting
+    RateLimitConfig,
+    UserCallCount(Address, String),
+    BlockCallCount(u64, String),
 }

--- a/contract/contracts/property_registry/src/tests_rate_limit.rs
+++ b/contract/contracts/property_registry/src/tests_rate_limit.rs
@@ -1,0 +1,161 @@
+use crate::rate_limit;
+use crate::storage::DataKey;
+use crate::types::RateLimitConfig;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+use crate::PropertyRegistryContract;
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    let contract_id = env.register(PropertyRegistryContract, ());
+    let user = Address::generate(&env);
+    (env, contract_id, user)
+}
+
+fn seed_config(env: &Env, contract_id: &Address, config: &RateLimitConfig) {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::RateLimitConfig, config);
+    });
+}
+
+#[test]
+fn test_rate_limit_config_default() {
+    let (env, contract_id, _user) = setup();
+
+    let config = env.as_contract(&contract_id, || rate_limit::get_rate_limit_config(&env));
+    assert_eq!(config.max_calls_per_block, 10);
+    assert_eq!(config.max_calls_per_user_per_day, 100);
+    assert_eq!(config.cooldown_blocks, 0);
+}
+
+#[test]
+fn test_check_rate_limit_within_limit() {
+    let (env, contract_id, user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 10,
+            max_calls_per_user_per_day: 5,
+            cooldown_blocks: 0,
+        },
+    );
+
+    for _ in 0..3 {
+        let result = env.as_contract(&contract_id, || {
+            rate_limit::check_rate_limit(&env, &user, "register_property")
+        });
+        assert!(result.is_ok());
+    }
+}
+
+#[test]
+fn test_check_rate_limit_exceed_block() {
+    let (env, contract_id, _user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 2,
+            max_calls_per_user_per_day: 100,
+            cooldown_blocks: 0,
+        },
+    );
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+
+    let r1 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user1, "register_property")
+    });
+    assert!(r1.is_ok());
+
+    let r2 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user2, "register_property")
+    });
+    assert!(r2.is_ok());
+
+    let r3 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user3, "register_property")
+    });
+    assert!(r3.is_err());
+}
+
+#[test]
+fn test_check_rate_limit_exceed_daily() {
+    let (env, contract_id, user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 100,
+            max_calls_per_user_per_day: 2,
+            cooldown_blocks: 0,
+        },
+    );
+
+    let r1 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_property")
+    });
+    assert!(r1.is_ok());
+
+    env.ledger().with_mut(|li| li.sequence_number += 1);
+
+    let r2 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_property")
+    });
+    assert!(r2.is_ok());
+
+    env.ledger().with_mut(|li| li.sequence_number += 1);
+
+    let r3 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_property")
+    });
+    assert!(r3.is_err());
+}
+
+#[test]
+fn test_check_rate_limit_cooldown() {
+    let (env, contract_id, user) = setup();
+
+    seed_config(
+        &env,
+        &contract_id,
+        &RateLimitConfig {
+            max_calls_per_block: 100,
+            max_calls_per_user_per_day: 100,
+            cooldown_blocks: 10,
+        },
+    );
+
+    // Start at block 1 so last_call_block is nonzero after the first call
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let r1 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_property")
+    });
+    assert!(r1.is_ok());
+
+    // Same block => cooldown not met
+    let r2 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_property")
+    });
+    assert!(r2.is_err());
+
+    // Advance past cooldown
+    env.ledger().with_mut(|li| li.sequence_number += 10);
+
+    let r3 = env.as_contract(&contract_id, || {
+        rate_limit::check_rate_limit(&env, &user, "register_property")
+    });
+    assert!(r3.is_ok());
+}

--- a/contract/contracts/property_registry/src/types.rs
+++ b/contract/contracts/property_registry/src/types.rs
@@ -17,3 +17,21 @@ pub struct ContractState {
     pub admin: Address,
     pub initialized: bool,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitConfig {
+    pub max_calls_per_block: u32,
+    pub max_calls_per_user_per_day: u32,
+    pub cooldown_blocks: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserCallCount {
+    pub user: Address,
+    pub call_count: u32,
+    pub last_call_block: u64,
+    pub daily_count: u32,
+    pub daily_reset_block: u64,
+}

--- a/contract/docs/deployment/MAINNET_DEPLOYMENT.md
+++ b/contract/docs/deployment/MAINNET_DEPLOYMENT.md
@@ -165,8 +165,12 @@ same as testnet:
 
 ### Option A — scripted (recommended for reproducibility)
 
-Only use this if `DEPLOYER_KEY` is a hardware/offline signer that the `stellar`
-CLI can drive; the script never handles a raw secret itself.
+Use [`scripts/deploy-mainnet.sh`](../../scripts/deploy-mainnet.sh) — a
+safety-focused wrapper around `deploy-testnet.sh` built specifically for this
+flow, so a production deploy is never run ad hoc from someone's shell history.
+Only use it if `DEPLOYER_KEY` is a hardware/offline signer that the `stellar`
+CLI can drive and that already exists as a CLI identity; the script never
+handles a raw secret itself and will not auto-generate one.
 
 ```bash
 cd contract
@@ -175,18 +179,20 @@ cd contract
 env -u CARGO_TARGET_DIR stellar contract build
 
 # Deploy + initialize on mainnet.
-NETWORK=mainnet \
 DEPLOYER_KEY=<mainnet-hardware-identity> \
-ENV_FILE=.env.mainnet \
-ALIAS_PREFIX=chioma_mainnet \
 PLATFORM_FEE_BPS=500 \
 MIN_DISPUTE_VOTES=3 \
-  ./scripts/deploy-testnet.sh --skip-fund
+  ./scripts/deploy-mainnet.sh --confirm
 ```
 
-The script writes each deployed `*_CONTRACT_ID` into `.env.mainnet` and runs the
-per-contract initializers with `--admin` set to the deployer's public key.
-**Immediately** hand off admin to the multisig — see
+`deploy-mainnet.sh` refuses to run without `--confirm` plus a typed
+`DEPLOY TO MAINNET` confirmation, refuses a dirty git tree, forces
+`--skip-fund` (mainnet has no Friendbot), writes each deployed
+`*_CONTRACT_ID` into `.env.mainnet`, appends the commit and contract
+addresses to `docs/deployment/MAINNET_DEPLOYMENTS.log` as a permanent audit
+record, and automatically runs `verify-deployment.sh` once the deploy
+completes. It initializes each contract with `--admin` set to the deployer's
+public key. **Immediately** hand off admin to the multisig — see
 [Post-deployment hardening](#post-deployment-hardening).
 
 ### Option B — manual, one contract at a time
@@ -252,7 +258,10 @@ Immediately after init, before announcing or routing any user funds:
 
 ## Verification
 
-Reuse [`scripts/verify-deployment.sh`](../../scripts/verify-deployment.sh)
+`deploy-mainnet.sh` already runs `verify-deployment.sh` automatically at the
+end of a successful deploy. To re-run it standalone (e.g. after Option B, or
+some time later), reuse
+[`scripts/verify-deployment.sh`](../../scripts/verify-deployment.sh)
 against mainnet — it checks on-chain presence and runs read-only smoke tests:
 
 ```bash
@@ -337,5 +346,7 @@ rollback can be executed quickly.
 - [../security/AUDIT.md](../security/AUDIT.md) — audit requirement and status (launch gate)
 - [../security/EMERGENCY-PROCEDURES.md](../security/EMERGENCY-PROCEDURES.md) — pause & incident response
 - [../../scripts/README.md](../../scripts/README.md) — deploy & verify scripts
+- [`scripts/deploy-mainnet.sh`](../../scripts/deploy-mainnet.sh) — the mainnet deploy script itself
+- `docs/deployment/MAINNET_DEPLOYMENTS.log` — append-only record of past mainnet deploys (created on first run)
 - [`.env.mainnet.example`](../../.env.mainnet.example) — mainnet config template
 - [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli)

--- a/contract/scripts/README.md
+++ b/contract/scripts/README.md
@@ -57,9 +57,40 @@ stellar keys fund testnet-deployer --network testnet
 
 **Output:** `.env.testnet` with `*_CONTRACT_ID` variables for the frontend/backend.
 
+## `deploy-mainnet.sh`
+
+Safety-focused wrapper around `deploy-testnet.sh` for Stellar mainnet (pubnet). See
+[docs/deployment/MAINNET_DEPLOYMENT.md](../docs/deployment/MAINNET_DEPLOYMENT.md)
+for the full runbook and the Production Launch Gate that must be satisfied first.
+
+```bash
+cd contract
+./scripts/deploy-mainnet.sh --confirm
+```
+
+Unlike hand-running `deploy-testnet.sh` with mainnet env vars, this script:
+
+- refuses to run without `--confirm` **and** a typed `DEPLOY TO MAINNET`
+  confirmation (or `$CONFIRM_PHRASE` in non-interactive shells)
+- never auto-generates a deployer identity — mainnet keys must already exist
+  and be hardware-backed / offline
+- always passes `--skip-fund` (mainnet has no Friendbot)
+- refuses a dirty git tree by default (`--allow-dirty` to override, not recommended)
+- appends the commit, deployer, and every deployed contract ID to
+  `docs/deployment/MAINNET_DEPLOYMENTS.log`
+- automatically runs `verify-deployment.sh` against mainnet once deploy completes
+
+| Flag            | Description                                        |
+| --------------- | --------------------------------------------------- |
+| `--confirm`     | Required, or the script exits immediately            |
+| `--skip-build`  | Use existing `target/wasm32v1-none/release/*.wasm`  |
+| `--deploy-only` | Deploy only; skip `initialize` calls                |
+| `--init-only`   | Initialize from existing `.env.mainnet`             |
+| `--allow-dirty` | Bypass the clean-git-tree check (NOT recommended)   |
+
 ## `verify-deployment.sh`
 
-Loads `.env.testnet`, checks each contract exists on testnet, and runs read-only `invoke` smoke tests.
+Loads `.env.testnet` (or `.env.mainnet` via `ENV_FILE`), checks each contract exists on the target network, and runs read-only `invoke` smoke tests.
 
 ## Troubleshooting
 
@@ -68,4 +99,4 @@ Loads `.env.testnet`, checks each contract exists on testnet, and runs read-only
 - **Init auth errors:** ensure `DEPLOYER_KEY` is the same identity used as `--admin` / `--collector`.
 - **Rate limits:** re-run with `--init-only` after deploy succeeds.
 
-See also: [docs/deployment/TESTNET_DEPLOYMENT.md](../docs/deployment/TESTNET_DEPLOYMENT.md)
+See also: [docs/deployment/TESTNET_DEPLOYMENT.md](../docs/deployment/TESTNET_DEPLOYMENT.md) and [docs/deployment/MAINNET_DEPLOYMENT.md](../docs/deployment/MAINNET_DEPLOYMENT.md)

--- a/contract/scripts/deploy-mainnet.sh
+++ b/contract/scripts/deploy-mainnet.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Deploy all Chioma Soroban contracts to Stellar MAINNET (pubnet).
+#
+# This is a safety-focused wrapper around deploy-testnet.sh, which is already
+# network-parameterized and drives both networks (see "Option A — scripted"
+# in docs/deployment/MAINNET_DEPLOYMENT.md). Unlike a hand-run
+# `NETWORK=mainnet ... ./deploy-testnet.sh`, this script:
+#   - refuses to run without an explicit --confirm flag and a typed
+#     confirmation phrase
+#   - refuses to auto-generate a deployer identity (mainnet keys must be
+#     hardware-backed / offline, provisioned out of band)
+#   - never attempts Friendbot funding (mainnet has none)
+#   - refuses to deploy from a dirty git tree (mainnet must ship the exact
+#     audited commit)
+#   - records the commit, deployer, and every deployed contract address to
+#     an append-only log, instead of leaving that history only in a shell
+#   - automatically runs verify-deployment.sh once the deploy completes
+#
+# Read docs/deployment/MAINNET_DEPLOYMENT.md in full — in particular the
+# Production Launch Gate — before running this script.
+#
+# Usage (from contract/):
+#   ./scripts/deploy-mainnet.sh --confirm
+#
+# Options:
+#   --confirm         Required. Without it the script exits immediately.
+#   --skip-build      Use existing WASM artifacts
+#   --deploy-only     Deploy WASM; skip initialization
+#   --init-only       Initialize using IDs in .env.mainnet (skip deploy)
+#   --allow-dirty     Bypass the clean-git-tree check (NOT recommended)
+#
+# Environment:
+#   DEPLOYER_KEY       Stellar identity name — MUST already exist and be
+#                      hardware/offline-backed (default: mainnet-deployer)
+#   PLATFORM_FEE_BPS   Default 500
+#   MIN_DISPUTE_VOTES  Default 3
+#   ALIAS_PREFIX       Default chioma_mainnet
+#   ENV_FILE           Default .env.mainnet
+#   DEPLOY_LOG         Default docs/deployment/MAINNET_DEPLOYMENTS.log
+#   CONFIRM_PHRASE     Non-interactive substitute for the typed prompt
+#                      (must equal "DEPLOY TO MAINNET")
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$CONTRACT_ROOT"
+
+NETWORK=mainnet
+DEPLOYER_KEY="${DEPLOYER_KEY:-mainnet-deployer}"
+ENV_FILE="${ENV_FILE:-.env.mainnet}"
+ALIAS_PREFIX="${ALIAS_PREFIX:-chioma_mainnet}"
+PLATFORM_FEE_BPS="${PLATFORM_FEE_BPS:-500}"
+MIN_DISPUTE_VOTES="${MIN_DISPUTE_VOTES:-3}"
+DEPLOY_LOG="${DEPLOY_LOG:-docs/deployment/MAINNET_DEPLOYMENTS.log}"
+
+CONFIRM=0
+ALLOW_DIRTY=0
+PASSTHROUGH_ARGS=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --confirm) CONFIRM=1 ;;
+    --allow-dirty) ALLOW_DIRTY=1 ;;
+    --skip-build | --deploy-only | --init-only) PASSTHROUGH_ARGS+=("$arg") ;;
+    -h | --help)
+      sed -n '2,38p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[*]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err() { echo -e "${RED}[!]${NC} $*" >&2; }
+
+require_cli() {
+  if ! command -v stellar >/dev/null 2>&1; then
+    err "Stellar CLI not found. Install: https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli"
+    exit 1
+  fi
+}
+
+require_confirm_flag() {
+  if [[ "$CONFIRM" -ne 1 ]]; then
+    err "Refusing to run: this deploys to Stellar MAINNET with real funds."
+    err "Re-run with --confirm only after the Production Launch Gate in"
+    err "docs/deployment/MAINNET_DEPLOYMENT.md is fully satisfied (independent"
+    err "audit, pre-deployment checklist, multisig ready, etc.)."
+    exit 1
+  fi
+}
+
+require_clean_tree() {
+  if [[ "$ALLOW_DIRTY" -eq 1 ]]; then
+    warn "Skipping git-clean check (--allow-dirty). Not recommended for mainnet."
+    return 0
+  fi
+  if [[ -n "$(git status --porcelain)" ]]; then
+    err "Working tree is not clean. Mainnet MUST deploy from the exact commit"
+    err "covered by the security audit. Commit or stash changes, or pass"
+    err "--allow-dirty to override (not recommended)."
+    exit 1
+  fi
+}
+
+require_existing_identity() {
+  if ! stellar keys ls 2>/dev/null | grep -qx "$DEPLOYER_KEY"; then
+    err "Identity '$DEPLOYER_KEY' not found."
+    err "Mainnet deployer keys must be provisioned out of band (hardware"
+    err "wallet / offline signer) — this script will not auto-generate one."
+    err "See 'Key custody and admin model' in docs/deployment/MAINNET_DEPLOYMENT.md."
+    exit 1
+  fi
+}
+
+confirm_interactively() {
+  local admin="$1"
+  echo ""
+  warn "==================================================================="
+  warn " MAINNET DEPLOYMENT"
+  warn " Network:   $NETWORK"
+  warn " Deployer:  $DEPLOYER_KEY ($admin)"
+  warn " Env file:  $ENV_FILE"
+  warn " Commit:    $(git rev-parse --short HEAD)"
+  warn " escrow/payment will hold REAL FUNDS once this goes live."
+  warn "==================================================================="
+  echo ""
+
+  local reply
+  if [[ -t 0 ]]; then
+    read -r -p "Type 'DEPLOY TO MAINNET' to continue: " reply
+  else
+    reply="${CONFIRM_PHRASE:-}"
+    log "Non-interactive shell: reading confirmation from \$CONFIRM_PHRASE."
+  fi
+
+  if [[ "$reply" != "DEPLOY TO MAINNET" ]]; then
+    err "Confirmation phrase did not match. Aborting."
+    exit 1
+  fi
+}
+
+record_deployment() {
+  local admin="$1" commit
+  commit="$(git rev-parse HEAD)"
+  mkdir -p "$(dirname "$DEPLOY_LOG")"
+  {
+    echo "## Mainnet deployment — $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo "- Commit: $commit"
+    echo "- Deployer identity: $DEPLOYER_KEY ($admin)"
+    echo "- Env file: $ENV_FILE"
+    if [[ -f "$ENV_FILE" ]]; then
+      grep '_CONTRACT_ID=' "$ENV_FILE" | sed 's/^/- /'
+    fi
+    echo ""
+  } >>"$DEPLOY_LOG"
+  log "Deployment recorded in $DEPLOY_LOG"
+}
+
+main() {
+  require_cli
+  require_confirm_flag
+  require_clean_tree
+  require_existing_identity
+
+  local admin
+  admin="$(stellar keys public-key "$DEPLOYER_KEY")"
+
+  confirm_interactively "$admin"
+
+  log "Delegating to deploy-testnet.sh with mainnet parameters (--skip-fund; mainnet has no Friendbot)..."
+  export NETWORK DEPLOYER_KEY ENV_FILE ALIAS_PREFIX PLATFORM_FEE_BPS MIN_DISPUTE_VOTES
+  if [[ ${#PASSTHROUGH_ARGS[@]} -gt 0 ]]; then
+    "$SCRIPT_DIR/deploy-testnet.sh" --skip-fund "${PASSTHROUGH_ARGS[@]}"
+  else
+    "$SCRIPT_DIR/deploy-testnet.sh" --skip-fund
+  fi
+
+  record_deployment "$admin"
+
+  log "Running post-deploy verification..."
+  NETWORK="$NETWORK" ENV_FILE="$ENV_FILE" DEPLOYER_KEY="$DEPLOYER_KEY" \
+    "$SCRIPT_DIR/verify-deployment.sh"
+
+  echo ""
+  warn "Deployment used '$DEPLOYER_KEY' as bootstrap admin. Immediately hand"
+  warn "off admin to the multisig — see 'Post-deployment hardening' in"
+  warn "docs/deployment/MAINNET_DEPLOYMENT.md."
+}
+
+main "$@"


### PR DESCRIPTION
. agent_registry rate limiting — added rate_limit.rs (mirroring the exact pattern shared by escrow/payment/dispute_resolution), new RateLimitConfig/UserCallCount types, RateLimitExceeded/CooldownNotMet errors, and wired check_rate_limit into all five mutating entry points: register_agent, verify_agent, rate_agent, register_transaction, complete_transaction. Added tests_rate_limit.rs with 5 tests covering defaults, per-block, per-day, and cooldown limits.

. property_registry rate limiting — same treatment: rate_limit.rs, types, errors, wired into register_property, verify_property, transfer_property, update_property_metadata, plus matching tests.

. deploy-mainnet.sh — a safety-focused wrapper around the existing deploy-testnet.sh (which the docs already described as network-parameterized). It:
- refuses to run without --confirm + a typed DEPLOY TO MAINNET phrase (or $CONFIRM_PHRASE non-interactively)
- refuses to auto-generate a deployer identity — mainnet keys must be pre-provisioned/hardware-backed
- forces --skip-fund (no Friendbot on mainnet)
- refuses a dirty git tree by default
- appends commit hash + deployer + every deployed contract address to docs/deployment/MAINNET_DEPLOYMENTS.log as a durable audit trail
- automatically runs verify-deployment.sh at the end

Updated scripts/README.md and docs/deployment/MAINNET_DEPLOYMENT.md to point at the new script instead of the old "hand-run with env vars" instructions.

All 641 workspace tests pass, cargo fmt --check and cargo clippy -D warnings are clean on both touched crates, and I dry-ran deploy-mainnet.sh end-to-end (confirmation gate, identity gate, real wasm build) confirming it behaves correctly and aborts safely when it hits the (expected, sandboxed) missing mainnet RPC.


closes #1673
closes #1674
closes #1676
closes #1677