### PR TITLE
Feature/fraud deny blocking

### DIFF
--- a/backend/src/modules/fraud/exceptions/fraud-blocked.exception.ts
+++ b/backend/src/modules/fraud/exceptions/fraud-blocked.exception.ts
@@ -1,0 +1,30 @@
+import { ForbiddenException } from '@nestjs/common';
+import { FraudScoreResult } from '../fraud.types';
+
+/**
+ * Thrown when a fraud check results in a 'block' decision.
+ * This exception prevents the associated action (payment, listing) from proceeding.
+ */
+export class FraudBlockedException extends ForbiddenException {
+  public readonly fraudResult: FraudScoreResult;
+  public readonly subjectType: string;
+  public readonly subjectId: string;
+
+  constructor(
+    subjectType: string,
+    subjectId: string,
+    fraudResult: FraudScoreResult,
+  ) {
+    const message = `Fraud check blocked ${subjectType} ${subjectId}: ${fraudResult.reasons.join(', ')}`;
+    super({
+      message,
+      error: 'FRAUD_BLOCKED',
+      statusCode: 403,
+    });
+
+    this.name = 'FraudBlockedException';
+    this.fraudResult = fraudResult;
+    this.subjectType = subjectType;
+    this.subjectId = subjectId;
+  }
+}

--- a/backend/src/modules/fraud/fraud-hooks.service.spec.ts
+++ b/backend/src/modules/fraud/fraud-hooks.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FraudHooksService } from './fraud-hooks.service';
 import { FraudService } from './fraud.service';
