### PR TITLE
Feature/1769 rent obligation burn reassign

### DIFF
--- a/backend/src/modules/agreements/__tests__/agreements.pagination.spec.ts
+++ b/backend/src/modules/agreements/__tests__/agreements.pagination.spec.ts
@@ -10,6 +10,7 @@ import { Payment } from '../../rent/entities/payment.entity';
 import { AuditService } from '../../audit/audit.service';
 import { ReviewPromptService } from '../../reviews/review-prompt.service';
 import { ChiomaContractService } from '../../stellar/services/chioma-contract.service';
+import { AgreementNftService } from '../agreement-nft.service';
 import { BlockchainSyncService } from '../blockchain-sync.service';
 import { EscrowIntegrationService } from '../escrow-integration.service';
 import { TemplateRenderingService } from '../template-rendering.service';
@@ -48,6 +49,10 @@ describe('AgreementsService – Pagination', () => {
         { provide: AuditService, useValue: {} },
         { provide: ReviewPromptService, useValue: {} },
         { provide: ChiomaContractService, useValue: {} },
+        {
+          provide: AgreementNftService,
+          useValue: { burnNftForAgreement: jest.fn() },
+        },
         { provide: BlockchainSyncService, useValue: {} },
         { provide: EscrowIntegrationService, useValue: {} },
         { provide: TemplateRenderingService, useValue: { render: jest.fn() } },

--- a/backend/src/modules/agreements/agreement-nft.controller.ts
+++ b/backend/src/modules/agreements/agreement-nft.controller.ts
@@ -7,14 +7,29 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { AgreementNftService } from './agreement-nft.service';
 import { NftAnalyticsService } from './nft-analytics.service';
-import { MintNftDto, TransferNftDto } from './dto/nft.dto';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  MintNftDto,
+  TransferNftDto,
+  BurnNftDto,
+  AdminReassignObligationDto,
+} from './dto/nft.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 import { ApiPaginatedResponse } from '../../common/decorators/api-paginated-response.decorator';
 import { RentObligationNft } from './entities/rent-obligation-nft.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../users/entities/user.entity';
 
 @Controller('agreements/nfts')
 @ApiTags('Agreement Nft')
@@ -90,5 +105,31 @@ export class AgreementNftController {
   async syncOwnership(@Param('agreementId') agreementId: string) {
     await this.nftService.syncNftOwnership(agreementId);
     return { message: 'Ownership synced successfully' };
+  }
+
+  @ApiBearerAuth('JWT-auth')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiResponse({ status: 200, description: 'Burned' })
+  @ApiOperation({ summary: 'Burn nft (admin only)' })
+  @Post('burn')
+  @HttpCode(HttpStatus.OK)
+  async burnNft(@Body() dto: BurnNftDto) {
+    return this.nftService.burnNftForAgreement(dto.agreementId, dto.reason);
+  }
+
+  @ApiBearerAuth('JWT-auth')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiResponse({ status: 200, description: 'Reassigned' })
+  @ApiOperation({ summary: 'Admin reassign obligation (admin only)' })
+  @Post('admin-reassign')
+  @HttpCode(HttpStatus.OK)
+  async adminReassign(@Body() dto: AdminReassignObligationDto) {
+    return this.nftService.adminReassignNft(
+      dto.agreementId,
+      dto.newOwnerAddress,
+      dto.adminAddress,
+    );
   }
 }

--- a/backend/src/modules/agreements/agreement-nft.service.spec.ts
+++ b/backend/src/modules/agreements/agreement-nft.service.spec.ts
@@ -29,6 +29,8 @@ describe('AgreementNftService', () => {
             mintObligation: jest.fn(),
             transferObligation: jest.fn(),
             getObligationOwner: jest.fn(),
+            burnObligation: jest.fn(),
+            adminReassignObligation: jest.fn(),
           },
         },
       ],
