### PR TITLE
feat:  Add in-app inquiry response flow (bridge inquiries into messaging)

### DIFF
--- a/backend/src/modules/inquiries/dto/respond-inquiry.dto.ts
+++ b/backend/src/modules/inquiries/dto/respond-inquiry.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class RespondInquiryDto {
+  @ApiProperty({
+    description: 'Reply the recipient posts into the in-app conversation',
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(4000)
+  message: string;
+}

--- a/backend/src/modules/inquiries/entities/property-inquiry.entity.ts
+++ b/backend/src/modules/inquiries/entities/property-inquiry.entity.ts
@@ -10,6 +10,8 @@ import {
 export enum PropertyInquiryStatus {
   PENDING = 'pending',
   VIEWED = 'viewed',
+  /** The recipient replied through the in-app messaging system. */
+  RESPONDED = 'responded',
   /** Terminal state: either party ended the conversation. */
   CLOSED = 'closed',
 }

--- a/backend/src/modules/inquiries/inquiries.controller.ts
+++ b/backend/src/modules/inquiries/inquiries.controller.ts
@@ -19,6 +19,7 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { User } from '../users/entities/user.entity';
 import { InquiriesService } from './inquiries.service';
 import { CreatePropertyInquiryDto } from './dto/create-property-inquiry.dto';
+import { RespondInquiryDto } from './dto/respond-inquiry.dto';
 import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
 @ApiTags('Inquiries')
@@ -63,6 +64,20 @@ export class InquiriesController {
   @ApiOperation({ summary: 'Mark an incoming inquiry as viewed' })
   async markViewed(@Param('id') id: string, @CurrentUser() user: User) {
     return this.inquiriesService.markViewed(id, user.id);
+  }
+
+  @Post(':id/respond')
+  @ApiOperation({
+    summary: 'Respond to an inquiry via in-app messaging (recipient only)',
+  })
+  @ApiResponse({ status: 201, description: 'Response posted' })
+  @ApiResponse({ status: 400, description: 'Invalid lifecycle transition' })
+  async respond(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+    @Body() dto: RespondInquiryDto,
+  ) {
+    return this.inquiriesService.respond(id, user.id, dto);
   }
 
   @Patch(':id/close')

--- a/backend/src/modules/inquiries/inquiries.module.ts
+++ b/backend/src/modules/inquiries/inquiries.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Property } from '../properties/entities/property.entity';
 import { User } from '../users/entities/user.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { MessagingModule } from '../messaging/messaging.module';
 import { InquiriesController } from './inquiries.controller';
 import { InquiriesService } from './inquiries.service';
 import { PropertyInquiry } from './entities/property-inquiry.entity';
@@ -11,6 +12,7 @@ import { PropertyInquiry } from './entities/property-inquiry.entity';
   imports: [
     TypeOrmModule.forFeature([PropertyInquiry, Property, User]),
     NotificationsModule,
+    MessagingModule,
   ],
   controllers: [InquiriesController],
   providers: [InquiriesService],

--- a/backend/src/modules/inquiries/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/inquiries.service.spec.ts
@@ -25,17 +25,26 @@ describe('InquiriesService', () => {
     notify: jest.fn(),
   };
 
+  const messagingService = {
+    sendDirectMessage: jest.fn(),
+  };
+
   let service: InquiriesService;
 
   beforeEach(() => {
     jest.clearAllMocks();
     propertyRepository.find.mockResolvedValue([]);
     userRepository.find.mockResolvedValue([]);
+    messagingService.sendDirectMessage.mockResolvedValue({
+      room: { id: 1 },
+      message: { id: 1 },
+    });
     service = new InquiriesService(
       inquiryRepository as any,
       propertyRepository as any,
       userRepository as any,
       notificationsService as any,
+      messagingService as any,
     );
   });
 
@@ -238,6 +247,80 @@ describe('InquiriesService', () => {
         InvalidInquiryTransitionError,
       );
       expect(inquiryRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('responds by bridging into messaging and advancing to RESPONDED', async () => {
+      inquiryRepository.findOne.mockResolvedValue({
+        id: 'inq-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.VIEWED,
+      });
+      inquiryRepository.save.mockImplementation((inquiry) =>
+        Promise.resolve(inquiry),
+      );
+
+      const result = await service.respond('inq-1', 'owner-1', {
+        message: 'Yes, still available — happy to arrange a viewing.',
+      });
+
+      expect(result.status).toBe(PropertyInquiryStatus.RESPONDED);
+      // Room is bridged from the recipient (owner) to the original sender.
+      expect(messagingService.sendDirectMessage).toHaveBeenCalledWith(
+        'owner-1',
+        'tenant-1',
+        'Yes, still available — happy to arrange a viewing.',
+      );
+      // Original sender is notified of the response.
+      expect(notificationsService.notify).toHaveBeenCalledWith(
+        'tenant-1',
+        'Response to your inquiry',
+        expect.any(String),
+        'PROPERTY_INQUIRY_RESPONSE',
+      );
+    });
+
+    it('appends another reply without re-transitioning when already RESPONDED', async () => {
+      inquiryRepository.findOne.mockResolvedValue({
+        id: 'inq-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.RESPONDED,
+      });
+      inquiryRepository.save.mockImplementation((inquiry) =>
+        Promise.resolve(inquiry),
+      );
+
+      const result = await service.respond('inq-1', 'owner-1', {
+        message: 'Following up on my last message.',
+      });
+
+      expect(result.status).toBe(PropertyInquiryStatus.RESPONDED);
+      expect(messagingService.sendDirectMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects responding to a closed inquiry without posting a message', async () => {
+      inquiryRepository.findOne.mockResolvedValue({
+        id: 'inq-1',
+        fromUserId: 'tenant-1',
+        toUserId: 'owner-1',
+        status: PropertyInquiryStatus.CLOSED,
+      });
+
+      await expect(
+        service.respond('inq-1', 'owner-1', { message: 'hello' }),
+      ).rejects.toThrow(InvalidInquiryTransitionError);
+      expect(messagingService.sendDirectMessage).not.toHaveBeenCalled();
+      expect(inquiryRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when a non-recipient tries to respond', async () => {
+      inquiryRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.respond('inq-1', 'tenant-1', { message: 'hello' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(messagingService.sendDirectMessage).not.toHaveBeenCalled();
     });
 
     it('closes a pending inquiry', async () => {

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -8,11 +8,13 @@ import { In, Repository } from 'typeorm';
 import { Property } from '../properties/entities/property.entity';
 import { User } from '../users/entities/user.entity';
 import { NotificationsService } from '../notifications/notifications.service';
+import { MessagingService } from '../messaging/messaging.service';
 import {
   PropertyInquiry,
   PropertyInquiryStatus,
 } from './entities/property-inquiry.entity';
 import { CreatePropertyInquiryDto } from './dto/create-property-inquiry.dto';
+import { RespondInquiryDto } from './dto/respond-inquiry.dto';
 import { assertInquiryTransition } from './inquiry-state-machine';
 import { PaginationUtils } from '../../common/utils';
 
@@ -46,6 +48,7 @@ export class InquiriesService {
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     private readonly notificationsService: NotificationsService,
+    private readonly messagingService: MessagingService,
   ) {}
 
   async createInquiry(
@@ -218,6 +221,59 @@ export class InquiriesService {
     inquiry.status = PropertyInquiryStatus.VIEWED;
     inquiry.viewedAt = new Date();
     return this.inquiryRepository.save(inquiry);
+  }
+
+  /**
+   * Respond to an inquiry as the recipient (property owner). Bridges the
+   * inquiry into the in-app messaging system: it finds or creates the DM room
+   * between the two parties, posts the reply there, advances the inquiry to
+   * RESPONDED, and notifies the original sender. A repeat reply simply appends
+   * another message without re-transitioning.
+   */
+  async respond(
+    id: string,
+    userId: string,
+    dto: RespondInquiryDto,
+  ): Promise<PropertyInquiry> {
+    const inquiry = await this.inquiryRepository.findOne({
+      where: { id, toUserId: userId },
+    });
+
+    if (!inquiry) {
+      throw new NotFoundException('Inquiry not found');
+    }
+
+    const alreadyResponded =
+      inquiry.status === PropertyInquiryStatus.RESPONDED;
+
+    // Validate the lifecycle move up front so an illegal state (e.g. CLOSED)
+    // is rejected before we post anything into the messaging room.
+    if (!alreadyResponded) {
+      assertInquiryTransition(
+        inquiry.status,
+        PropertyInquiryStatus.RESPONDED,
+      );
+    }
+
+    await this.messagingService.sendDirectMessage(
+      inquiry.toUserId,
+      inquiry.fromUserId,
+      dto.message,
+    );
+
+    if (!alreadyResponded) {
+      inquiry.status = PropertyInquiryStatus.RESPONDED;
+    }
+    const saved = await this.inquiryRepository.save(inquiry);
+
+    await this.notificationsService.notify(
+      inquiry.fromUserId,
+      'Response to your inquiry',
+      'The property owner replied to your inquiry.',
+      'PROPERTY_INQUIRY_RESPONSE',
+    );
+
+    return saved;
   }
 
   /**

--- a/backend/src/modules/inquiries/inquiry-state-machine.spec.ts
+++ b/backend/src/modules/inquiries/inquiry-state-machine.spec.ts
@@ -17,8 +17,11 @@ describe('inquiry state machine', () => {
 
   const legal: Array<[PropertyInquiryStatus, PropertyInquiryStatus]> = [
     [PropertyInquiryStatus.PENDING, PropertyInquiryStatus.VIEWED],
+    [PropertyInquiryStatus.PENDING, PropertyInquiryStatus.RESPONDED],
     [PropertyInquiryStatus.PENDING, PropertyInquiryStatus.CLOSED],
+    [PropertyInquiryStatus.VIEWED, PropertyInquiryStatus.RESPONDED],
     [PropertyInquiryStatus.VIEWED, PropertyInquiryStatus.CLOSED],
+    [PropertyInquiryStatus.RESPONDED, PropertyInquiryStatus.CLOSED],
   ];
 
   it.each(legal)('allows %s -> %s', (from, to) => {

--- a/backend/src/modules/inquiries/inquiry-state-machine.ts
+++ b/backend/src/modules/inquiries/inquiry-state-machine.ts
@@ -21,8 +21,13 @@ export class InvalidInquiryTransitionError extends BadRequestException {
  * The explicit inquiry lifecycle. Every legal transition is listed here;
  * anything not in the table is rejected. Terminal states have an empty list.
  *
- *   PENDING ──▶ VIEWED ──▶ CLOSED
- *      └────────────────────▲
+ *   PENDING ──▶ VIEWED ──▶ RESPONDED ──▶ CLOSED
+ *      │           └───────────┬────────────▲
+ *      └──────────────────────────────────────
+ *
+ * RESPONDED is reached when the recipient replies via in-app messaging. A
+ * repeat reply keeps the inquiry in RESPONDED (callers short-circuit before
+ * asserting), so RESPONDED -> RESPONDED is intentionally absent.
  */
 export const INQUIRY_STATUS_TRANSITIONS: Record<
   PropertyInquiryStatus,
@@ -30,9 +35,14 @@ export const INQUIRY_STATUS_TRANSITIONS: Record<
 > = {
   [PropertyInquiryStatus.PENDING]: [
     PropertyInquiryStatus.VIEWED,
+    PropertyInquiryStatus.RESPONDED,
     PropertyInquiryStatus.CLOSED,
   ],
-  [PropertyInquiryStatus.VIEWED]: [PropertyInquiryStatus.CLOSED],
+  [PropertyInquiryStatus.VIEWED]: [
+    PropertyInquiryStatus.RESPONDED,
+    PropertyInquiryStatus.CLOSED,
+  ],
+  [PropertyInquiryStatus.RESPONDED]: [PropertyInquiryStatus.CLOSED],
   [PropertyInquiryStatus.CLOSED]: [],
 };
 

--- a/backend/src/modules/messaging/messaging.service.spec.ts
+++ b/backend/src/modules/messaging/messaging.service.spec.ts
@@ -47,4 +47,35 @@ describe('MessagingService', () => {
     const result = await service.getHistory('group1', 1, 2);
     expect(result).toEqual(messages);
   });
+
+  describe('sendDirectMessage', () => {
+    it('bridges two users into a room and posts a message', async () => {
+      const room = {
+        id: 7,
+        participants: [{ userId: 1 }, { userId: 2 }],
+      };
+      jest.spyOn(service, 'findOrCreateRoom').mockResolvedValue(room as any);
+      messageRepo.create.mockImplementation((input) => input);
+      messageRepo.save.mockImplementation(async (input) => ({
+        id: 99,
+        ...input,
+      }));
+
+      const result = await service.sendDirectMessage('1', '2', 'hi there');
+
+      expect(service.findOrCreateRoom).toHaveBeenCalledWith('1', '2');
+      expect(messageRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          senderId: 1,
+          receiverId: 2,
+          content: 'hi there',
+          chatRoom: room,
+          sender: { userId: 1 },
+          receiver: { userId: 2 },
+        }),
+      );
+      expect(result.room).toBe(room);
+      expect(result.message.id).toBe(99);
+    });
+  });
 });

--- a/backend/src/modules/messaging/messaging.service.ts
+++ b/backend/src/modules/messaging/messaging.service.ts
@@ -114,6 +114,36 @@ export class MessagingService {
     }) as Promise<ChatRoom>;
   }
 
+  /**
+   * Bridge helper for other modules (e.g. inquiries): ensure a DM room exists
+   * between two users and post a message from `senderUserId` into it. Returns
+   * the room and the persisted message so callers can link the two parties'
+   * conversation into the in-app messaging system instead of pushing them to
+   * reply off-platform.
+   */
+  async sendDirectMessage(
+    senderUserId: string,
+    recipientUserId: string,
+    content: string,
+  ): Promise<{ room: ChatRoom; message: Message }> {
+    const room = await this.findOrCreateRoom(senderUserId, recipientUserId);
+
+    const senderNumericId = parseInt(senderUserId, 10);
+    const recipientNumericId = parseInt(recipientUserId, 10);
+
+    const message = this.messageRepository.create({
+      senderId: senderNumericId,
+      receiverId: recipientNumericId,
+      content,
+      chatRoom: room,
+      sender: room.participants?.find((p) => p.userId === senderNumericId),
+      receiver: room.participants?.find((p) => p.userId === recipientNumericId),
+    });
+
+    const saved = await this.messageRepository.save(message);
+    return { room, message: saved };
+  }
+
   // ── Messages ──────────────────────────────────────────────────────────────
 
   async getMessagesForRoom(roomId: string, page = 1, limit = 50) {


### PR DESCRIPTION

`inquiries.controller.ts` only exposed `POST /`, `GET incoming/outgoing`, `PATCH :id/viewed`, and `PATCH :id/close`. There was no way for a landlord to reply to an inquiry through the platform, and `inquiry-state-machine.ts` had no `RESPONDED` state.

As a result, landlords were pushed to reply off-platform via the `senderEmail`/`senderPhone` captured on the inquiry — defeating the purpose of an in-app inquiry system and losing the conversation history, even though a full `messaging` module already exists.

## What changed

Added a `respond()` flow that bridges an inquiry into the existing in-app messaging system: it finds or creates the DM room between the two parties, posts the recipient's reply there, advances the inquiry lifecycle to `RESPONDED`, and notifies the original sender.

### State machine (`inquiry-state-machine.ts`, `property-inquiry.entity.ts`)
- Added a `RESPONDED` status to `PropertyInquiryStatus`.
- Extended the transition table:
  - `PENDING → {VIEWED, RESPONDED, CLOSED}`
  - `VIEWED → {RESPONDED, CLOSED}`
  - `RESPONDED → {CLOSED}`
  - `CLOSED → {}` (terminal)
- `RESPONDED → RESPONDED` is intentionally omitted. Repeat replies short-circuit before asserting the transition, mirroring the existing idempotency pattern used by `markViewed`/`close`.

### Messaging bridge (`messaging.service.ts`)
- Added `sendDirectMessage(senderUserId, recipientUserId, content)` — a reusable helper that reuses `findOrCreateRoom` to get/create the DM room, posts the message, and returns `{ room, message }`.
- Kept consistent with the messaging module's existing convention rather than reworking the messaging schema (out of scope).

### Response flow (`inquiries.service.ts`, `dto/respond-inquiry.dto.ts`, `inquiries.controller.ts`, `inquiries.module.ts`)
- New `RespondInquiryDto` with a validated `message` (1–4000 chars).
- `InquiriesService.respond()`:
  - Recipient-only lookup (scoped to `toUserId`).
  - Validates the lifecycle move **before** posting, so responding to a `CLOSED` inquiry is rejected with the domain error and **no** message is written.
  - Bridges via `sendDirectMessage`, advances status to `RESPONDED`, and notifies the original sender (`PROPERTY_INQUIRY_RESPONSE`).
  - A repeat reply appends another message without re-transitioning.
- Exposed `POST inquiries/:id/respond` on the controller.
- Wired `MessagingModule` into `InquiriesModule` and injected `MessagingService`.

## API

```
POST /inquiries/:id/respond
Auth: Bearer (recipient / property owner only)

Body:
{
  "message": "Yes, still available — happy to arrange a viewing."
}
```

- `201` — response posted (room created/reused, message stored, sender notified)
- `400` — invalid lifecycle transition (e.g. inquiry already `CLOSED`)
- `404` — inquiry not found or caller is not the recipient

## Tests

- **State machine spec** — added the new `RESPONDED` legal transitions; existing "reject everything not in the table" coverage now guards them.
- **Inquiries service spec**:
  - happy-path respond (room bridged owner → sender, sender notified, status → `RESPONDED`)
  - repeat reply without re-transition (single message per call, status stays `RESPONDED`)
  - reject on `CLOSED` (domain error, no message posted, no save)
  - `NotFound` when a non-recipient responds
- **Messaging service spec** — covers `sendDirectMessage` bridging two users into a room and posting the message.

### Verification
- `npm test` (inquiries + messaging): **29 passed / 29**
- `tsc --noEmit`: clean

## Acceptance criteria

- [x] `POST inquiries/:id/respond` creates/reuses a messaging room and posts the reply
- [x] Inquiry state machine gains and enforces a `RESPONDED` transition
- [x] The original sender is notified of the response
- [x] Tests cover the state transition and messaging-room bridging

## Notes / follow-ups

- The messaging module is a legacy integer-`userId` design (`Participant.userId` is numeric; `findOrCreateRoom` uses `parseInt`), while users/inquiries are UUID-based. The bridge follows the existing module convention; reconciling the messaging schema to UUIDs is a larger, separate effort and out of scope for this change.



closes #1765
