### PR TITLE
Fix/1610 1620 logger sink agreement idempotency

### DIFF
--- a/backend/src/common/logger/logger.service.spec.ts
+++ b/backend/src/common/logger/logger.service.spec.ts
@@ -1,0 +1,67 @@
+import {
+  ConsoleTransport,
+  FileTransport,
+  LoggerService,
+  SentryTransport,
+  resolveTransports,
+} from './logger.service';
+
+describe('resolveTransports', () => {
+  it('defaults to console only in development', () => {
+    const transports = resolveTransports({ NODE_ENV: 'development' });
+    expect(transports).toHaveLength(1);
+    expect(transports[0]).toBeInstanceOf(ConsoleTransport);
+  });
+
+  it('defaults to console + sentry in production when SENTRY_DSN is set', () => {
+    const transports = resolveTransports({
+      NODE_ENV: 'production',
+      SENTRY_DSN: 'https://example@sentry.io/1',
+    });
+    expect(transports).toHaveLength(2);
+    expect(transports[0]).toBeInstanceOf(ConsoleTransport);
+    expect(transports[1]).toBeInstanceOf(SentryTransport);
+  });
+
+  it('omits sentry in production when SENTRY_DSN is unset, falling back to console', () => {
+    const transports = resolveTransports({ NODE_ENV: 'production' });
+    expect(transports).toHaveLength(1);
+    expect(transports[0]).toBeInstanceOf(ConsoleTransport);
+  });
+
+  it('is configuration-driven via LOG_TRANSPORT', () => {
+    const transports = resolveTransports({
+      NODE_ENV: 'development',
+      LOG_TRANSPORT: 'file,console',
+      LOG_FILE: '/tmp/app.log',
+    });
+    expect(transports).toHaveLength(2);
+    expect(transports[0]).toBeInstanceOf(FileTransport);
+    expect(transports[1]).toBeInstanceOf(ConsoleTransport);
+  });
+
+  it('ignores unknown transport names', () => {
+    const transports = resolveTransports({
+      NODE_ENV: 'development',
+      LOG_TRANSPORT: 'bogus',
+    });
+    expect(transports).toHaveLength(1);
+    expect(transports[0]).toBeInstanceOf(ConsoleTransport);
+  });
+});
+
+describe('LoggerService', () => {
+  it('writes each log entry to every configured transport', () => {
+    const service = new LoggerService();
+    const writeSpy = jest
+      .spyOn(ConsoleTransport.prototype, 'write')
+      .mockImplementation(() => undefined);
+
+    service.info('hello', { service: 'test' });
+
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'INFO', message: 'hello' }),
+    );
+    writeSpy.mockRestore();
+  });
+});

--- a/backend/src/common/logger/logger.service.ts
+++ b/backend/src/common/logger/logger.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, Scope } from '@nestjs/common';
 import * as fs from 'fs';
+import * as Sentry from '@sentry/nestjs';
 
 export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'FATAL';
 
@@ -14,11 +15,112 @@ export interface LogContext {
   context?: any;
 }
 
