### PR TITLE
Feat/screening renewal workflow

### DIFF
--- a/backend/src/migrations/1930200000000-AddScreeningRenewalWorkflow.ts
+++ b/backend/src/migrations/1930200000000-AddScreeningRenewalWorkflow.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddScreeningRenewalWorkflow1930200000000 implements MigrationInterface {
+  name = 'AddScreeningRenewalWorkflow1930200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add renewed_from_id column to tenant_screening_requests
+    await queryRunner.query(`
+      ALTER TABLE "tenant_screening_requests"
+      ADD COLUMN "renewed_from_id" uuid
+    `);
+
+    // Create foreign key constraint for renewal linkage
+    await queryRunner.query(`
+      ALTER TABLE "tenant_screening_requests"
+      ADD CONSTRAINT "FK_tenant_screening_requests_renewed_from"
+      FOREIGN KEY ("renewed_from_id")
+      REFERENCES "tenant_screening_requests"("id")
+      ON DELETE SET NULL
+      ON UPDATE NO ACTION
+    `);
+
+    // Create index for efficient renewal queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_tenant_screening_requests_renewed_from_id"
+      ON "tenant_screening_requests" ("renewed_from_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_tenant_screening_requests_renewed_from_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tenant_screening_requests" DROP CONSTRAINT "FK_tenant_screening_requests_renewed_from"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tenant_screening_requests" DROP COLUMN "renewed_from_id"`,
+    );
+  }
+}

--- a/backend/src/modules/scheduled-tasks/scheduled-tasks.service.ts
+++ b/backend/src/modules/scheduled-tasks/scheduled-tasks.service.ts
@@ -5,6 +5,7 @@ import { RentReminderService } from '../rent/rent-reminder.service';
 import { QueueMonitoringService } from '../queues/services/queue-monitoring.service';
 import { DeadLetterQueueService } from '../queues/services/dead-letter-queue.service';
 import { SecurityPatchManagementService } from '../cleanup/security-patch-management.service';
+import { ScreeningExpiryNotificationService } from '../screening/services/screening-expiry-notification.service';
 
 @Injectable()
 export class ScheduledTasksService {
@@ -16,6 +17,7 @@ export class ScheduledTasksService {
     private readonly queueMonitoring: QueueMonitoringService,
     private readonly deadLetterQueue: DeadLetterQueueService,
     private readonly securityPatch: SecurityPatchManagementService,
+    private readonly screeningExpiryNotification: ScreeningExpiryNotificationService,
   ) {}
 
   @Cron(CronExpression.EVERY_HOUR)
@@ -46,5 +48,15 @@ export class ScheduledTasksService {
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async runSecurityPatchCheck(): Promise<void> {
     await this.securityPatch.runScheduledSecurityPatchCheck();
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async checkScreeningExpirations(): Promise<void> {
+    this.logger.log('Checking for expiring tenant screening reports');
+    const notified =
+      await this.screeningExpiryNotification.notifyExpiringReports();
+    this.logger.log(
+      `Screening expiry check completed. Notified ${notified} user(s)`,
+    );
   }
 }

--- a/backend/src/modules/screening/dto/renew-tenant-screening-request.dto.ts
+++ b/backend/src/modules/screening/dto/renew-tenant-screening-request.dto.ts
@@ -1,0 +1,24 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ScreeningCheckType } from '../screening.enums';
+
+export class RenewTenantScreeningRequestDto {
+  @ApiPropertyOptional({
+    example: ['IDENTITY', 'CRIMINAL', 'EVICTION'],
+    enum: ScreeningCheckType,
+    isArray: true,
+    description:
+      'Types of screening checks to perform. If not provided, uses original checks.',
+  })
+  @IsOptional()
+  @IsEnum(ScreeningCheckType, { each: true })
+  requestedChecks?: ScreeningCheckType[];
+
+  @ApiPropertyOptional({
+    example: 'Updated applicant information',
+    description: 'Additional notes for the renewal request',
+  })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/backend/src/modules/screening/entities/tenant-screening-request.entity.ts
+++ b/backend/src/modules/screening/entities/tenant-screening-request.entity.ts
@@ -54,6 +54,9 @@ export class TenantScreeningRequest {
   @Column({ name: 'provider_reference', type: 'varchar', nullable: true })
   providerReference?: string | null;
 
+  @Column({ name: 'renewed_from_id', type: 'uuid', nullable: true })
+  renewedFromId?: string | null;
+
   @Column({ name: 'encrypted_applicant_data', type: 'text' })
   encryptedApplicantData: string;
 

--- a/backend/src/modules/screening/screening.controller.ts
+++ b/backend/src/modules/screening/screening.controller.ts
@@ -22,6 +22,7 @@ import { ScreeningService } from './screening.service';
 import { CreateTenantScreeningRequestDto } from './dto/create-tenant-screening-request.dto';
 import { GrantTenantScreeningConsentDto } from './dto/grant-tenant-screening-consent.dto';
 import { TenantScreeningWebhookDto } from './dto/tenant-screening-webhook.dto';
+import { RenewTenantScreeningRequestDto } from './dto/renew-tenant-screening-request.dto';
 import { WebhookSignatureGuard } from '../webhooks/guards/webhook-signature.guard';
 import { WebhookSecret } from '../webhooks/decorators/webhook-secret.decorator';
 
@@ -104,6 +105,28 @@ export class ScreeningController {
       id: req.user.id,
       role: req.user.role,
     });
+  }
+
+  @ApiResponse({ status: 201, description: 'Created' })
+  @Post(':id/renew')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Renew an expired tenant screening request' })
+  renewRequest(
+    @Param('id') screeningId: string,
+    @Req() req: RequestWithUser,
+    @Body() dto: RenewTenantScreeningRequestDto,
+  ) {
+    return this.screeningService.renewRequest(
+      screeningId,
+      {
+        id: req.user.id,
+        role: req.user.role,
+        ipAddress: req.ip,
+        userAgent: this.getUserAgent(req),
+      },
+      dto,
+    );
   }
 
   @ApiResponse({ status: 201, description: 'Created' })

--- a/backend/src/modules/screening/screening.module.ts
+++ b/backend/src/modules/screening/screening.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScreeningController } from './screening.controller';
 import { ScreeningService } from './screening.service';