@@ -120,6 +122,116 @@ describe('AgreementNftService', () => {
 
       expect(result.currentOwner).toBe(toAddress);
       expect(result.transferCount).toBe(1);
+    });
+  });
+
+  describe('burnNftForAgreement', () => {
+    it('burns the NFT and marks it burned', async () => {
+      const agreementId = 'agreement-123';
+      const existingNft = {
+        id: 'nft-id',
+        agreementId,
+        tokenId: 'token-123',
+        currentOwner: 'GOWNER',
+        status: 'active',
+        isActive: true,
+      } as unknown as RentObligationNft;
+
+      jest.spyOn(nftRepository, 'findOne').mockResolvedValue(existingNft);
+      jest.spyOn(nftContractService, 'burnObligation').mockResolvedValue({
+        txHash: 'burn-tx-hash',
+      });
+      jest
+        .spyOn(nftRepository, 'save')
+        .mockImplementation((n) => Promise.resolve(n as RentObligationNft));
+
+      const result = await service.burnNftForAgreement(
+        agreementId,
+        'AgreementTerminated',
+      );
+
+      expect(nftContractService.burnObligation).toHaveBeenCalledWith({
+        tokenId: 'token-123',
+        reason: 'AgreementTerminated',
+        ownerAddress: 'GOWNER',
+      });
+      expect(result.status).toBe('burned');
+      expect(result.isActive).toBe(false);
+      expect(result.burnTxHash).toBe('burn-tx-hash');
+    });
+
+    it('is a no-op when the NFT is already burned', async () => {
+      const agreementId = 'agreement-123';
+      const existingNft = {
+        id: 'nft-id',
+        agreementId,
+        tokenId: 'token-123',
+        currentOwner: 'GOWNER',
+        status: 'burned',
+        isActive: false,
+      } as unknown as RentObligationNft;
+
+      jest.spyOn(nftRepository, 'findOne').mockResolvedValue(existingNft);
+
+      const result = await service.burnNftForAgreement(
+        agreementId,
+        'AgreementTerminated',
+      );
+
+      expect(nftContractService.burnObligation).not.toHaveBeenCalled();
+      expect(result.status).toBe('burned');
+    });
+
+    it('throws when NFT is not found', async () => {
+      jest.spyOn(nftRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.burnNftForAgreement('missing-agreement', 'AgreementTerminated'),
+      ).rejects.toThrow('NFT not found for agreement missing-agreement');
+    });
+  });
+
+  describe('adminReassignNft', () => {
+    it('reassigns the obligation to a new owner', async () => {
+      const agreementId = 'agreement-123';
+      const newOwnerAddress = 'GNEWOWNER';
+      const adminAddress = 'GADMIN';
+      const existingNft = {
+        id: 'nft-id',
+        agreementId,
+        currentOwner: 'GOLDOWNER',
+        transferCount: 0,
+      } as unknown as RentObligationNft;
+
+      jest.spyOn(nftRepository, 'findOne').mockResolvedValue(existingNft);
+      jest
+        .spyOn(nftContractService, 'adminReassignObligation')
+        .mockResolvedValue({ txHash: 'reassign-tx-hash' });
+      jest
+        .spyOn(nftRepository, 'save')
+        .mockImplementation((n) => Promise.resolve(n as RentObligationNft));
+
+      const result = await service.adminReassignNft(
+        agreementId,
+        newOwnerAddress,
+        adminAddress,
+      );
+
+      expect(nftContractService.adminReassignObligation).toHaveBeenCalledWith({
+        agreementId,
+        newOwnerAddress,
+        adminAddress,
+      });
+      expect(result.currentOwner).toBe(newOwnerAddress);
+      expect(result.transferCount).toBe(1);
+    });
+
+    it('throws when NFT is not found', async () => {
+      jest.spyOn(nftRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.adminReassignNft('missing-agreement', 'GNEW', 'GADMIN'),
+      ).rejects.toThrow('NFT not found for agreement missing-agreement');
     });
   });
 });

--- a/backend/src/modules/agreements/agreement-nft.service.ts
+++ b/backend/src/modules/agreements/agreement-nft.service.ts
@@ -86,6 +86,71 @@ export class AgreementNftService {
     return nft;
   }
 