+export interface LogEntry extends LogContext {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  error?: string;
+}
+
+/** A destination log entries are written to. */
+export interface LogTransport {
+  write(entry: LogEntry): void;
+}
+
+/** Local, non-durable: NestJS console output. Always available for dev. */
+export class ConsoleTransport implements LogTransport {
+  constructor(
+    private readonly nestLogger: Logger = new Logger(LoggerService.name),
+  ) {}
+
+  write(entry: LogEntry): void {
+    const logStr = JSON.stringify(entry);
+    if (entry.level === 'ERROR' || entry.level === 'FATAL') {
+      this.nestLogger.error(logStr);
+    } else if (entry.level === 'WARN') {
+      this.nestLogger.warn(logStr);
+    } else {
+      this.nestLogger.log(logStr);
+    }
+  }
+}
+
+/** Local, non-durable: append-only file on the instance's own disk. */
+export class FileTransport implements LogTransport {
+  constructor(private readonly filePath: string) {}
+
+  write(entry: LogEntry): void {
+    fs.appendFileSync(this.filePath, JSON.stringify(entry) + '\n');
+  }
+}
+
+/**
+ * Durable sink: ships WARN+ entries to Sentry so they survive instance
+ * restarts and scale-in. Silently disabled when SENTRY_DSN isn't set.
+ */
+export class SentryTransport implements LogTransport {
+  write(entry: LogEntry): void {
+    const { level, message, error, timestamp, ...extra } = entry;
+    if (level === 'ERROR' || level === 'FATAL') {
+      Sentry.captureException(new Error(error || message), {
+        level: level === 'FATAL' ? 'fatal' : 'error',
+        extra: { message, timestamp, ...extra },
+      });
+    } else if (level === 'WARN') {
+      Sentry.captureMessage(message, { level: 'warning', extra });
+    } else {
+      Sentry.addBreadcrumb({
+        category: 'log',
+        level: 'info',
+        message,
+        data: extra,
+      });
+    }
+  }
+}
+
+const TRANSPORT_FACTORIES: Record<
+  string,
+  (env: NodeJS.ProcessEnv) => LogTransport | null
+> = {
+  console: () => new ConsoleTransport(),
+  file: (env) => new FileTransport(env.LOG_FILE || 'logs/app.log'),
+  sentry: (env) => (env.SENTRY_DSN ? new SentryTransport() : null),
+};
+
+/**
+ * Reads LOG_TRANSPORT (comma-separated, e.g. "console,sentry") to pick
+ * transports. Defaults to console-only in development/test, and
+ * console+sentry in staging/production so logs reach a durable sink there
+ * without any extra configuration.
+ */
+export function resolveTransports(
+  env: NodeJS.ProcessEnv = process.env,
+): LogTransport[] {
+  const configured = env.LOG_TRANSPORT;
+  const names = configured
+    ? configured
+        .split(',')
+        .map((name) => name.trim().toLowerCase())
+        .filter(Boolean)
+    : env.NODE_ENV === 'production' || env.NODE_ENV === 'staging'
+      ? ['console', 'sentry']
+      : ['console'];
+
+  const transports = names
+    .map((name) => TRANSPORT_FACTORIES[name]?.(env))
+    .filter((t): t is LogTransport => t != null);
+
+  return transports.length > 0 ? transports : [new ConsoleTransport()];
+}
+
 @Injectable({ scope: Scope.TRANSIENT })
 export class LoggerService {
-  private logToFile = process.env.NODE_ENV === 'production';
-  private logFile = 'logs/app.log';
-  private readonly nestLogger = new Logger(LoggerService.name);
+  private readonly transports: LogTransport[];
+
+  constructor() {
+    this.transports = resolveTransports();
+  }
 
   private log(
     level: LogLevel,
@@ -26,27 +128,16 @@ export class LoggerService {
     context: LogContext = {},
     error?: Error,
   ) {
-    const logEntry = {
+    const logEntry: LogEntry = {
       timestamp: new Date().toISOString(),
       level,
       ...context,
       message,
       error: error ? error.stack || error.message : undefined,
     };
-    const logStr = JSON.stringify(logEntry);
-    if (this.logToFile) {
-      fs.appendFileSync(this.logFile, logStr + '\n');
-    } else {
-      // Use NestJS Logger for dev output
-      if (level === 'ERROR' || level === 'FATAL') {
-        this.nestLogger.error(logStr);
-      } else if (level === 'WARN') {
-        this.nestLogger.warn(logStr);
-      } else {
-        this.nestLogger.log(logStr);
-      }
+    for (const transport of this.transports) {
+      transport.write(logEntry);
     }
-    // TODO: Add Sentry, CloudWatch, ELK integration as needed
   }
 
   debug(message: string, context?: LogContext) {

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -396,6 +396,8 @@ const securitySchema = Joi.object({
 const loggingSchema = Joi.object({
   LOG_LEVEL: Joi.string().valid('debug', 'info', 'warn', 'error'),
   LOG_FORMAT: Joi.string().valid('simple', 'json'),
+  LOG_TRANSPORT: Joi.string(),
+  LOG_FILE: Joi.string(),
   LOG_SLOW_REQUEST_THRESHOLD: Joi.number().min(0),
   LOG_SKIP_PATHS: Joi.string(),
   LOG_MAX_FILES: Joi.string(),

--- a/backend/src/modules/agreements/agreements.controller.ts
+++ b/backend/src/modules/agreements/agreements.controller.ts
@@ -31,6 +31,7 @@ import { RecordPaymentDto } from './dto/record-payment.dto';
 import { TerminateAgreementDto } from './dto/terminate-agreement.dto';
 import { QueryAgreementsDto } from './dto/query-agreements.dto';
 import { RenewAgreementDto } from './dto/renew-agreement.dto';
+import { SignAgreementDto } from './dto/sign-agreement.dto';
 import { QueryAgreementFeesDto } from './dto/query-agreement-fees.dto';
 import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -162,6 +163,25 @@ export class AgreementsController {
     @Body() terminateDto: TerminateAgreementDto,
   ) {
     return await this.agreementsService.terminate(id, terminateDto);
+  }
+
+  @ApiResponse({ status: 200, description: 'Signed' })
+  @ApiOperation({
+    summary: 'Sign agreement',
+    description:
+      'Transitions the agreement to SIGNED. Pass idempotencyKey to safely retry on client timeout or network drop — ' +
+      'the original result is returned for the same agreement+key instead of re-running side effects, for 7 days.',
+  })
+  @Post(':id/sign')
+  @AuditLog({
+    action: AuditAction.UPDATE,
+    entityType: 'RentAgreement',
+    level: AuditLevel.INFO,
+    includeNewValues: true,
+  })
+  @HttpCode(HttpStatus.OK)
+  async sign(@Param('id') id: string, @Body() dto: SignAgreementDto) {
+    return await this.agreementsService.sign(id, dto);
   }
 
   @ApiResponse({ status: 201, description: 'Created' })

--- a/backend/src/modules/agreements/agreements.service.spec.ts
+++ b/backend/src/modules/agreements/agreements.service.spec.ts
@@ -21,6 +21,11 @@ import { AgreementStateService } from './state-machines/agreement-state-machine.
 
 describe('AgreementsService (lease extensions)', () => {
   let service: AgreementsService;
+  let mockIdempotencyService: {
+    retrieve: jest.Mock;
+    store: jest.Mock;
+    process: jest.Mock;
+  };
 
   const baseAgreement = {
     id: 'agr-1',
@@ -82,6 +87,19 @@ describe('AgreementsService (lease extensions)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockIdempotencyService = {
+      retrieve: jest.fn().mockResolvedValue(null),
+      store: jest.fn().mockResolvedValue(undefined),
+      process: jest.fn(
+        async (key: string, ttlMs: number, fn: () => Promise<unknown>) => {
+          const existing = await mockIdempotencyService.retrieve(key);
+          if (existing !== null) return existing;
+          const result = await fn();
+          await mockIdempotencyService.store(key, result, ttlMs);
+          return result;
+        },
+      ),
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AgreementsService,
@@ -114,10 +132,7 @@ describe('AgreementsService (lease extensions)', () => {
         },
         {
           provide: IdempotencyService,
-          useValue: {
-            get: jest.fn().mockResolvedValue(null),
-            set: jest.fn().mockResolvedValue(undefined),
-          },
+          useFactory: () => mockIdempotencyService,
         },
         {
           provide: AgreementStateService,
@@ -127,7 +142,7 @@ describe('AgreementsService (lease extensions)', () => {
             transition: jest.fn(),
           },
         },
-        { provide: EventEmitter2, useValue: {} },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 
@@ -204,6 +219,38 @@ describe('AgreementsService (lease extensions)', () => {
     it('throws when missing', async () => {
       mockAgreementRepo.findOne.mockResolvedValue(null);
       await expect(service.findOne('x')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sign', () => {
+    it('transitions the agreement to SIGNED', async () => {
+      mockAgreementRepo.findOne.mockResolvedValue({
+        ...baseAgreement,
+        status: AgreementStatus.PENDING_DEPOSIT,
+      });
+      mockAgreementRepo.save.mockImplementation((a) => Promise.resolve(a));
+
+      const result = await service.sign('agr-1', {});
+
+      expect(result.status).toBe(AgreementStatus.SIGNED);
+    });
+
+    it('returns the original result for a repeated idempotency key without re-signing', async () => {
+      mockAgreementRepo.findOne.mockResolvedValue({
+        ...baseAgreement,
+        status: AgreementStatus.PENDING_DEPOSIT,
+      });
+      mockAgreementRepo.save.mockImplementation((a) => Promise.resolve(a));
+
+      const dto = { idempotencyKey: 'retry-key-1' };
+      const first = await service.sign('agr-1', dto);
+
+      mockIdempotencyService.retrieve.mockResolvedValue(first);
+
+      const second = await service.sign('agr-1', dto);
+
+      expect(second).toEqual(first);
+      expect(mockAgreementRepo.save).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/backend/src/modules/agreements/agreements.service.ts
+++ b/backend/src/modules/agreements/agreements.service.ts
@@ -17,6 +17,7 @@ import { RecordPaymentDto } from './dto/record-payment.dto';
 import { TerminateAgreementDto } from './dto/terminate-agreement.dto';
 import { QueryAgreementsDto } from './dto/query-agreements.dto';
 import { RenewAgreementDto } from './dto/renew-agreement.dto';
+import { SignAgreementDto } from './dto/sign-agreement.dto';
 import { AuditService } from '../audit/audit.service';
 import { ReviewPromptService } from '../reviews/review-prompt.service';
 import { ChiomaContractService } from '../stellar/services/chioma-contract.service';
@@ -245,6 +246,36 @@ export class AgreementsService {
         ),
       );
     }
+
+    return saved;
+  }
+
+  @Locked({ key: (id: string) => `agreement:sign:${id}`, ttlMs: 10000 })
+  @Idempotent({
+    ttlMs: 604_800_000,
+    key: (id: string, dto: SignAgreementDto) =>
+      dto?.idempotencyKey ? `agreement:sign:${id}:${dto.idempotencyKey}` : null,
+    requireKey: false,
+  })
+  async sign(id: string, _dto: SignAgreementDto) {
+    const agreement = await this.findOne(id);
+    const oldStatus = agreement.status;
+    this.stateService.validateTransition(
+      agreement.status,
+      AgreementStatus.SIGNED,
+    );
+    agreement.status = AgreementStatus.SIGNED;
+    const saved = await this.agreementRepository.save(agreement);
+
+    this.eventEmitter.emit(
+      'agreement.status.changed',
+      new AgreementStatusChangedEvent(
+        id,
+        oldStatus,
+        AgreementStatus.SIGNED,
+        'Agreement signed',
+      ),
+    );
 
     return saved;
   }

--- a/backend/src/modules/agreements/dto/sign-agreement.dto.ts
+++ b/backend/src/modules/agreements/dto/sign-agreement.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SignAgreementDto {
+  @ApiPropertyOptional({
+    description:
+      'Optional idempotency key for safely retrying agreement signing (client timeout, mobile network drop). ' +
+      'The first result for a given agreement+key is returned for repeat submissions instead of re-running the signature/escrow side effects. Retained for 7 days.',
+    example: '66b2c4b6-38c6-4f18-a591-2e0f9d4f1d4e',
+  })
+  @IsOptional()
+  @IsString()
+  idempotencyKey?: string;
+}


### PR DESCRIPTION
# Logger durable sink + agreement signing idempotency

## Summary
- **#1610**: `LoggerService` now writes through pluggable, config-driven transports (`LOG_TRANSPORT` env var). Staging/production default to `console+sentry` (reusing the already-configured `SENTRY_DSN`) so logs survive instance restarts/scale-in; local dev stays console-only.
- **#1620**: `POST /agreements/:id/sign` now accepts an optional `idempotencyKey`, reusing the existing `@Locked`/`@Idempotent` infra (same pattern as `create`). A retried request with the same key returns the original result instead of re-running the signing transition/side effects. Retention: 7 days.

## Testing
- `npx jest` — full backend suite (217 suites / 2520 tests) passes
- `npx tsc --noEmit` — clean
- `npm run lint` — no new errors/warnings
- `npm run build` — clean

## Notes
- No new dependencies; Sentry and winston were already in the project.
- Key retention window for the sign endpoint is 7 days, documented in the endpoint's Swagger description and the DTO.

Closes #1610
Closes #1620