+import { ScreeningExpiryNotificationService } from './services/screening-expiry-notification.service';
 import { TenantScreeningRequest } from './entities/tenant-screening-request.entity';
 import { TenantScreeningConsent } from './entities/tenant-screening-consent.entity';
 import { TenantScreeningReport } from './entities/tenant-screening-report.entity';
@@ -23,7 +24,7 @@ import { WebhooksModule } from '../webhooks/webhooks.module';
     WebhooksModule,
   ],
   controllers: [ScreeningController],
-  providers: [ScreeningService],
-  exports: [ScreeningService],
+  providers: [ScreeningService, ScreeningExpiryNotificationService],
+  exports: [ScreeningService, ScreeningExpiryNotificationService],
 })
 export class ScreeningModule {}

--- a/backend/src/modules/screening/screening.service.ts
+++ b/backend/src/modules/screening/screening.service.ts
@@ -23,6 +23,7 @@ import { TenantScreeningReport } from './entities/tenant-screening-report.entity
 import { CreateTenantScreeningRequestDto } from './dto/create-tenant-screening-request.dto';
 import { GrantTenantScreeningConsentDto } from './dto/grant-tenant-screening-consent.dto';
 import { TenantScreeningWebhookDto } from './dto/tenant-screening-webhook.dto';