+  async burnNftForAgreement(
+    agreementId: string,
+    reason: string,
+  ): Promise<RentObligationNft> {
+    const nft = await this.nftRepository.findOne({ where: { agreementId } });
+
+    if (!nft) {
+      throw new Error(`NFT not found for agreement ${agreementId}`);
+    }
+
+    if (nft.status === 'burned') {
+      return nft;
+    }
+
+    const { txHash } = await this.nftContractService.burnObligation({
+      tokenId: nft.tokenId,
+      reason,
+      ownerAddress: nft.currentOwner,
+    });
+
+    nft.status = 'burned';
+    nft.isActive = false;
+    nft.burnTxHash = txHash;
+    nft.burnedAt = new Date();
+
+    await this.nftRepository.save(nft);
+
+    this.logger.log(
+      `NFT burned for agreement ${agreementId} (reason: ${reason}): ${txHash}`,
+    );
+
+    return nft;
+  }
+
+  async adminReassignNft(
+    agreementId: string,
+    newOwnerAddress: string,
+    adminAddress: string,
+  ): Promise<RentObligationNft> {
+    const nft = await this.nftRepository.findOne({ where: { agreementId } });
+
+    if (!nft) {
+      throw new Error(`NFT not found for agreement ${agreementId}`);
+    }
+
+    const { txHash } = await this.nftContractService.adminReassignObligation({
+      agreementId,
+      newOwnerAddress,
+      adminAddress,
+    });
+
+    nft.currentOwner = newOwnerAddress;
+    nft.lastTransferTxHash = txHash;
+    nft.lastTransferredAt = new Date();
+    nft.transferCount += 1;
+
+    await this.nftRepository.save(nft);
+
+    this.logger.log(
+      `NFT admin-reassigned for agreement ${agreementId} to ${newOwnerAddress}: ${txHash}`,
+    );
+
+    return nft;
+  }
+
   async syncNftOwnership(agreementId: string): Promise<void> {
     const nft = await this.nftRepository.findOne({ where: { agreementId } });
 

--- a/backend/src/modules/agreements/agreements.service.spec.ts
+++ b/backend/src/modules/agreements/agreements.service.spec.ts
@@ -11,6 +11,7 @@ import { Payment } from '../rent/entities/payment.entity';
 import { AuditService } from '../audit/audit.service';
 import { ReviewPromptService } from '../reviews/review-prompt.service';
 import { ChiomaContractService } from '../stellar/services/chioma-contract.service';
+import { AgreementNftService } from './agreement-nft.service';
 import { BlockchainSyncService } from './blockchain-sync.service';
 import { EscrowIntegrationService } from './escrow-integration.service';
 import { TemplateRenderingService } from './template-rendering.service';
@@ -85,6 +86,10 @@ describe('AgreementsService (lease extensions)', () => {
     find: jest.fn(),
   };
 
+  const mockAgreementNftService = {
+    burnNftForAgreement: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     mockIdempotencyService = {
@@ -111,6 +116,7 @@ describe('AgreementsService (lease extensions)', () => {
         { provide: AuditService, useValue: {} },
         { provide: ReviewPromptService, useValue: {} },
         { provide: ChiomaContractService, useValue: {} },
+        { provide: AgreementNftService, useValue: mockAgreementNftService },
         { provide: BlockchainSyncService, useValue: {} },
         { provide: EscrowIntegrationService, useValue: {} },
         { provide: TemplateRenderingService, useValue: { render: jest.fn() } },
@@ -251,6 +257,43 @@ describe('AgreementsService (lease extensions)', () => {
 
       expect(second).toEqual(first);
       expect(mockAgreementRepo.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('terminate', () => {
+    it('transitions the agreement to TERMINATED and burns the NFT obligation', async () => {
+      mockAgreementRepo.findOne.mockResolvedValue({
+        ...baseAgreement,
+        status: AgreementStatus.ACTIVE,
+      });
+      mockAgreementRepo.save.mockImplementation((a) => Promise.resolve(a));
+
+      const result = await service.terminate('agr-1', {
+        terminationReason: 'Mutual agreement',
+      });
+
+      expect(result.status).toBe(AgreementStatus.TERMINATED);
+      expect(mockAgreementNftService.burnNftForAgreement).toHaveBeenCalledWith(
+        'agr-1',
+        'AgreementTerminated',
+      );
+    });
+
+    it('still returns the terminated agreement when burning the NFT fails', async () => {
+      mockAgreementRepo.findOne.mockResolvedValue({
+        ...baseAgreement,
+        status: AgreementStatus.ACTIVE,
+      });
+      mockAgreementRepo.save.mockImplementation((a) => Promise.resolve(a));
+      mockAgreementNftService.burnNftForAgreement.mockRejectedValueOnce(
+        new Error('NFT not found for agreement agr-1'),
+      );
+
+      const result = await service.terminate('agr-1', {
+        terminationReason: 'Mutual agreement',
+      });
+
+      expect(result.status).toBe(AgreementStatus.TERMINATED);
     });
   });
 });

--- a/backend/src/modules/agreements/agreements.service.ts
+++ b/backend/src/modules/agreements/agreements.service.ts
@@ -21,6 +21,7 @@ import { SignAgreementDto } from './dto/sign-agreement.dto';
 import { AuditService } from '../audit/audit.service';
 import { ReviewPromptService } from '../reviews/review-prompt.service';
 import { ChiomaContractService } from '../stellar/services/chioma-contract.service';
+import { AgreementNftService } from './agreement-nft.service';
 import { BlockchainSyncService } from './blockchain-sync.service';
 import { EscrowIntegrationService } from './escrow-integration.service';
 import { TemplateRenderingService } from './template-rendering.service';
@@ -46,6 +47,7 @@ export class AgreementsService {
     private readonly auditService: AuditService,
     private readonly reviewPromptService: ReviewPromptService,
     private readonly chiomaContract: ChiomaContractService,
+    private readonly agreementNftService: AgreementNftService,
     private readonly blockchainSync: BlockchainSyncService,
     private readonly escrowIntegration: EscrowIntegrationService,
     private readonly templateService: TemplateRenderingService,
@@ -338,6 +340,19 @@ export class AgreementsService {
         'Agreement terminated',
       ),
     );
+
+    try {
+      await this.agreementNftService.burnNftForAgreement(
+        id,
+        'AgreementTerminated',
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to burn NFT obligation for terminated agreement ${id}`,
+        error,
+      );
+    }
+
     return saved;
   }
 

--- a/backend/src/modules/agreements/dto/nft.dto.ts
+++ b/backend/src/modules/agreements/dto/nft.dto.ts
@@ -1,4 +1,5 @@
 import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class MintNftDto {
   @IsString()
@@ -22,4 +23,49 @@ export class TransferNftDto {
   @IsString()
   @IsNotEmpty()
   toAddress: string;
+}
+
+export class BurnNftDto {
+  @ApiProperty({
+    description: 'Agreement whose NFT obligation should be burned',
+    example: 'agreement-123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  agreementId: string;
+
+  @ApiProperty({
+    description:
+      'Reason for burning, must match contract-accepted values (e.g. AgreementTerminated, LeaseCompleted, DisputeResolved, UserRequested)',
+    example: 'AgreementTerminated',
+  })
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}
+
+export class AdminReassignObligationDto {
+  @ApiProperty({
+    description: 'Agreement whose NFT obligation should be reassigned',
+    example: 'agreement-123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  agreementId: string;
+
+  @ApiProperty({
+    description: 'Stellar address of the new obligation owner',
+    example: 'GABCD...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  newOwnerAddress: string;
+
+  @ApiProperty({
+    description: 'Stellar address of the admin performing the reassignment',
+    example: 'GADMIN...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  adminAddress: string;
 }

--- a/backend/src/modules/stellar/services/rent-obligation-nft.service.spec.ts
+++ b/backend/src/modules/stellar/services/rent-obligation-nft.service.spec.ts
@@ -1,0 +1,277 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { xdr, Address } from '@stellar/stellar-sdk';
+import { RentObligationNftService } from './rent-obligation-nft.service';
+
+const mockSendTransaction = jest.fn();
+const mockSimulateTransaction = jest.fn();
+const mockGetAccount = jest.fn();
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  const mockTx = { sign: jest.fn() };
+  return {
+    ...actual,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Api: {
+        ...actual.SorobanRpc.Api,
+        isSimulationError: jest.fn().mockReturnValue(false),
+        isSimulationSuccess: jest.fn().mockReturnValue(true),
+      },
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: (...args: unknown[]) => mockGetAccount(...args),
+        simulateTransaction: (...args: unknown[]) =>
+          mockSimulateTransaction(...args),
+        sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
+      })),
+      assembleTransaction: jest.fn().mockReturnValue({
+        build: jest.fn().mockReturnValue(mockTx),
+      }),
+    },
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue('mock-operation'),
+    })),
+    Keypair: {
+      fromSecret: jest.fn().mockReturnValue({ publicKey: () => 'GADMIN' }),
+    },
+    Account: jest.fn().mockImplementation(() => ({})),
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue(mockTx),
+    })),
+  };
+});
+
+const OWNER_ADDRESS =
+  'GDBVWDMYONNID3S2Q7DNSYFNW2EX7UQBBJDQSZH3OHH2WAQKY74JJWXE';
+const ADMIN_ADDRESS =
+  'GC4NLUIPQ3QDBC7HLCFWY47WQJNPHXGRFBW5GK7ADSRXVLSSUZ5TUQOZ';
+const NEW_OWNER_ADDRESS =
+  'GA7JCDMFINQJ53T5QPM4GQN7EW3JZEKMOAKMC2Z6EYW77YP47TJNCTOU';
+
+describe('RentObligationNftService', () => {
+  let service: RentObligationNftService;
+
+  const mockConfigService = {
+    get: jest.fn((key: string, defaultValue?: unknown) => {
+      if (key === 'SOROBAN_RPC_URL') return 'http://localhost';
+      if (key === 'RENT_OBLIGATION_CONTRACT_ID') return 'C_MOCK_CONTRACT_ID';
+      if (key === 'STELLAR_ADMIN_SECRET_KEY') return 'SADMIN_SECRET';
+      if (key === 'STELLAR_NETWORK') return defaultValue ?? 'testnet';
+      return null;
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        RentObligationNftService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(RentObligationNftService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('burnObligation', () => {
+    it('builds and sends a burn transaction', async () => {
+      mockGetAccount.mockResolvedValue({ sequenceNumber: () => '1' });
+      mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+      mockSendTransaction.mockResolvedValue({ hash: 'burn-tx-hash' });
+
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationError',
+        )
+        .mockReturnValue(false);
+
+      const result = await service.burnObligation({
+        tokenId: 'token-123',
+        reason: 'AgreementTerminated',
+        ownerAddress: OWNER_ADDRESS,
+      });
+
+      expect(result.txHash).toBe('burn-tx-hash');
+      expect(mockSendTransaction).toHaveBeenCalled();
+    });
+
+    it('throws when the contract is not configured', async () => {
+      mockConfigService.get.mockImplementationOnce(() => '');
+      const unconfiguredModule = await Test.createTestingModule({
+        providers: [
+          RentObligationNftService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn(() => ''),
+            },
+          },
+        ],
+      }).compile();
+      const unconfiguredService = unconfiguredModule.get(
+        RentObligationNftService,
+      );
+
+      await expect(
+        unconfiguredService.burnObligation({
+          tokenId: 'token-123',
+          reason: 'AgreementTerminated',
+          ownerAddress: OWNER_ADDRESS,
+        }),
+      ).rejects.toThrow('Contract not configured');
+    });
+  });
+
+  describe('adminReassignObligation', () => {
+    it('builds and sends an admin reassign transaction', async () => {
+      mockGetAccount.mockResolvedValue({ sequenceNumber: () => '1' });
+      mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+      mockSendTransaction.mockResolvedValue({ hash: 'reassign-tx-hash' });
+
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationError',
+        )
+        .mockReturnValue(false);
+
+      const result = await service.adminReassignObligation({
+        agreementId: 'agreement-123',
+        newOwnerAddress: NEW_OWNER_ADDRESS,
+        adminAddress: ADMIN_ADDRESS,
+      });
+
+      expect(result.txHash).toBe('reassign-tx-hash');
+      expect(mockSendTransaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('canBurn', () => {
+    it('returns true when the contract reports the token is burnable', async () => {
+      mockSimulateTransaction.mockResolvedValue({
+        result: { retval: xdr.ScVal.scvBool(true) },
+      });
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationSuccess',
+        )
+        .mockReturnValue(true);
+
+      const result = await service.canBurn('token-123');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false on simulation failure', async () => {
+      mockSimulateTransaction.mockResolvedValue({ result: undefined });
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationSuccess',
+        )
+        .mockReturnValue(false);
+
+      const result = await service.canBurn('token-123');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getBurnRecord', () => {
+    it('parses a burn record map into BurnRecordData', async () => {
+      const retval = xdr.ScVal.scvMap([
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvString('token_id'),
+          val: xdr.ScVal.scvString('token-123'),
+        }),
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvString('burned_by'),
+          val: new Address(OWNER_ADDRESS).toScVal(),
+        }),
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvString('burned_at'),
+          val: xdr.ScVal.scvU64(new xdr.Uint64(1700000000)),
+        }),
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvString('reason'),
+          val: xdr.ScVal.scvString('AgreementTerminated'),
+        }),
+      ]);
+
+      mockSimulateTransaction.mockResolvedValue({ result: { retval } });
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationSuccess',
+        )
+        .mockReturnValue(true);
+
+      const result = await service.getBurnRecord('token-123');
+
+      expect(result).toEqual({
+        tokenId: 'token-123',
+        burnedBy: OWNER_ADDRESS,
+        burnedAt: 1700000000,
+        reason: 'AgreementTerminated',
+      });
+    });
+
+    it('returns null when simulation does not succeed', async () => {
+      mockSimulateTransaction.mockResolvedValue({ result: undefined });
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationSuccess',
+        )
+        .mockReturnValue(false);
+
+      const result = await service.getBurnRecord('token-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getBurnedNfts', () => {
+    it('returns the list of burned token ids for an owner', async () => {
+      const retval = xdr.ScVal.scvVec([
+        xdr.ScVal.scvString('token-1'),
+        xdr.ScVal.scvString('token-2'),
+      ]);
+
+      mockSimulateTransaction.mockResolvedValue({ result: { retval } });
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationSuccess',
+        )
+        .mockReturnValue(true);
+
+      const result = await service.getBurnedNfts(OWNER_ADDRESS);
+
+      expect(result).toEqual(['token-1', 'token-2']);
+    });
+
+    it('returns an empty array when simulation fails', async () => {
+      mockSimulateTransaction.mockResolvedValue({ result: undefined });
+      jest
+        .spyOn(
+          require('@stellar/stellar-sdk').SorobanRpc.Api,
+          'isSimulationSuccess',
+        )
+        .mockReturnValue(false);
+
+      const result = await service.getBurnedNfts(OWNER_ADDRESS);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/backend/src/modules/stellar/services/rent-obligation-nft.service.ts
+++ b/backend/src/modules/stellar/services/rent-obligation-nft.service.ts
@@ -20,6 +20,25 @@ export interface RentObligationData {
   mintedAt: number;
 }
 
+export interface BurnObligationParams {
+  tokenId: string;
+  reason: string;
+  ownerAddress: string;
+}
+
+export interface AdminReassignObligationParams {
+  agreementId: string;
+  newOwnerAddress: string;
+  adminAddress: string;
+}
+
+export interface BurnRecordData {
+  tokenId: string;
+  burnedBy: string;
+  burnedAt: number;
+  reason: string;
+}
+
 @Injectable()
 export class RentObligationNftService {
   private readonly logger = new Logger(RentObligationNftService.name);
@@ -288,6 +307,178 @@ export class RentObligationNftService {
     }
   }
 
+  async burnObligation(
+    params: BurnObligationParams,
+  ): Promise<{ txHash: string }> {
+    try {
+      if (!this.isConfigured || !this.contract) {
+        throw new Error('Contract not configured');
+      }
+      const tokenIdScVal = xdr.ScVal.scvString(params.tokenId);
+      const reasonScVal = xdr.ScVal.scvString(params.reason);
+
+      const tx = await this.buildTransaction(
+        'burn_nft',
+        [tokenIdScVal, reasonScVal],
+        params.ownerAddress,
+      );
+
+      const response = await this.server.sendTransaction(tx);
+
+      this.logger.log(
+        `Burned rent obligation NFT ${params.tokenId} (reason: ${params.reason})`,
+      );
+
+      return { txHash: response.hash };
+    } catch (error) {
+      this.logger.error(`Failed to burn obligation ${params.tokenId}`, error);
+      throw error;
+    }
+  }
+
+  async adminReassignObligation(
+    params: AdminReassignObligationParams,
+  ): Promise<{ txHash: string }> {
+    try {
+      if (!this.isConfigured || !this.contract) {
+        throw new Error('Contract not configured');
+      }
+      const adminAddress = new Address(params.adminAddress);
+      const newOwnerAddress = new Address(params.newOwnerAddress);
+      const agreementIdScVal = xdr.ScVal.scvString(params.agreementId);
+
+      const tx = await this.buildTransaction(
+        'admin_reassign_obligation',
+        [adminAddress.toScVal(), agreementIdScVal, newOwnerAddress.toScVal()],
+        params.adminAddress,
+      );
+
+      const response = await this.server.sendTransaction(tx);
+
+      this.logger.log(
+        `Admin reassigned obligation ${params.agreementId} to ${params.newOwnerAddress}`,
+      );
+
+      return { txHash: response.hash };
+    } catch (error) {
+      this.logger.error(
+        `Failed to admin-reassign obligation ${params.agreementId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  async canBurn(tokenId: string): Promise<boolean> {
+    try {
+      if (!this.isConfigured || !this.contract) {
+        return false;
+      }
+      const tokenIdScVal = xdr.ScVal.scvString(tokenId);
+      const result = this.contract.call('can_burn', tokenIdScVal);
+
+      const simulated = await this.server.simulateTransaction(
+        new StellarSdk.TransactionBuilder(
+          new StellarSdk.Account(
+            this.adminKeypair?.publicKey() ||
+              'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+            '0',
+          ),
+          { fee: '100', networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(result)
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (SorobanRpc.Api.isSimulationSuccess(simulated)) {
+        return simulated.result?.retval?.switch().name === 'scvBool'
+          ? simulated.result.retval.b()
+          : false;
+      }
+
+      return false;
+    } catch (error) {
+      this.logger.error(`Failed to check can_burn for ${tokenId}`, error);
+      return false;
+    }
+  }
+
+  async getBurnRecord(tokenId: string): Promise<BurnRecordData | null> {
+    try {
+      if (!this.isConfigured || !this.contract) {
+        return null;
+      }
+      const tokenIdScVal = xdr.ScVal.scvString(tokenId);
+      const result = this.contract.call('get_burn_record', tokenIdScVal);
+
+      const simulated = await this.server.simulateTransaction(
+        new StellarSdk.TransactionBuilder(
+          new StellarSdk.Account(
+            this.adminKeypair?.publicKey() ||
+              'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+            '0',
+          ),
+          { fee: '100', networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(result)
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (
+        SorobanRpc.Api.isSimulationSuccess(simulated) &&
+        simulated.result?.retval
+      ) {
+        return this.parseBurnRecord(simulated.result.retval);
+      }
+
+      return null;
+    } catch (error) {
+      this.logger.error(`Failed to get burn record for ${tokenId}`, error);
+      return null;
+    }
+  }
+
+  async getBurnedNfts(ownerAddress: string): Promise<string[]> {
+    try {
+      if (!this.isConfigured || !this.contract) {
+        return [];
+      }
+      const ownerScVal = new Address(ownerAddress).toScVal();
+      const result = this.contract.call('get_burned_nfts', ownerScVal);
+
+      const simulated = await this.server.simulateTransaction(
+        new StellarSdk.TransactionBuilder(
+          new StellarSdk.Account(
+            this.adminKeypair?.publicKey() ||
+              'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+            '0',
+          ),
+          { fee: '100', networkPassphrase: this.networkPassphrase },
+        )
+          .addOperation(result)
+          .setTimeout(30)
+          .build(),
+      );
+
+      if (
+        SorobanRpc.Api.isSimulationSuccess(simulated) &&
+        simulated.result?.retval?.switch().name === 'scvVec'
+      ) {
+        const vec = simulated.result.retval.vec() || [];
+        return vec
+          .filter((entry) => entry.switch().name === 'scvString')
+          .map((entry) => entry.str().toString());
+      }
+
+      return [];
+    } catch (error) {
+      this.logger.error(`Failed to get burned nfts for ${ownerAddress}`, error);
+      return [];
+    }
+  }
+
   private async buildTransaction(
     method: string,
     params: xdr.ScVal[],
@@ -354,6 +545,52 @@ export class RentObligationNftService {
       return data as RentObligationData;
     } catch (error) {
       this.logger.error('Failed to parse obligation data', error);
+      return null;
+    }
+  }
+
+  private parseBurnRecord(scVal: xdr.ScVal): BurnRecordData | null {
+    try {
+      const map = scVal.map();
+      if (!map) return null;
+
+      const data: Partial<BurnRecordData> = {};
+
+      map.forEach((entry) => {
+        const key = entry.key();
+        const val = entry.val();
+
+        if (key.switch().name !== 'scvString') {
+          return;
+        }
+
+        const keyStr = key.str().toString();
+
+        switch (keyStr) {
+          case 'token_id':
+            if (val.switch().name === 'scvString') {
+              data.tokenId = val.str().toString();
+            }
+            break;
+          case 'burned_by':
+            data.burnedBy = Address.fromScVal(val).toString();
+            break;
+          case 'burned_at':
+            if (val.switch().name === 'scvU64') {
+              data.burnedAt = Number(val.u64());
+            }
+            break;
+          case 'reason':
+            if (val.switch().name === 'scvString') {
+              data.reason = val.str().toString();
+            }
+            break;
+        }
+      });
+
+      return data as BurnRecordData;
+    } catch (error) {
+      this.logger.error('Failed to parse burn record', error);
       return null;
     }
   }


### PR DESCRIPTION
# Wrap rent_obligation burn/admin-reassign contract calls

## Summary
- Adds `burnObligation`, `canBurn`, `getBurnRecord`, `getBurnedNfts`, and `adminReassignObligation` to `RentObligationNftService`, wrapping the previously orphaned Soroban contract calls.
- Extends `AgreementNftService` with `burnNftForAgreement` and `adminReassignNft`, keeping the `RentObligationNft` entity's status/tx-hash/ownership fields in sync with on-chain state.
- Exposes `POST agreements/nfts/burn` and `POST agreements/nfts/admin-reassign`, both admin-only (`JwtAuthGuard` + `RolesGuard`, `ADMIN`/`SUPER_ADMIN`).
- Wires `AgreementsService.terminate()` to burn the associated NFT obligation (reason `AgreementTerminated`) after the status transition; burn failures are logged but don't block termination.

## Test plan
- [x] `npx jest rent-obligation-nft.service.spec.ts agreement-nft.service.spec.ts agreements.service.spec.ts` — all passing (new service spec + updated specs)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx prettier --check` on changed files — clean
- [x] `npm run check:api-docs` — passing (62 controllers)
- [x] `npm run build` — clean
- [x] Full backend unit suite (`npx jest --testPathIgnorePatterns=e2e`) — 218 suites / 2537 tests passing, no regressions

Closes #1769