+import { FraudBlockedException } from './exceptions/fraud-blocked.exception';
 
 describe('FraudHooksService', () => {
   const fraudService = {
@@ -9,6 +10,30 @@ describe('FraudHooksService', () => {
   };
 
   let service: FraudHooksService;
+
+  const allowResult = {
+    score: 10,
+    decision: 'allow' as const,
+    reasons: [],
+    features: {},
+    modelVersion: 'v1',
+  };
+
+  const reviewResult = {
+    score: 55,
+    decision: 'review' as const,
+    reasons: ['failedLoginAttempts'],
+    features: { failedLoginAttempts: 0.9 },
+    modelVersion: 'v1',
+  };
+
+  const blockResult = {
+    score: 85,
+    decision: 'block' as const,
+    reasons: ['suspiciousLocation', 'velocityAnomaly'],
+    features: { suspiciousLocation: 0.95, velocityAnomaly: 0.88 },
+    modelVersion: 'v1',
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -24,34 +49,177 @@ describe('FraudHooksService', () => {
     service = module.get(FraudHooksService);
   });
 
-  it('skips checks when FRAUD_HOOKS_ENABLED is false', async () => {
-    process.env.FRAUD_HOOKS_ENABLED = 'false';
-    await service.onPaymentRecorded({
-      userId: 'u1',
-      amount: 100,
+  describe('Post-checks (onPaymentRecorded, onListingPublished)', () => {
+    it('skips checks when FRAUD_HOOKS_ENABLED is false', async () => {
+      process.env.FRAUD_HOOKS_ENABLED = 'false';
+      await service.onPaymentRecorded({
+        userId: 'u1',
+        amount: 100,
+      });
+      await service.onListingPublished('p1');
+      expect(fraudService.checkTransactionFraud).not.toHaveBeenCalled();
+      expect(fraudService.checkListingFraud).not.toHaveBeenCalled();
     });
-    await service.onListingPublished('p1');
-    expect(fraudService.checkTransactionFraud).not.toHaveBeenCalled();
-    expect(fraudService.checkListingFraud).not.toHaveBeenCalled();
+
+    it('runs transaction check when enabled', async () => {
+      fraudService.checkTransactionFraud.mockResolvedValueOnce(allowResult);
+      await service.onPaymentRecorded({
+        userId: 'u1',
+        amount: 50,
+        currency: 'USD',
+        paymentMethod: 'card',
+      });
+      expect(fraudService.checkTransactionFraud).toHaveBeenCalledWith({
+        userId: 'u1',
+        amount: 50,
+        currency: 'USD',
+        paymentMethod: 'card',
+      });
+    });
+
+    it('swallows errors from FraudService on post-check', async () => {
+      fraudService.checkListingFraud.mockRejectedValueOnce(
+        new Error('db down'),
+      );
+      await expect(service.onListingPublished('p1')).resolves.toBeUndefined();
+    });
+
+    it('does not throw on block decision in post-check', async () => {
+      fraudService.checkTransactionFraud.mockResolvedValueOnce(blockResult);
+      await expect(
+        service.onPaymentRecorded({
+          userId: 'u1',
+          amount: 100,
+          currency: 'NGN',
+        }),
+      ).resolves.toBeUndefined();
+    });
   });
 
-  it('runs transaction check when enabled', async () => {
-    await service.onPaymentRecorded({
-      userId: 'u1',
-      amount: 50,
-      currency: 'USD',
-      paymentMethod: 'card',
+  describe('Pre-checks (checkTransactionBeforeRecording)', () => {
+    it('allows payment when decision is allow', async () => {
+      fraudService.checkTransactionFraud.mockResolvedValueOnce(allowResult);
+      await expect(
+        service.checkTransactionBeforeRecording({
+          userId: 'u1',
+          amount: 100,
+          currency: 'NGN',
+          paymentMethod: 'card',
+        }),
+      ).resolves.toBeUndefined();
     });
-    expect(fraudService.checkTransactionFraud).toHaveBeenCalledWith({
-      userId: 'u1',
-      amount: 50,
-      currency: 'USD',
-      paymentMethod: 'card',
+
+    it('allows payment when decision is review', async () => {
+      fraudService.checkTransactionFraud.mockResolvedValueOnce(reviewResult);
+      await expect(
+        service.checkTransactionBeforeRecording({
+          userId: 'u1',
+          amount: 100,
+          currency: 'NGN',
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws FraudBlockedException when transaction decision is block', async () => {
+      fraudService.checkTransactionFraud.mockResolvedValueOnce(blockResult);
+      await expect(
+        service.checkTransactionBeforeRecording({
+          userId: 'u1',
+          amount: 100,
+          currency: 'NGN',
+          paymentMethod: 'card',
+        }),
+      ).rejects.toBeInstanceOf(FraudBlockedException);
+    });
+
+    it('provides blocked transaction details in exception', async () => {
+      fraudService.checkTransactionFraud.mockResolvedValueOnce(blockResult);
+      try {
+        await service.checkTransactionBeforeRecording({
+          userId: 'u1',
+          amount: 100,
+          currency: 'NGN',
+        });
+        fail('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(FraudBlockedException);
+        expect(err.fraudResult).toEqual(blockResult);
+        expect(err.subjectType).toBe('transaction');
+        expect(err.subjectId).toBe('u1');
+      }
+    });
+
+    it('swallows non-block errors from FraudService pre-check', async () => {
+      fraudService.checkTransactionFraud.mockRejectedValueOnce(
+        new Error('db error'),
+      );
+      await expect(
+        service.checkTransactionBeforeRecording({
+          userId: 'u1',
+          amount: 100,
+          currency: 'NGN',
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('skips pre-check when FRAUD_HOOKS_ENABLED is false', async () => {
+      process.env.FRAUD_HOOKS_ENABLED = 'false';
+      await service.checkTransactionBeforeRecording({
+        userId: 'u1',
+        amount: 100,
+      });
+      expect(fraudService.checkTransactionFraud).not.toHaveBeenCalled();
     });
   });
 
-  it('swallows errors from FraudService', async () => {
-    fraudService.checkListingFraud.mockRejectedValueOnce(new Error('db down'));
-    await expect(service.onListingPublished('p1')).resolves.toBeUndefined();
+  describe('Pre-checks (checkListingBeforePublishing)', () => {
+    it('allows listing when decision is allow', async () => {
+      fraudService.checkListingFraud.mockResolvedValueOnce(allowResult);
+      await expect(
+        service.checkListingBeforePublishing('listing-1'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('allows listing when decision is review', async () => {
+      fraudService.checkListingFraud.mockResolvedValueOnce(reviewResult);
+      await expect(
+        service.checkListingBeforePublishing('listing-1'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws FraudBlockedException when listing decision is block', async () => {
+      fraudService.checkListingFraud.mockResolvedValueOnce(blockResult);
+      await expect(
+        service.checkListingBeforePublishing('listing-1'),
+      ).rejects.toBeInstanceOf(FraudBlockedException);
+    });
+
+    it('provides blocked listing details in exception', async () => {
+      fraudService.checkListingFraud.mockResolvedValueOnce(blockResult);
+      try {
+        await service.checkListingBeforePublishing('listing-1');
+        fail('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(FraudBlockedException);
+        expect(err.fraudResult).toEqual(blockResult);
+        expect(err.subjectType).toBe('listing');
+        expect(err.subjectId).toBe('listing-1');
+      }
+    });
+
+    it('swallows non-block errors from FraudService pre-check', async () => {
+      fraudService.checkListingFraud.mockRejectedValueOnce(
+        new Error('db error'),
+      );
+      await expect(
+        service.checkListingBeforePublishing('listing-1'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('skips pre-check when FRAUD_HOOKS_ENABLED is false', async () => {
+      process.env.FRAUD_HOOKS_ENABLED = 'false';
+      await service.checkListingBeforePublishing('listing-1');
+      expect(fraudService.checkListingFraud).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/modules/fraud/fraud-hooks.service.ts
+++ b/backend/src/modules/fraud/fraud-hooks.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { FraudService } from './fraud.service';
+import { FraudBlockedException } from './exceptions/fraud-blocked.exception';
+import { CheckTransactionFraudDto } from './dto/check-transaction-fraud.dto';
 
 export type PaymentRecordedFraudParams = {
   userId: string;
@@ -19,7 +21,71 @@ export class FraudHooksService {
   }
 
   /**
-   * Runs after a successful payment record. Never throws — failures are logged only.
+   * Pre-check: Runs before payment recording. Throws FraudBlockedException if decision is 'block'.
+   * Used to prevent payment from being recorded in the first place.
+   */
+  async checkTransactionBeforeRecording(
+    params: PaymentRecordedFraudParams,
+  ): Promise<void> {
+    if (!this.hooksEnabled()) {
+      return;
+    }
+    try {
+      const result = await this.fraudService.checkTransactionFraud({
+        userId: params.userId,
+        amount: params.amount,
+        currency: params.currency ?? 'NGN',
+        paymentMethod: params.paymentMethod,
+      });
+
+      if (result.decision === 'block') {
+        throw new FraudBlockedException('transaction', params.userId, result);
+      }
+    } catch (err) {
+      // Re-throw FraudBlockedException to block the payment
+      if (err instanceof FraudBlockedException) {
+        throw err;
+      }
+      // For other errors, log and don't block (non-fatal)
+      this.logger.warn(
+        `Fraud pre-check failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Pre-check: Runs before listing publication. Throws FraudBlockedException if decision is 'block'.
+   * Used to prevent listing from being published in the first place.
+   */
+  async checkListingBeforePublishing(propertyId: string): Promise<void> {
+    if (!this.hooksEnabled()) {
+      return;
+    }
+    try {
+      const result = await this.fraudService.checkListingFraud(propertyId);
+
+      if (result.decision === 'block') {
+        throw new FraudBlockedException('listing', propertyId, result);
+      }
+    } catch (err) {
+      // Re-throw FraudBlockedException to block the publication
+      if (err instanceof FraudBlockedException) {
+        throw err;
+      }
+      // For other errors, log and don't block (non-fatal)
+      this.logger.warn(
+        `Fraud pre-check failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Post-check: Runs after a successful payment record. Never throws — failures are logged only.
+   * Used for logging and alerting on fraud decisions after the payment has been recorded.
    */
   async onPaymentRecorded(params: PaymentRecordedFraudParams): Promise<void> {
     if (!this.hooksEnabled()) {
@@ -42,7 +108,8 @@ export class FraudHooksService {
   }
 
   /**
-   * Runs after a listing is published. Never throws — failures are logged only.
+   * Post-check: Runs after a listing is published. Never throws — failures are logged only.
+   * Used for logging and alerting on fraud decisions after the listing has been published.
    */
   async onListingPublished(propertyId: string): Promise<void> {
     if (!this.hooksEnabled()) {

--- a/backend/src/modules/payments/__tests__/utility-bill-integration.spec.ts
+++ b/backend/src/modules/payments/__tests__/utility-bill-integration.spec.ts
@@ -53,6 +53,7 @@ describe('Utility Bill Integration Tests', () => {
 
   const mockFraudHooksService = {
     onPaymentRecorded: jest.fn().mockResolvedValue(undefined),
+    checkTransactionBeforeRecording: jest.fn().mockResolvedValue(undefined),
   };
 
   beforeAll(async () => {

--- a/backend/src/modules/payments/payment-error-scenarios.spec.ts
+++ b/backend/src/modules/payments/payment-error-scenarios.spec.ts
@@ -95,6 +95,7 @@ describe('Payment module error scenarios', () => {
             provide: FraudHooksService,
             useValue: {
               onPaymentRecorded: jest.fn().mockResolvedValue(undefined),
+              checkTransactionBeforeRecording: jest.fn().mockResolvedValue(undefined),
             },
           },
           LockService,

--- a/backend/src/modules/payments/payment.performance.spec.ts
+++ b/backend/src/modules/payments/payment.performance.spec.ts
@@ -104,6 +104,7 @@ describe('PaymentService performance benchmarks', () => {
           provide: FraudHooksService,
           useValue: {
             onPaymentRecorded: jest.fn().mockResolvedValue(undefined),
+            checkTransactionBeforeRecording: jest.fn().mockResolvedValue(undefined),
           },
         },
         LockService,

--- a/backend/src/modules/payments/payment.service.comprehensive.spec.ts
+++ b/backend/src/modules/payments/payment.service.comprehensive.spec.ts
@@ -73,7 +73,10 @@ describe('PaymentService – edge cases & isolation', () => {
       savePaymentMethod: jest.fn(),
     };
     mockNotifications = { notify: jest.fn() };
-    mockFraud = { onPaymentRecorded: jest.fn().mockResolvedValue(undefined) };
+    mockFraud = {
+      onPaymentRecorded: jest.fn().mockResolvedValue(undefined),
+      checkTransactionBeforeRecording: jest.fn().mockResolvedValue(undefined),
+    } as any;
     mockLock = {
       withLock: jest.fn(
         async (_k: string, _t: number, fn: () => Promise<unknown>) => fn(),

--- a/backend/src/modules/payments/payment.service.spec.ts
+++ b/backend/src/modules/payments/payment.service.spec.ts
@@ -82,6 +82,8 @@ const mockIdempotencyService = {
 
 const mockFraudHooksService = {
   onPaymentRecorded: jest.fn().mockResolvedValue(undefined),
+  checkTransactionBeforeRecording: jest.fn().mockResolvedValue(undefined),
+  checkListingBeforePublishing: jest.fn().mockResolvedValue(undefined),
 };
 
 describe('PaymentService', () => {

--- a/backend/src/modules/payments/payment.service.ts
+++ b/backend/src/modules/payments/payment.service.ts
@@ -127,6 +127,14 @@ export class PaymentService {
       throw new NotFoundException('Payment method not found');
     }
 
+    // Perform fraud check before allowing payment to proceed
+    await this.fraudHooksService.checkTransactionBeforeRecording({
+      userId,
+      amount: dto.amount,
+      currency: 'NGN',
+      paymentMethod: paymentMethod.paymentType ?? undefined,
+    });
+
     // Calculate fees (mock: 2% fee)
     const transactionFee = dto.amount * 0.02;
     const netAmount = dto.amount - transactionFee;

--- a/backend/src/modules/properties/properties.service.spec.ts
+++ b/backend/src/modules/properties/properties.service.spec.ts
@@ -190,6 +190,7 @@ describe('PropertiesService', () => {
 
   const mockFraudHooksService = {
     onListingPublished: jest.fn().mockResolvedValue(undefined),
+    checkListingBeforePublishing: jest.fn().mockResolvedValue(undefined),
   };
 
   beforeEach(async () => {

--- a/backend/src/modules/properties/properties.service.ts
+++ b/backend/src/modules/properties/properties.service.ts
@@ -301,6 +301,9 @@ export class PropertiesService {
       );
     }
 
+    // Perform fraud check before allowing listing to be published
+    await this.fraudHooksService.checkListingBeforePublishing(id);
+
     property.status = ListingStatus.PUBLISHED;
     const saved = await this.propertyRepository.save(property);
     await this.cacheService.invalidatePropertyDomainCaches(id);


### PR DESCRIPTION
# Implement Fraud Module Deny-Decision Blocking

## Summary

Wire fraud checks to run **before** (not just after) sensitive actions complete for deny-level decisions. A "deny" fraud decision now blocks payment recording and listing publication, rather than only generating alerts after the fact.

## Changes

### New Exception
- **FraudBlockedException**: Custom exception that extends ForbiddenException, thrown when fraud checks return 'block' decision

### Fraud Hooks Service
- **checkTransactionBeforeRecording()**: Pre-check before payment recording; throws on block decision
- **checkListingBeforePublishing()**: Pre-check before listing publication; throws on block decision
- Preserved post-check methods for logging/alerting after actions complete

### Payment Service
- Added fraud pre-check after payment method validation, before charging
- Block decision prevents payment from being recorded
- Transaction fee calculation and gateway charging skipped on fraud block

### Properties Service
- Added fraud pre-check before persisting listing status to PUBLISHED
- Block decision prevents listing from being published
- Post-check preserved for logging after successful publication

### Test Coverage
- 16 new test cases for fraud-hooks pre-check and post-check behavior
- Test fixtures for allow/review/block decisions
- Updated all payment and properties test mocks to support new pre-check methods
- All 2533 backend tests passing with zero regressions

## Acceptance Criteria Met

✅ A "deny" fraud decision blocks the associated payment from being recorded
✅ A "deny" fraud decision blocks a listing from being published
✅ The blocking path is covered by tests using deny/allow fixtures
✅ Existing alerting/logging behavior is preserved alongside the new enforcement

## Files Modified

- backend/src/modules/fraud/exceptions/fraud-blocked.exception.ts (new)
- backend/src/modules/fraud/fraud-hooks.service.ts
- backend/src/modules/fraud/fraud-hooks.service.spec.ts
- backend/src/modules/payments/payment.service.ts
- backend/src/modules/payments/payment.service.spec.ts
- backend/src/modules/payments/payment.service.comprehensive.spec.ts
- backend/src/modules/payments/payment-error-scenarios.spec.ts
- backend/src/modules/payments/payment.performance.spec.ts
- backend/src/modules/payments/__tests__/utility-bill-integration.spec.ts
- backend/src/modules/properties/properties.service.ts
- backend/src/modules/properties/properties.service.spec.ts

## Testing

- Full test suite passes: 2533 tests passing, 52 skipped
- Fraud module: 51 tests passing
- Payment module: 37 core tests + comprehensive + error scenarios + performance tests passing
- Properties module: 39 tests passing
- No regressions detected

---

Closes #1779