+import { RenewTenantScreeningRequestDto } from './dto/renew-tenant-screening-request.dto';
 import {
   UserScreeningProvider,
   UserScreeningRiskLevel,
@@ -239,6 +240,81 @@ export class ScreeningService {
     }
 
     await this.notifyStakeholders(saved);
+    return saved;
+  }
+
+  async renewRequest(
+    screeningId: string,
+    actor: RequestActor,
+    dto: RenewTenantScreeningRequestDto,
+  ): Promise<TenantScreeningRequest> {
+    const originalScreening = await this.requireScreening(screeningId);
+    this.assertCanAccess(originalScreening, actor);
+
+    // Verify the original screening is completed
+    if (originalScreening.status !== UserScreeningStatus.COMPLETED) {
+      throw new BadRequestException(
+        'Only completed screening requests can be renewed',
+      );
+    }
+
+    // Get the original applicant data
+    const applicantData = JSON.parse(
+      this.encryptionService.decrypt(originalScreening.encryptedApplicantData),
+    ) as Record<string, unknown>;
+
+    // Determine which checks to use
+    const checksToUse =
+      dto.requestedChecks ?? originalScreening.requestedChecks;
+
+    // Create new screening request linked to the original
+    const consentTtlDays = Number(
+      this.configService.get<string>('TENANT_SCREENING_CONSENT_TTL_DAYS', '30'),
+    );
+    const renewedScreening = this.screeningRepository.create({
+      tenantId: originalScreening.tenantId,
+      requestedByUserId: actor.id,
+      provider: originalScreening.provider,
+      requestedChecks: checksToUse,
+      status: UserScreeningStatus.PENDING_CONSENT,
+      consentRequired: true,
+      consentVersion: originalScreening.consentVersion,
+      consentExpiresAt: new Date(
+        Date.now() + consentTtlDays * 24 * 60 * 60 * 1000,
+      ),
+      renewedFromId: originalScreening.id,
+      encryptedApplicantData: originalScreening.encryptedApplicantData,
+      metadata: {
+        propertyId: originalScreening.metadata?.propertyId ?? null,
+        notes: dto.notes ?? originalScreening.metadata?.notes ?? null,
+        renewalReason: 'Proactive renewal before access expiration',
+      },
+    });
+
+    const saved = await this.screeningRepository.save(renewedScreening);
+
+    await this.auditService.log({
+      action: AuditAction.CREATE,
+      entityType: 'TenantScreeningRequest',
+      entityId: saved.id,
+      performedBy: actor.id,
+      level: AuditLevel.SECURITY,
+      metadata: {
+        provider: originalScreening.provider,
+        tenantId: originalScreening.tenantId,
+        requestedChecks: checksToUse,
+        renewedFromId: originalScreening.id,
+      },
+    });
+
+    // Notify stakeholders about renewal
+    await this.notificationsService.notify(
+      actor.id,
+      'Screening renewal initiated',
+      'Your tenant screening request has been renewed. Awaiting consent.',
+      'screening_renewal',
+    );
+
     return saved;
   }
 
@@ -489,8 +565,8 @@ export class ScreeningService {
   private getDefaultProvider(): UserScreeningProvider {
     return (
       (this.configService.get<string>('USER_SCREENING_DEFAULT_PROVIDER') as
-        UserScreeningProvider | undefined) ??
-      UserScreeningProvider.TRANSUNION_SMARTMOVE
+        | UserScreeningProvider
+        | undefined) ?? UserScreeningProvider.TRANSUNION_SMARTMOVE
     );
   }
 

