### PR TITLE
Feature/1768 saved search alerts

### DIFF
--- a/backend/src/migrations/1930200000000-CreateSavedSearchesTable.ts
+++ b/backend/src/migrations/1930200000000-CreateSavedSearchesTable.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSavedSearchesTable1930200000000 implements MigrationInterface {
+  name = 'CreateSavedSearchesTable1930200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "saved_searches" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "user_id" uuid NOT NULL,
+        "name" character varying(150) NOT NULL,
+        "filters" jsonb NOT NULL,
+        "alerts_enabled" boolean NOT NULL DEFAULT true,
+        "last_notified_at" TIMESTAMP,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_saved_searches_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_saved_searches_user_id" FOREIGN KEY ("user_id")
+          REFERENCES "users" ("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_saved_searches_user_id"
+        ON "saved_searches" ("user_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "saved_searches"`);
+  }
+}

--- a/backend/src/modules/properties/__tests__/properties.pagination.spec.ts
+++ b/backend/src/modules/properties/__tests__/properties.pagination.spec.ts
@@ -14,6 +14,7 @@ import { RentalUnit } from '../entities/rental-unit.entity';
 import { PropertyListingDraft } from '../entities/property-listing-draft.entity';
 import { CacheService } from '../../../common/cache/cache.service';
 import { FraudHooksService } from '../../fraud/fraud-hooks.service';
+import { SavedSearchService } from '../../search/saved-search.service';
 import { User } from '../../users/entities/user.entity';
 
 describe('PropertiesService – Pagination', () => {
@@ -134,6 +135,10 @@ describe('PropertiesService – Pagination', () => {
     onListingPublished: jest.fn().mockResolvedValue(undefined),
   };
 
+  const mockSavedSearchService = {
+    notifyMatchingSearches: jest.fn().mockResolvedValue(0),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -171,6 +176,7 @@ describe('PropertiesService – Pagination', () => {
         },
         { provide: CacheService, useValue: mockCacheService },
         { provide: FraudHooksService, useValue: mockFraudHooksService },
+        { provide: SavedSearchService, useValue: mockSavedSearchService },
       ],
     }).compile();
 

--- a/backend/src/modules/properties/properties.module.ts
+++ b/backend/src/modules/properties/properties.module.ts
@@ -18,11 +18,13 @@ import { PropertyAvailability } from './entities/property-availability.entity';
 import { AvailabilityService } from './availability.service';
 import { AvailabilityController } from './availability.controller';
 import { FraudModule } from '../fraud/fraud.module';
+import { SearchModule } from '../search/search.module';
 
 @Module({
   imports: [
     ScheduleModule,
     FraudModule,
+    SearchModule,
     TypeOrmModule.forFeature([
       Property,
       PropertyImage,

--- a/backend/src/modules/properties/properties.service.spec.ts
+++ b/backend/src/modules/properties/properties.service.spec.ts
@@ -21,6 +21,7 @@ import { PropertyListingDraft } from './entities/property-listing-draft.entity';
 import { User, UserRole, AuthMethod } from '../users/entities/user.entity';
 import { KycStatus } from '../kyc/kyc-status.enum';
 import { FraudHooksService } from '../fraud/fraud-hooks.service';
+import { SavedSearchService } from '../search/saved-search.service';
 
 describe('PropertiesService', () => {
   let service: PropertiesService;
@@ -192,6 +193,10 @@ describe('PropertiesService', () => {
     onListingPublished: jest.fn().mockResolvedValue(undefined),
   };
 
+  const mockSavedSearchService = {
+    notifyMatchingSearches: jest.fn().mockResolvedValue(0),
+  };
+
   beforeEach(async () => {
     mockCacheService.getOrSet.mockImplementation(
       async (_key: string, factory: () => Promise<unknown>) => factory(),
@@ -230,6 +235,10 @@ describe('PropertiesService', () => {
         {
           provide: FraudHooksService,
           useValue: mockFraudHooksService,
+        },
+        {
+          provide: SavedSearchService,
+          useValue: mockSavedSearchService,
         },
       ],
     }).compile();
@@ -628,6 +637,9 @@ describe('PropertiesService', () => {
       expect(mockFraudHooksService.onListingPublished).toHaveBeenCalledWith(
         'property-id',
       );
+      expect(
+        mockSavedSearchService.notifyMatchingSearches,
+      ).toHaveBeenCalledWith(publishedProperty);
     });
 
     it('should throw BadRequestException if already published', async () => {

--- a/backend/src/modules/properties/properties.service.ts
+++ b/backend/src/modules/properties/properties.service.ts
@@ -24,6 +24,7 @@ import {
   TTL_PUBLIC_PROPERTY_LIST_MS,
 } from '../../common/cache/cache.constants';
 import { FraudHooksService } from '../fraud/fraud-hooks.service';
+import { SavedSearchService } from '../search/saved-search.service';
 import {
   PropertyNotFoundError,
   AuthorizationError,
@@ -46,6 +47,7 @@ export class PropertiesService {
     private readonly propertyListingDraftRepository: Repository<PropertyListingDraft>,
     private readonly cacheService: CacheService,
     private readonly fraudHooksService: FraudHooksService,
+    private readonly savedSearchService: SavedSearchService,
   ) {}
 
   private generateCacheKey(query: QueryPropertyDto): string {
@@ -305,6 +307,7 @@ export class PropertiesService {
     const saved = await this.propertyRepository.save(property);
     await this.cacheService.invalidatePropertyDomainCaches(id);
     void this.fraudHooksService.onListingPublished(saved.id);
+    void this.savedSearchService.notifyMatchingSearches(saved);
     return saved;
   }
 

--- a/backend/src/modules/search/dto/index.ts
+++ b/backend/src/modules/search/dto/index.ts
@@ -2,3 +2,4 @@ export * from './search-properties.dto';
 export * from './search-users.dto';
 export * from './search-documents.dto';
 export * from './suggest.dto';
+export * from './saved-search.dto';

--- a/backend/src/modules/search/dto/saved-search.dto.ts
+++ b/backend/src/modules/search/dto/saved-search.dto.ts
@@ -1,0 +1,76 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { SearchPropertiesDto } from './search-properties.dto';
+
+export class CreateSavedSearchDto {
+  @ApiProperty({
+    description: 'Display name for the saved search',
+    example: 'Furnished 2-bed in Lekki under $1500',
+    minLength: 1,
+    maxLength: 150,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(150)
+  name: string;
+
+  @ApiProperty({
+    description: 'Filter set to persist and re-run against new listings',
+    type: () => SearchPropertiesDto,
+  })
+  @ValidateNested()
+  @Type(() => SearchPropertiesDto)
+  filters: SearchPropertiesDto;
+
+  @ApiPropertyOptional({
+    description: 'Whether to notify the owner when a new listing matches',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  alertsEnabled?: boolean;
+}
+
+export class SavedSearchDto {
+  @ApiProperty({ description: 'Saved search ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Display name' })
+  name: string;
+
+  @ApiProperty({
+    description: 'Persisted filter set',
+    type: () => SearchPropertiesDto,
+  })
+  filters: SearchPropertiesDto;
+
+  @ApiProperty({ description: 'Whether match notifications are enabled' })
+  alertsEnabled: boolean;
+
+  @ApiProperty({
+    description: 'When a matching listing was last notified',
+    nullable: true,
+  })
+  lastNotifiedAt: string | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: string;
+}
+
+export class SavedSearchIdParamDto {
+  @ApiProperty({ description: 'Saved search ID' })
+  @IsUUID()
+  id: string;
+}

--- a/backend/src/modules/search/entities/saved-search.entity.ts
+++ b/backend/src/modules/search/entities/saved-search.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { SearchFilters } from '../search.service';
+
+@Entity('saved_searches')
+@Index('idx_saved_searches_user_id', ['userId'])
+export class SavedSearch {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'varchar', length: 150 })
+  name: string;
+
+  @Column({ type: 'jsonb' })
+  filters: SearchFilters;
+
+  @Column({ type: 'boolean', default: true })
+  alertsEnabled: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastNotifiedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: false })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+}

--- a/backend/src/modules/search/saved-search-cron.service.spec.ts
+++ b/backend/src/modules/search/saved-search-cron.service.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SavedSearchCronService } from './saved-search-cron.service';
+import { SavedSearchService } from './saved-search.service';
+
+describe('SavedSearchCronService', () => {
+  let service: SavedSearchCronService;
+  let savedSearchService: SavedSearchService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SavedSearchCronService,
+        {
+          provide: SavedSearchService,
+          useValue: {
+            notifyForRecentListings: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SavedSearchCronService);
+    savedSearchService = module.get(SavedSearchService);
+  });
+
+  it('sweeps recently published listings on a 15 minute lookback', async () => {
+    jest
+      .spyOn(savedSearchService, 'notifyForRecentListings')
+      .mockResolvedValue(3);
+
+    await service.sweepRecentListings();
+
+    expect(savedSearchService.notifyForRecentListings).toHaveBeenCalledWith(15);
+  });
+});

--- a/backend/src/modules/search/saved-search-cron.service.ts
+++ b/backend/src/modules/search/saved-search-cron.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { SavedSearchService } from './saved-search.service';
+
+/** Safety-net window covering the gap between two runs of this cron. */
+const LOOKBACK_MINUTES = 15;
+
+@Injectable()
+export class SavedSearchCronService {
+  private readonly logger = new Logger(SavedSearchCronService.name);
+
+  constructor(private readonly savedSearchService: SavedSearchService) {}
+
+  /**
+   * Catches saved-search matches for listings published outside the
+   * publish-time hook (e.g. a transient failure, direct DB writes, imports).
+   */
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async sweepRecentListings(): Promise<void> {
+    const notified =
+      await this.savedSearchService.notifyForRecentListings(LOOKBACK_MINUTES);
+    if (notified > 0) {
+      this.logger.log(`Saved search sweep sent ${notified} notification(s)`);
+    }
+  }
+}

--- a/backend/src/modules/search/saved-search.controller.ts
+++ b/backend/src/modules/search/saved-search.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+import { SavedSearchService } from './saved-search.service';
+import { CreateSavedSearchDto, SavedSearchDto } from './dto/saved-search.dto';
+
+@ApiTags('Saved Searches')
+@Controller('search/saved-searches')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth('JWT-auth')
+export class SavedSearchController {
+  constructor(private readonly savedSearchService: SavedSearchService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "List the current user's saved searches" })
+  @ApiResponse({
+    status: 200,
+    description: 'Retrieved',
+    type: [SavedSearchDto],
+  })
+  async findAll(@CurrentUser() user: User): Promise<SavedSearchDto[]> {
+    return this.savedSearchService.findAllForUser(user.id);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Save a named filter set with optional alerts' })
+  @ApiResponse({ status: 201, description: 'Created', type: SavedSearchDto })
+  async create(
+    @CurrentUser() user: User,
+    @Body() dto: CreateSavedSearchDto,
+  ): Promise<SavedSearchDto> {
+    return this.savedSearchService.create(user.id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a saved search' })
+  @ApiResponse({ status: 204, description: 'Deleted' })
+  @ApiResponse({ status: 404, description: 'Saved search not found' })
+  async remove(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.savedSearchService.remove(user.id, id);
+  }
+}

--- a/backend/src/modules/search/saved-search.service.spec.ts
+++ b/backend/src/modules/search/saved-search.service.spec.ts
@@ -1,0 +1,282 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import {
+  SavedSearchService,
+  propertyMatchesFilters,
+} from './saved-search.service';
+import { SavedSearch } from './entities/saved-search.entity';
+import {
+  Property,
+  PropertyType,
+  ListingStatus,
+} from '../properties/entities/property.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+
+describe('propertyMatchesFilters', () => {
+  const baseProperty: Property = {
+    id: 'prop-1',
+    title: 'Sunny 2-bed apartment',
+    address: '12 Palm Ave',
+    city: 'Lekki',
+    state: 'Lagos',
+    country: 'NG',
+    type: PropertyType.APARTMENT,
+    status: ListingStatus.PUBLISHED,
+    price: 1200,
+    bedrooms: 2,
+    bathrooms: 2,
+    isFurnished: true,
+    hasParking: true,
+    petsAllowed: false,
+    amenities: [{ name: 'Gym' } as any, { name: 'Pool' } as any],
+  } as any;
+
+  it('matches when all filters are satisfied', () => {
+    expect(
+      propertyMatchesFilters(baseProperty, {
+        city: 'lekki',
+        minPrice: 1000,
+        maxPrice: 1500,
+        bedrooms: 2,
+        isFurnished: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects when price is above maxPrice', () => {
+    expect(propertyMatchesFilters(baseProperty, { maxPrice: 1000 })).toBe(
+      false,
+    );
+  });
+
+  it('rejects when bedrooms is below the requested minimum', () => {
+    expect(propertyMatchesFilters(baseProperty, { bedrooms: 3 })).toBe(false);
+  });
+
+  it('rejects a non-published property by default', () => {
+    const draft = { ...baseProperty, status: ListingStatus.DRAFT };
+    expect(propertyMatchesFilters(draft, {})).toBe(false);
+  });
+
+  it('rejects when a required amenity is missing', () => {
+    expect(propertyMatchesFilters(baseProperty, { amenities: ['Sauna'] })).toBe(
+      false,
+    );
+  });
+
+  it('matches when all required amenities are present', () => {
+    expect(
+      propertyMatchesFilters(baseProperty, { amenities: ['gym', 'pool'] }),
+    ).toBe(true);
+  });
+
+  it('rejects when petsAllowed does not match', () => {
+    expect(propertyMatchesFilters(baseProperty, { petsAllowed: true })).toBe(
+      false,
+    );
+  });
+});
+
+describe('SavedSearchService', () => {
+  let service: SavedSearchService;
+  let savedSearchRepository: Repository<SavedSearch>;
+  let propertyRepository: Repository<Property>;
+  let notificationsService: NotificationsService;
+
+  const mockUserId = 'user-123';
+
+  const mockSavedSearch: SavedSearch = {
+    id: 'saved-1',
+    userId: mockUserId,
+    name: 'My search',
+    filters: { city: 'Lekki' },
+    alertsEnabled: true,
+    lastNotifiedAt: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  } as any;
+
+  const mockProperty: Property = {
+    id: 'prop-1',
+    title: 'Sunny 2-bed apartment',
+    address: '12 Palm Ave',
+    city: 'Lekki',
+    type: PropertyType.APARTMENT,
+    status: ListingStatus.PUBLISHED,
+    price: 1200,
+    amenities: [],
+  } as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SavedSearchService,
+        {
+          provide: getRepositoryToken(SavedSearch),
+          useValue: {
+            find: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Property),
+          useValue: {
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: {
+            notify: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SavedSearchService>(SavedSearchService);
+    savedSearchRepository = module.get(getRepositoryToken(SavedSearch));
+    propertyRepository = module.get(getRepositoryToken(Property));
+    notificationsService = module.get(NotificationsService);
+  });
+
+  describe('create', () => {
+    it('persists a new saved search for the user', async () => {
+      jest
+        .spyOn(savedSearchRepository, 'create')
+        .mockReturnValue(mockSavedSearch);
+      jest
+        .spyOn(savedSearchRepository, 'save')
+        .mockResolvedValue(mockSavedSearch);
+
+      const result = await service.create(mockUserId, {
+        name: 'My search',
+        filters: { city: 'Lekki' } as any,
+      });
+
+      expect(result.name).toBe('My search');
+      expect(savedSearchRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: mockUserId,
+          name: 'My search',
+          alertsEnabled: true,
+        }),
+      );
+    });
+  });
+
+  describe('findAllForUser', () => {
+    it('returns saved searches for the user ordered by creation date', async () => {
+      jest
+        .spyOn(savedSearchRepository, 'find')
+        .mockResolvedValue([mockSavedSearch]);
+
+      const result = await service.findAllForUser(mockUserId);
+
+      expect(result).toHaveLength(1);
+      expect(savedSearchRepository.find).toHaveBeenCalledWith({
+        where: { userId: mockUserId },
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes a saved search owned by the user', async () => {
+      jest
+        .spyOn(savedSearchRepository, 'delete')
+        .mockResolvedValue({ affected: 1 } as any);
+
+      await service.remove(mockUserId, 'saved-1');
+
+      expect(savedSearchRepository.delete).toHaveBeenCalledWith({
+        id: 'saved-1',
+        userId: mockUserId,
+      });
+    });
+
+    it('throws when the saved search does not exist for the user', async () => {
+      jest
+        .spyOn(savedSearchRepository, 'delete')
+        .mockResolvedValue({ affected: 0 } as any);
+
+      await expect(service.remove(mockUserId, 'saved-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('notifyMatchingSearches', () => {
+    it('notifies owners of matching saved searches and stamps lastNotifiedAt', async () => {
+      jest
+        .spyOn(savedSearchRepository, 'find')
+        .mockResolvedValue([mockSavedSearch]);
+      jest
+        .spyOn(savedSearchRepository, 'save')
+        .mockResolvedValue(mockSavedSearch);
+
+      const matchCount = await service.notifyMatchingSearches(mockProperty);
+
+      expect(matchCount).toBe(1);
+      expect(notificationsService.notify).toHaveBeenCalledWith(
+        mockUserId,
+        expect.any(String),
+        expect.stringContaining(mockProperty.title),
+        'saved_search_match',
+      );
+      expect(savedSearchRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ lastNotifiedAt: expect.any(Date) }),
+      );
+    });
+
+    it('does not notify when no saved searches match', async () => {
+      const nonMatching = { ...mockSavedSearch, filters: { city: 'Ikeja' } };
+      jest
+        .spyOn(savedSearchRepository, 'find')
+        .mockResolvedValue([nonMatching as SavedSearch]);
+
+      const matchCount = await service.notifyMatchingSearches(mockProperty);
+
+      expect(matchCount).toBe(0);
+      expect(notificationsService.notify).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors so a failure never throws', async () => {
+      jest
+        .spyOn(savedSearchRepository, 'find')
+        .mockRejectedValue(new Error('db down'));
+
+      await expect(service.notifyMatchingSearches(mockProperty)).resolves.toBe(
+        0,
+      );
+    });
+  });
+
+  describe('notifyForRecentListings', () => {
+    it('sweeps recently published listings and notifies matches', async () => {
+      const qb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockProperty]),
+      };
+      jest.spyOn(propertyRepository, 'createQueryBuilder').mockReturnValue(qb);
+      jest
+        .spyOn(savedSearchRepository, 'find')
+        .mockResolvedValue([mockSavedSearch]);
+      jest
+        .spyOn(savedSearchRepository, 'save')
+        .mockResolvedValue(mockSavedSearch);
+
+      const notified = await service.notifyForRecentListings(15);
+
+      expect(notified).toBe(1);
+      expect(qb.where).toHaveBeenCalledWith('property.status = :status', {
+        status: ListingStatus.PUBLISHED,
+      });
+    });
+  });
+});

--- a/backend/src/modules/search/saved-search.service.ts
+++ b/backend/src/modules/search/saved-search.service.ts
@@ -1,0 +1,219 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SavedSearch } from './entities/saved-search.entity';
+import {
+  Property,
+  ListingStatus,
+} from '../properties/entities/property.entity';
+import { SearchFilters } from './search.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { CreateSavedSearchDto, SavedSearchDto } from './dto/saved-search.dto';
+
+function toDto(entity: SavedSearch): SavedSearchDto {
+  return {
+    id: entity.id,
+    name: entity.name,
+    filters: entity.filters,
+    alertsEnabled: entity.alertsEnabled,
+    lastNotifiedAt: entity.lastNotifiedAt
+      ? entity.lastNotifiedAt.toISOString()
+      : null,
+    createdAt: entity.createdAt.toISOString(),
+    updatedAt: entity.updatedAt.toISOString(),
+  };
+}
+
+/** Checks whether a single published property satisfies a saved filter set. */
+export function propertyMatchesFilters(
+  property: Property,
+  filters: SearchFilters,
+): boolean {
+  if (filters.query) {
+    const q = filters.query.toLowerCase();
+    const haystack =
+      `${property.title} ${property.address ?? ''} ${property.city ?? ''}`.toLowerCase();
+    if (!haystack.includes(q)) return false;
+  }
+  if (
+    filters.city &&
+    !property.city?.toLowerCase().includes(filters.city.toLowerCase())
+  ) {
+    return false;
+  }
+  if (
+    filters.state &&
+    !property.state?.toLowerCase().includes(filters.state.toLowerCase())
+  ) {
+    return false;
+  }
+  if (filters.country && property.country !== filters.country) {
+    return false;
+  }
+  if (filters.type && property.type !== filters.type) {
+    return false;
+  }
+  const status = filters.status ?? ListingStatus.PUBLISHED;
+  if (property.status !== status) {
+    return false;
+  }
+  if (
+    filters.minPrice !== undefined &&
+    Number(property.price) < filters.minPrice
+  ) {
+    return false;
+  }
+  if (
+    filters.maxPrice !== undefined &&
+    Number(property.price) > filters.maxPrice
+  ) {
+    return false;
+  }
+  if (
+    filters.bedrooms !== undefined &&
+    (property.bedrooms ?? 0) < filters.bedrooms
+  ) {
+    return false;
+  }
+  if (
+    filters.bathrooms !== undefined &&
+    (property.bathrooms ?? 0) < filters.bathrooms
+  ) {
+    return false;
+  }
+  if (
+    filters.isFurnished !== undefined &&
+    property.isFurnished !== filters.isFurnished
+  ) {
+    return false;
+  }
+  if (
+    filters.hasParking !== undefined &&
+    property.hasParking !== filters.hasParking
+  ) {
+    return false;
+  }
+  if (
+    filters.petsAllowed !== undefined &&
+    property.petsAllowed !== filters.petsAllowed
+  ) {
+    return false;
+  }
+  if (filters.amenities && filters.amenities.length > 0) {
+    const propertyAmenityNames = new Set(
+      (property.amenities ?? []).map((a) => a.name?.toLowerCase()),
+    );
+    const hasAll = filters.amenities.every((name) =>
+      propertyAmenityNames.has(name.toLowerCase()),
+    );
+    if (!hasAll) return false;
+  }
+
+  return true;
+}
+
+@Injectable()
+export class SavedSearchService {
+  private readonly logger = new Logger(SavedSearchService.name);
+
+  constructor(
+    @InjectRepository(SavedSearch)
+    private readonly savedSearchRepository: Repository<SavedSearch>,
+    @InjectRepository(Property)
+    private readonly propertyRepository: Repository<Property>,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  async create(
+    userId: string,
+    dto: CreateSavedSearchDto,
+  ): Promise<SavedSearchDto> {
+    const savedSearch = this.savedSearchRepository.create({
+      userId,
+      name: dto.name,
+      filters: dto.filters as SearchFilters,
+      alertsEnabled: dto.alertsEnabled ?? true,
+    });
+    const saved = await this.savedSearchRepository.save(savedSearch);
+    return toDto(saved);
+  }
+
+  async findAllForUser(userId: string): Promise<SavedSearchDto[]> {
+    const savedSearches = await this.savedSearchRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+    return savedSearches.map(toDto);
+  }
+
+  async remove(userId: string, id: string): Promise<void> {
+    const result = await this.savedSearchRepository.delete({ id, userId });
+    if (result.affected === 0) {
+      throw new NotFoundException(`Saved search ${id} not found`);
+    }
+  }
+
+  /**
+   * Finds saved searches matching a newly published property and notifies
+   * their owners. Never throws — failures are logged only so a listing
+   * publish never fails because of the alerting side-effect.
+   */
+  async notifyMatchingSearches(property: Property): Promise<number> {
+    try {
+      const candidates = await this.savedSearchRepository.find({
+        where: { alertsEnabled: true },
+      });
+
+      const matches = candidates.filter((saved) =>
+        propertyMatchesFilters(property, saved.filters),
+      );
+
+      for (const match of matches) {
+        await this.notifySavedSearchOwner(match, property);
+      }
+
+      return matches.length;
+    } catch (err) {
+      this.logger.warn(
+        `Saved search matching failed for property ${property.id} (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return 0;
+    }
+  }
+
+  /**
+   * Fallback sweep for any recently published listings that weren't caught
+   * by the publish-time hook (e.g. after a deploy or a transient failure).
+   */
+  async notifyForRecentListings(sinceMinutes: number): Promise<number> {
+    const since = new Date(Date.now() - sinceMinutes * 60_000);
+    const recentlyPublished = await this.propertyRepository
+      .createQueryBuilder('property')
+      .leftJoinAndSelect('property.amenities', 'amenities')
+      .where('property.status = :status', { status: ListingStatus.PUBLISHED })
+      .andWhere('property.updatedAt >= :since', { since })
+      .getMany();
+
+    let notified = 0;
+    for (const property of recentlyPublished) {
+      notified += await this.notifyMatchingSearches(property);
+    }
+    return notified;
+  }
+
+  private async notifySavedSearchOwner(
+    savedSearch: SavedSearch,
+    property: Property,
+  ): Promise<void> {
+    await this.notificationsService.notify(
+      savedSearch.userId,
+      'New listing matches your saved search',
+      `"${property.title}" matches your saved search "${savedSearch.name}".`,
+      'saved_search_match',
+    );
+    savedSearch.lastNotifiedAt = new Date();
+    await this.savedSearchRepository.save(savedSearch);
+  }
+}

--- a/backend/src/modules/search/search.module.ts
+++ b/backend/src/modules/search/search.module.ts
@@ -1,15 +1,25 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { SearchService } from './search.service';
 import { SearchController } from './search.controller';
+import { SavedSearchService } from './saved-search.service';
+import { SavedSearchController } from './saved-search.controller';
+import { SavedSearchCronService } from './saved-search-cron.service';
+import { SavedSearch } from './entities/saved-search.entity';
 import { Property } from '../properties/entities/property.entity';
 import { User } from '../users/entities/user.entity';
 import { RentAgreement } from '../rent/entities/rent-contract.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Property, User, RentAgreement])],
-  providers: [SearchService],
-  controllers: [SearchController],
-  exports: [SearchService],
+  imports: [
+    ScheduleModule,
+    TypeOrmModule.forFeature([Property, User, RentAgreement, SavedSearch]),
+    NotificationsModule,
+  ],
+  providers: [SearchService, SavedSearchService, SavedSearchCronService],
+  controllers: [SearchController, SavedSearchController],
+  exports: [SearchService, SavedSearchService],
 })
 export class SearchModule {}

--- a/backend/src/types/notification.types.ts
+++ b/backend/src/types/notification.types.ts
@@ -15,7 +15,8 @@ export type NotificationType =
   | 'dispute_resolved'
   | 'message_received'
   | 'low_balance_warning'
-  | 'transaction_failed';
+  | 'transaction_failed'
+  | 'saved_search_match';
 
 export type NotificationChannel = 'email' | 'sms' | 'push' | 'in_app';
 export type NotificationPriority = 'low' | 'medium' | 'high' | 'urgent';

--- a/frontend/__tests__/e2e/property-search-filter-flow.test.tsx
+++ b/frontend/__tests__/e2e/property-search-filter-flow.test.tsx
@@ -116,6 +116,10 @@ vi.mock('@/lib/query/hooks', async (importOriginal) => {
       isPending: false,
       toggleFavorite: vi.fn(),
     })),
+    useCreateSavedSearch: vi.fn(() => ({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })),
   };
 });
 

--- a/frontend/__tests__/lib/query/saved-search-hooks.test.ts
+++ b/frontend/__tests__/lib/query/saved-search-hooks.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { queryKeys } from '@/lib/query/keys';
+import { toSavedSearchFilters } from '@/lib/query/hooks/use-saved-searches';
+
+describe('saved searches query keys', () => {
+  it('all is a stable tuple', () => {
+    expect(queryKeys.savedSearches.all).toEqual(['saved-searches']);
+  });
+
+  it('list extends all', () => {
+    expect(queryKeys.savedSearches.list()).toEqual(['saved-searches', 'list']);
+  });
+});
+
+describe('toSavedSearchFilters', () => {
+  it('omits fields that are absent from the params', () => {
+    expect(toSavedSearchFilters({})).toEqual({});
+  });
+
+  it('maps querystring-shaped params to typed filters', () => {
+    const filters = toSavedSearchFilters({
+      q: 'lekki apartment',
+      city: 'Lekki',
+      minPrice: '1000',
+      maxPrice: '2000',
+      bedrooms: '2',
+      furnished: 'true',
+      parking: 'false',
+      amenities: 'gym,pool',
+    });
+
+    expect(filters).toEqual({
+      q: 'lekki apartment',
+      city: 'Lekki',
+      minPrice: 1000,
+      maxPrice: 2000,
+      bedrooms: 2,
+      furnished: true,
+      parking: false,
+      amenities: ['gym', 'pool'],
+    });
+  });
+});

--- a/frontend/components/properties/PropertySearchFilters.tsx
+++ b/frontend/components/properties/PropertySearchFilters.tsx
@@ -8,10 +8,17 @@ import {
   ChevronDown,
   Filter,
   X,
+  BookmarkPlus,
 } from 'lucide-react';
 import { useState, useEffect, useCallback, useRef } from 'react';
+import toast from 'react-hot-toast';
 import { usePropertyStore } from '@/store/property-store';
-import { useSearchSuggest } from '@/lib/query/hooks';
+import {
+  useSearchSuggest,
+  useCreateSavedSearch,
+  toSavedSearchFilters,
+} from '@/lib/query/hooks';
+import { useAuthStore } from '@/store/authStore';
 
 interface FilterOption {
   label: string;
@@ -68,8 +75,13 @@ export default function PropertySearchFilters() {
   const [availability, setAvailability] = useState('');
   const [activeTags, setActiveTags] = useState<Set<string>>(new Set());
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [isSaveSearchOpen, setIsSaveSearchOpen] = useState(false);
+  const [savedSearchName, setSavedSearchName] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const suggestionsRef = useRef<HTMLDivElement>(null);
+
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const createSavedSearch = useCreateSavedSearch();
 
   const debouncedSearch = useDebounce(localSearch, 300);
 
@@ -161,6 +173,51 @@ export default function PropertySearchFilters() {
     maxBudget ||
     selectedType !== 'all' ||
     activeTags.size > 0;
+
+  const handleOpenSaveSearch = useCallback(() => {
+    if (!isAuthenticated) {
+      toast.error('Sign in to save searches');
+      return;
+    }
+    setSavedSearchName(localSearch || 'My search');
+    setIsSaveSearchOpen(true);
+  }, [isAuthenticated, localSearch]);
+
+  const handleSaveSearch = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!savedSearchName.trim()) return;
+
+      const searchFilters = toSavedSearchFilters({
+        q: localSearch || undefined,
+        minPrice: minBudget || undefined,
+        maxPrice: maxBudget || undefined,
+        type: selectedType !== 'all' ? selectedType : undefined,
+        petsAllowed: activeTags.has('pets allowed') ? 'true' : undefined,
+        parking: activeTags.has('parking') ? 'true' : undefined,
+      });
+
+      try {
+        await createSavedSearch.mutateAsync({
+          name: savedSearchName.trim(),
+          filters: searchFilters,
+        });
+        toast.success('Search saved — we’ll notify you of new matches');
+        setIsSaveSearchOpen(false);
+      } catch {
+        toast.error('Could not save this search. Please try again.');
+      }
+    },
+    [
+      savedSearchName,
+      localSearch,
+      minBudget,
+      maxBudget,
+      selectedType,
+      activeTags,
+      createSavedSearch,
+    ],
+  );
 
   return (
     <div
@@ -273,6 +330,16 @@ export default function PropertySearchFilters() {
             className="bg-blue-600 hover:bg-blue-500 text-white font-bold px-8 py-3.5 rounded-2xl transition-all shadow-lg shadow-blue-500/20 active:scale-95"
           >
             Search
+          </button>
+
+          <button
+            type="button"
+            onClick={handleOpenSaveSearch}
+            data-testid="save-search-btn"
+            className="flex items-center gap-1.5 text-blue-200/70 hover:text-white text-sm px-3 py-2 rounded-xl border border-white/5 hover:border-white/10 transition-all"
+          >
+            <BookmarkPlus className="w-4 h-4" />
+            <span>Save search</span>
           </button>
 
           {hasActiveFilters && (
@@ -436,6 +503,55 @@ export default function PropertySearchFilters() {
               Apply Filters
             </button>
           </div>
+        </div>
+      )}
+
+      {/* Save Search Modal */}
+      {isSaveSearchOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-in fade-in duration-200"
+          data-testid="save-search-modal"
+        >
+          <div
+            className="absolute inset-0 bg-slate-950/80 backdrop-blur-sm"
+            onClick={() => setIsSaveSearchOpen(false)}
+          />
+          <form
+            onSubmit={handleSaveSearch}
+            className="relative w-full max-w-sm bg-slate-900 border border-white/10 rounded-3xl p-6 space-y-4 shadow-2xl"
+          >
+            <div className="flex justify-between items-center">
+              <h3 className="text-lg font-bold text-white">Save this search</h3>
+              <button
+                type="button"
+                onClick={() => setIsSaveSearchOpen(false)}
+                data-testid="save-search-close-btn"
+                className="p-1.5 bg-slate-800 rounded-full text-blue-200/50 hover:text-white"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <p className="text-sm text-blue-200/60">
+              We&apos;ll notify you when a new listing matches these filters.
+            </p>
+            <input
+              type="text"
+              value={savedSearchName}
+              onChange={(e) => setSavedSearchName(e.target.value)}
+              placeholder="Name this search"
+              data-testid="save-search-name-input"
+              autoFocus
+              className="w-full bg-slate-800 border border-white/5 rounded-xl py-3 px-4 text-white placeholder:text-blue-200/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+            />
+            <button
+              type="submit"
+              disabled={createSavedSearch.isPending || !savedSearchName.trim()}
+              data-testid="save-search-submit-btn"
+              className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold py-3 rounded-xl transition-all"
+            >
+              {createSavedSearch.isPending ? 'Saving…' : 'Save & get alerts'}
+            </button>
+          </form>
         </div>
       )}
     </div>

--- a/frontend/components/properties/__tests__/PropertySearchFilters.test.tsx
+++ b/frontend/components/properties/__tests__/PropertySearchFilters.test.tsx
@@ -2,19 +2,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
+const mockMutateAsync = vi.fn();
+
 vi.mock('@/lib/query/hooks', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/query/hooks')>();
   return {
     ...actual,
     useSearchSuggest: vi.fn(() => ({ data: undefined })),
+    useCreateSavedSearch: vi.fn(() => ({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    })),
   };
 });
 
+import { useAuthStore } from '@/store/authStore';
 import PropertySearchFilters from '../PropertySearchFilters';
 
 describe('PropertySearchFilters', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAuthStore.setState({ isAuthenticated: false });
   });
 
   it('renders the location search input', () => {
@@ -31,7 +39,12 @@ describe('PropertySearchFilters', () => {
 
   it('renders the search button', () => {
     render(React.createElement(PropertySearchFilters));
-    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+    expect(screen.getByTestId('search-submit-btn')).toBeInTheDocument();
+  });
+
+  it('renders the save search button', () => {
+    render(React.createElement(PropertySearchFilters));
+    expect(screen.getByTestId('save-search-btn')).toBeInTheDocument();
   });
 
   it('renders popular filter tags', () => {
@@ -102,5 +115,53 @@ describe('PropertySearchFilters', () => {
     const closeBtn = screen.getByRole('button', { name: '' });
     fireEvent.click(closeBtn);
     expect(screen.queryByText('Apply Filters')).not.toBeInTheDocument();
+  });
+
+  describe('save search', () => {
+    it('does not open the save search modal for an unauthenticated user', () => {
+      useAuthStore.setState({ isAuthenticated: false });
+      render(React.createElement(PropertySearchFilters));
+
+      fireEvent.click(screen.getByTestId('save-search-btn'));
+
+      expect(screen.queryByTestId('save-search-modal')).not.toBeInTheDocument();
+    });
+
+    it('opens the save search modal for an authenticated user', () => {
+      useAuthStore.setState({ isAuthenticated: true });
+      render(React.createElement(PropertySearchFilters));
+
+      fireEvent.click(screen.getByTestId('save-search-btn'));
+
+      expect(screen.getByTestId('save-search-modal')).toBeInTheDocument();
+    });
+
+    it('submits the saved search with the entered name', async () => {
+      useAuthStore.setState({ isAuthenticated: true });
+      mockMutateAsync.mockResolvedValue({ id: 'saved-1' });
+      render(React.createElement(PropertySearchFilters));
+
+      fireEvent.click(screen.getByTestId('save-search-btn'));
+      const nameInput = screen.getByTestId(
+        'save-search-name-input',
+      ) as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: 'Lekki 2-beds' } });
+      fireEvent.click(screen.getByTestId('save-search-submit-btn'));
+
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Lekki 2-beds' }),
+      );
+    });
+
+    it('closes the save search modal via the close button', () => {
+      useAuthStore.setState({ isAuthenticated: true });
+      render(React.createElement(PropertySearchFilters));
+
+      fireEvent.click(screen.getByTestId('save-search-btn'));
+      expect(screen.getByTestId('save-search-modal')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('save-search-close-btn'));
+      expect(screen.queryByTestId('save-search-modal')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/lib/query/hooks/index.ts
+++ b/frontend/lib/query/hooks/index.ts
@@ -38,6 +38,18 @@ export {
 } from './use-transactions';
 
 export {
+  useSavedSearches,
+  useCreateSavedSearch,
+  useDeleteSavedSearch,
+  toSavedSearchFilters,
+} from './use-saved-searches';
+export type {
+  SavedSearch,
+  SavedSearchFilters,
+  CreateSavedSearchPayload,
+} from './use-saved-searches';
+
+export {
   useAnchorTransactions,
   useAnchorTransaction,
   useAnchorTransactionStats,

--- a/frontend/lib/query/hooks/use-saved-searches.ts
+++ b/frontend/lib/query/hooks/use-saved-searches.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { useAuthStore } from '@/store/authStore';
+import { queryKeys } from '../keys';
+import type { PropertySearchParams } from './use-properties';
+
+export interface SavedSearchFilters {
+  q?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  type?: string;
+  status?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  bedrooms?: number;
+  bathrooms?: number;
+  furnished?: boolean;
+  parking?: boolean;
+  petsAllowed?: boolean;
+  amenities?: string[];
+  lat?: number;
+  lng?: number;
+  radiusKm?: number;
+}
+
+export interface SavedSearch {
+  id: string;
+  name: string;
+  filters: SavedSearchFilters;
+  alertsEnabled: boolean;
+  lastNotifiedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSavedSearchPayload {
+  name: string;
+  filters: SavedSearchFilters;
+  alertsEnabled?: boolean;
+}
+
+function useSavedSearchesEnabled(): boolean {
+  return useAuthStore((state) => state.isAuthenticated);
+}
+
+/** Converts the querystring-shaped PropertySearchParams into a typed filters object. */
+export function toSavedSearchFilters(
+  params: PropertySearchParams,
+): SavedSearchFilters {
+  const filters: SavedSearchFilters = {};
+  if (params.q) filters.q = params.q;
+  if (params.city) filters.city = params.city;
+  if (params.state) filters.state = params.state;
+  if (params.country) filters.country = params.country;
+  if (params.type) filters.type = params.type;
+  if (params.status) filters.status = params.status;
+  if (params.minPrice) filters.minPrice = Number(params.minPrice);
+  if (params.maxPrice) filters.maxPrice = Number(params.maxPrice);
+  if (params.bedrooms) filters.bedrooms = Number(params.bedrooms);
+  if (params.bathrooms) filters.bathrooms = Number(params.bathrooms);
+  if (params.furnished) filters.furnished = params.furnished === 'true';
+  if (params.parking) filters.parking = params.parking === 'true';
+  if (params.petsAllowed) filters.petsAllowed = params.petsAllowed === 'true';
+  if (params.amenities) filters.amenities = params.amenities.split(',');
+  if (params.lat) filters.lat = Number(params.lat);
+  if (params.lng) filters.lng = Number(params.lng);
+  if (params.radiusKm) filters.radiusKm = Number(params.radiusKm);
+  return filters;
+}
+
+export function useSavedSearches() {
+  const isEnabled = useSavedSearchesEnabled();
+
+  return useQuery({
+    queryKey: queryKeys.savedSearches.list(),
+    queryFn: async () => {
+      const { data } = await apiClient.get<SavedSearch[]>(
+        '/search/saved-searches',
+      );
+      return data;
+    },
+    enabled: isEnabled,
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateSavedSearch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: CreateSavedSearchPayload) => {
+      const { data } = await apiClient.post<SavedSearch>(
+        '/search/saved-searches',
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.savedSearches.all,
+      });
+    },
+  });
+}
+
+export function useDeleteSavedSearch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiClient.delete(`/search/saved-searches/${id}`);
+      return id;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.savedSearches.all,
+      });
+    },
+  });
+}

--- a/frontend/lib/query/keys.ts
+++ b/frontend/lib/query/keys.ts
@@ -199,6 +199,11 @@ export const queryKeys = {
       [...queryKeys.search.all, 'suggest', query] as const,
   },
 
+  savedSearches: {
+    all: ['saved-searches'] as const,
+    list: () => [...queryKeys.savedSearches.all, 'list'] as const,
+  },
+
   documents: {
     all: ['documents'] as const,
     lists: () => [...queryKeys.documents.all, 'list'] as const,


### PR DESCRIPTION
# Saved search / search-alert feature

## Summary
- Adds a `SavedSearch` entity (jsonb filters, `alertsEnabled`, `lastNotifiedAt`) + migration.
- Adds `SavedSearchService`: CRUD, an in-memory `propertyMatchesFilters` matcher, and `notifyMatchingSearches` which alerts owners via `NotificationsService` (new `saved_search_match` type).
- Exposes `GET/POST /search/saved-searches` and `DELETE /search/saved-searches/:id`, JWT-guarded and scoped to the current user.
- Hooks `PropertiesService.publish()` to notify matching saved searches (fire-and-forget, mirrors the existing fraud hook pattern) plus a 10-minute cron sweep as a fallback safety net.
- Frontend: `useSavedSearches`/`useCreateSavedSearch`/`useDeleteSavedSearch` hooks, and a "Save search" action + modal in `PropertySearchFilters`.

## Test plan
- [x] `npx jest saved-search.service.spec.ts saved-search-cron.service.spec.ts properties.service.spec.ts properties.pagination.spec.ts` — passing
- [x] Full backend suite (`npx jest --testPathIgnorePatterns=e2e`) — 219 suites / 2536 tests passing, no regressions
- [x] `npx tsc --noEmit`, `npm run build`, `npm run check:api-docs` (63 controllers) — clean
- [x] `npx eslint` / `npx prettier --check` on changed backend files — clean
- [x] Frontend `npx vitest run` — same pre-existing failures as `devv` (unrelated: WalletConnectButton, RoleSelectionModal, ReviewForm, messaging-flow, PropertyCard), zero new failures
- [x] `npx next build`, frontend `eslint`/`prettier --check` on changed files — clean

Closes #1768