--- a/backend/src/modules/screening/services/screening-expiry-notification.service.ts
+++ b/backend/src/modules/screening/services/screening-expiry-notification.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Repository, LessThan } from 'typeorm';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { AuditService } from '../../audit/audit.service';
+import { AuditAction, AuditLevel } from '../../audit/entities/audit-log.entity';
+import { TenantScreeningReport } from '../entities/tenant-screening-report.entity';
+import { TenantScreeningRequest } from '../entities/tenant-screening-request.entity';
+import { UserScreeningStatus } from '../screening.enums';
+
+@Injectable()
+export class ScreeningExpiryNotificationService {
+  private readonly logger = new Logger(ScreeningExpiryNotificationService.name);
+
+  constructor(
+    @InjectRepository(TenantScreeningReport)
+    private readonly reportRepository: Repository<TenantScreeningReport>,
+    @InjectRepository(TenantScreeningRequest)
+    private readonly screeningRepository: Repository<TenantScreeningRequest>,
+    private readonly notificationsService: NotificationsService,
+    private readonly auditService: AuditService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async notifyExpiringReports(): Promise<number> {
+    this.logger.log('Starting screening expiry notification check');
+
+    // Get the notification window in days (default: 7 days before expiry)
+    const notificationWindowDays = Number(
+      this.configService.get<string>(
+        'TENANT_SCREENING_EXPIRY_NOTIFICATION_DAYS',
+        '7',
+      ),
+    );
+
+    // Calculate the cutoff date: reports expiring within the notification window
+    const now = new Date();
+    const expiryWindowStart = new Date(
+      now.getTime() + notificationWindowDays * 24 * 60 * 60 * 1000,
+    );
+
+    // Find reports that will expire within the notification window
+    const expiringReports = await this.reportRepository.find({
+      where: {
+        accessExpiresAt: LessThan(expiryWindowStart),
+      },
+      relations: ['screening'],
+    });
+
+    this.logger.log(
+      `Found ${expiringReports.length} screening report(s) expiring within ${notificationWindowDays} days`,
+    );
+
+    let notificationsSent = 0;
+
+    for (const report of expiringReports) {
+      const screening = await this.screeningRepository.findOne({
+        where: { id: report.screeningId },
+      });
+
+      if (!screening) {
+        this.logger.warn(`Screening request not found for report ${report.id}`);
+        continue;
+      }
+
+      // Skip if screening is not in completed status
+      if (screening.status !== UserScreeningStatus.COMPLETED) {
+        continue;
+      }
+
+      try {
+        // Calculate days until expiry
+        const daysUntilExpiry = Math.ceil(
+          (report.accessExpiresAt!.getTime() - now.getTime()) /
+            (24 * 60 * 60 * 1000),
+        );
+
+        const expiryMessage =
+          daysUntilExpiry <= 0
+            ? 'Your tenant screening report has expired.'
+            : `Your tenant screening report will expire in ${daysUntilExpiry} day(s).`;
+
+        // Notify the requester
+        await this.notificationsService.notify(
+          screening.requestedByUserId,
+          'Tenant screening report expiring soon',
+          `${expiryMessage} Please renew if needed.`,
+          'screening_expiry_notification',
+        );
+
+        // Notify the tenant as well
+        await this.notificationsService.notify(
+          screening.tenantId,
+          'Tenant screening report expiring soon',
+          `${expiryMessage} Your rental application screening will need renewal if required.`,
+          'screening_expiry_notification',
+        );
+
+        await this.auditService.log({
+          action: AuditAction.UPDATE,
+          entityType: 'TenantScreeningReport',
+          entityId: report.id,
+          performedBy: 'SYSTEM',
+          level: AuditLevel.INFO,
+          metadata: {
+            screeningId: screening.id,
+            daysUntilExpiry,
+            notificationType: 'expiry_approaching',
+          },
+        });
+
+        notificationsSent++;
+      } catch (error) {
+        this.logger.error(
+          `Failed to send expiry notification for report ${report.id}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
+
+    this.logger.log(`Sent ${notificationsSent} expiry notification(s)`);
+    return notificationsSent;
+  }
+}


### PR DESCRIPTION
# Screening Report Renewal Workflow Implementation

## Summary
Implements renewal workflow for expired tenant screening reports with proactive expiry notifications, addressing landlord context loss during tenant renewals.

## Changes
- **Renewal Endpoint**: `POST /screenings/tenant/:id/renew` creates linked renewal requests referencing original via `renewedFromId`
- **Expiry Notifications**: Daily scheduled job (3 AM) notifies requesters/tenants 7 days before access expiration
- **Lineage Tracking**: New `renewedFromId` field in `TenantScreeningRequest` records renewal relationships with database-level foreign key constraint
- **Flexible Renewals**: Optional `requestedChecks` and `notes` in renewal request; defaults to original checks if not specified

## Files Modified
- `backend/src/modules/screening/screening.service.ts` - Added `renewRequest()` method
- `backend/src/modules/screening/screening.controller.ts` - Added renew endpoint
- `backend/src/modules/screening/entities/tenant-screening-request.entity.ts` - Added `renewedFromId` field
- `backend/src/modules/screening/services/screening-expiry-notification.service.ts` - New notification service
- `backend/src/modules/screening/screening.module.ts` - Exported notification service
- `backend/src/modules/scheduled-tasks/scheduled-tasks.service.ts` - Added expiry check job
- `backend/src/migrations/1930200000000-AddScreeningRenewalWorkflow.ts` - Migration for `renewedFromId` column

## Testing
- All 2520 backend tests passing
- Linter clean
- TypeScript compilation successful

Closes #1775
