### PR TITLE
 Add durable user language preference for i18n and notification emails

### DIFF
--- a/backend/src/modules/i18n/data/ar.ts
+++ b/backend/src/modules/i18n/data/ar.ts
@@ -25,4 +25,8 @@ export const ar = {
     suspiciousActivity: 'تم اكتشاف نشاط مشبوه',
     accountLocked: 'تم قفل الحساب مؤقتاً بسبب محاولات فاشلة',
   },
+  notifications: {
+    emailTitle: 'إشعار',
+    viewDetails: 'عرض التفاصيل',
+  },
 } as const;

--- a/backend/src/modules/i18n/data/en.ts
+++ b/backend/src/modules/i18n/data/en.ts
@@ -25,4 +25,8 @@ export const en = {
     suspiciousActivity: 'Suspicious activity detected',
     accountLocked: 'Account temporarily locked due to failed attempts',
   },
+  notifications: {
+    emailTitle: 'Notification',
+    viewDetails: 'View Details',
+  },
 } as const;

--- a/backend/src/modules/i18n/data/es.ts
+++ b/backend/src/modules/i18n/data/es.ts
@@ -25,4 +25,8 @@ export const es = {
     suspiciousActivity: 'Actividad sospechosa detectada',
     accountLocked: 'Cuenta bloqueada temporalmente por intentos fallidos',
   },
+  notifications: {
+    emailTitle: 'Notificacion',
+    viewDetails: 'Ver detalles',
+  },
 } as const;

--- a/backend/src/modules/i18n/data/fr.ts
+++ b/backend/src/modules/i18n/data/fr.ts
@@ -26,4 +26,8 @@ export const fr = {
     accountLocked:
       'Compte temporairement verrouille apres des tentatives echouees',
   },
+  notifications: {
+    emailTitle: 'Notification',
+    viewDetails: 'Voir les details',
+  },
 } as const;

--- a/backend/src/modules/i18n/i18n.service.spec.ts
+++ b/backend/src/modules/i18n/i18n.service.spec.ts
@@ -57,6 +57,22 @@ describe('I18nService', () => {
       expect(service.resolveLanguage('FR-ca')).toBe('fr');
       expect(service.resolveLanguage('EN-US')).toBe('en');
     });
+
+    it('falls back to the stored preference when no candidate is given', () => {
+      expect(service.resolveLanguage(undefined, 'es')).toBe('es');
+    });
+
+    it('prefers an explicit candidate over the stored preference', () => {
+      expect(service.resolveLanguage('fr', 'es')).toBe('fr');
+    });
+
+    it('uses the stored preference when the candidate is unsupported', () => {
+      expect(service.resolveLanguage('de', 'ar')).toBe('ar');
+    });
+
+    it('defaults to English when both candidate and fallback are unusable', () => {
+      expect(service.resolveLanguage('de', 'xx')).toBe('en');
+    });
   });
 
   describe('t', () => {

--- a/backend/src/modules/i18n/i18n.service.ts
+++ b/backend/src/modules/i18n/i18n.service.ts
@@ -5,7 +5,9 @@ import { es } from './data/es';
 import { ar } from './data/ar';
 import { FormatUtils } from '../../common/utils';
 
-export type SupportedLanguage = 'en' | 'fr' | 'es' | 'ar';
+export const SUPPORTED_LANGUAGES = ['en', 'fr', 'es', 'ar'] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 type TranslationTree = Record<string, unknown>;
 
@@ -24,19 +26,38 @@ export class I18nService {
     return Object.keys(this.translations) as SupportedLanguage[];
   }
 
-  resolveLanguage(candidate?: string): SupportedLanguage {
+  /**
+   * Resolves the effective language for a request/operation.
+   *
+   * `candidate` is the per-request signal (a `?lang=` query param or
+   * `Accept-Language`/`x-language` header). When it is absent or
+   * unsupported, `fallback` — typically the user's stored
+   * {@link User.preferredLanguage} preference — is tried next, so outbound
+   * emails and API responses can honour a durable choice without the client
+   * passing `lang` on every request. If neither yields a supported locale,
+   * the service default (`en`) is used.
+   */
+  resolveLanguage(candidate?: string, fallback?: string): SupportedLanguage {
+    return (
+      this.normalizeLanguage(candidate) ??
+      this.normalizeLanguage(fallback) ??
+      this.defaultLanguage
+    );
+  }
+
+  private normalizeLanguage(
+    candidate?: string | null,
+  ): SupportedLanguage | undefined {
     if (!candidate) {
-      return this.defaultLanguage;
+      return undefined;
     }
 
     const normalized = candidate
       .toLowerCase()
       .split('-')[0] as SupportedLanguage;
-    if (this.getSupportedLanguages().includes(normalized)) {
-      return normalized;
-    }
-
-    return this.defaultLanguage;
+    return this.getSupportedLanguages().includes(normalized)
+      ? normalized
+      : undefined;
   }
 
   t(

--- a/backend/src/modules/notifications/email.service.spec.ts
+++ b/backend/src/modules/notifications/email.service.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import * as nodemailer from 'nodemailer';
 import { EmailService } from './email.service';
+import { I18nService } from '../i18n/i18n.service';
 import { NetworkError } from '../../common/errors/retry-errors';
 
 jest.mock('nodemailer');
@@ -58,6 +59,7 @@ describe('EmailService', () => {
         EmailService,
         { provide: ConfigService, useValue: configService },
         { provide: CACHE_MANAGER, useValue: cacheManager },
+        I18nService,
       ],
     }).compile();
 
@@ -157,6 +159,7 @@ describe('EmailService', () => {
           EmailService,
           { provide: ConfigService, useValue: configService },
           { provide: CACHE_MANAGER, useValue: createMockCacheManager() },
+          I18nService,
         ],
       }).compile();
       const svc = module.get<EmailService>(EmailService);
@@ -264,6 +267,7 @@ describe('EmailService', () => {
           EmailService,
           { provide: ConfigService, useValue: configService },
           { provide: CACHE_MANAGER, useValue: createMockCacheManager() },
+          I18nService,
         ],
       }).compile();
       const svc = module.get<EmailService>(EmailService);

--- a/backend/src/modules/notifications/email.service.ts
+++ b/backend/src/modules/notifications/email.service.ts
@@ -4,6 +4,7 @@ import { Cache } from 'cache-manager';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
 import { Retry } from '../../common/decorators/retry.decorator';
+import { I18nService } from '../i18n/i18n.service';
 
 @Injectable()
 export class EmailService {
@@ -16,6 +17,7 @@ export class EmailService {
   constructor(
     private configService: ConfigService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly i18nService: I18nService,
   ) {
     const service = this.configService.get<string>('EMAIL_SERVICE');
     const user = this.configService.get<string>('EMAIL_USER');
@@ -136,12 +138,13 @@ export class EmailService {
     subject: string,
     template: string,
     data: Record<string, any>,
+    language?: string,
   ): Promise<void> {
     const mailOptions = {
       from: this.configService.get<string>('EMAIL_FROM'),
       to: email,
       subject,
-      html: this.renderTemplate(template, data),
+      html: this.renderTemplate(template, data, language),
     };
 
     try {
@@ -190,9 +193,22 @@ export class EmailService {
     }
   }
 
-  private renderTemplate(template: string, data: Record<string, any>): string {
-    // Simple template rendering - can be extended with more sophisticated templating
-    let html = `<h1>${data.title || 'Notification'}</h1>`;
+  private renderTemplate(
+    template: string,
+    data: Record<string, any>,
+    language?: string,
+  ): string {
+    // Simple template rendering - can be extended with more sophisticated
+    // templating. The recipient's language localizes the chrome (default
+    // title and call-to-action) so emails honour a stored preference even
+    // when the caller only supplies English content.
+    const lang = this.i18nService.resolveLanguage(language);
+    const title =
+      data.title || this.i18nService.t('notifications.emailTitle', lang);
+    const actionText =
+      data.actionText || this.i18nService.t('notifications.viewDetails', lang);
+
+    let html = `<h1>${title}</h1>`;
     html += `<p>${data.message || ''}</p>`;
 
     if (data.items && Array.isArray(data.items)) {
@@ -204,7 +220,7 @@ export class EmailService {
     }
 
     if (data.actionUrl) {
-      html += `<a href="${data.actionUrl}">${data.actionText || 'View Details'}</a>`;
+      html += `<a href="${data.actionUrl}">${actionText}</a>`;
     }
 
     return html;

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -18,8 +18,20 @@ describe('NotificationsService', () => {
     delete: jest.fn(),
   };
 
+  const userRepo = {
+    findOne: jest.fn(),
+  };
+
   const preferenceRepo = {
     findOne: jest.fn(),
+  };
+
+  const emailService = {
+    sendNotificationEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const i18nService = {
+    resolveLanguage: jest.fn().mockReturnValue('en'),
   };
 
   const realtimeService = {
@@ -58,7 +70,10 @@ describe('NotificationsService', () => {
     jest.clearAllMocks();
     service = new NotificationsService(
       notificationRepo as any,
+      userRepo as any,
       preferenceRepo as any,
+      emailService as any,
+      i18nService as any,
       realtimeService as any,
       errorNotificationService as any,
       retryService as any,
@@ -294,5 +309,43 @@ describe('NotificationsService', () => {
     await expect(service.markAsRead('missing', 'user-5')).rejects.toThrow(
       'Notification not found',
     );
+  });
+
+  describe('sendEmailNotification', () => {
+    it("localizes the email to the user's stored preferredLanguage", async () => {
+      userRepo.findOne.mockResolvedValue({
+        id: 'user-9',
+        email: 'user9@example.com',
+        preferredLanguage: 'fr',
+      });
+      i18nService.resolveLanguage.mockReturnValue('fr');
+
+      await service.sendEmailNotification('user-9', 'Sujet', 'tmpl', {
+        message: 'Bonjour',
+      });
+
+      // No per-request lang exists here, so the stored preference is the
+      // fallback passed to resolveLanguage.
+      expect(i18nService.resolveLanguage).toHaveBeenCalledWith(undefined, 'fr');
+      expect(emailService.sendNotificationEmail).toHaveBeenCalledWith(
+        'user9@example.com',
+        'Sujet',
+        'tmpl',
+        { message: 'Bonjour' },
+        'fr',
+      );
+    });
+
+    it('skips sending when the user has no email on file', async () => {
+      userRepo.findOne.mockResolvedValue({
+        id: 'user-10',
+        email: null,
+        preferredLanguage: 'en',
+      });
+
+      await service.sendEmailNotification('user-10', 'Subject', 'tmpl', {});
+
+      expect(emailService.sendNotificationEmail).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -2,6 +2,9 @@ import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
+import { User } from '../users/entities/user.entity';
+import { EmailService } from './email.service';
+import { I18nService } from '../i18n/i18n.service';
 import { NotificationsRealtimeService } from './notifications-realtime.service';
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
@@ -50,8 +53,12 @@ export class NotificationsService {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     @InjectRepository(UserNotificationPreference)
     private readonly preferencesRepository: Repository<UserNotificationPreference>,
+    private readonly emailService: EmailService,
+    private readonly i18nService: I18nService,
     private readonly realtimeService: NotificationsRealtimeService,
     @Inject(forwardRef(() => ErrorNotificationService))
     private readonly errorNotificationService: ErrorNotificationService,
@@ -103,6 +110,45 @@ export class NotificationsService {
       await this.alertNotificationFailure(userId, title, type, error);
       throw error;
     }
+  }
+
+  /**
+   * Sends a notification email to a user, localized to their stored
+   * {@link User.preferredLanguage} preference. No per-request `lang` signal
+   * exists in this background flow, so the stored preference is the only
+   * language source (see I18nService.resolveLanguage). Returns silently when
+   * the user has no email on file (e.g. wallet-only sign-ups).
+   */
+  async sendEmailNotification(
+    userId: string,
+    subject: string,
+    template: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      select: ['id', 'email', 'preferredLanguage'],
+    });
+
+    if (!user?.email) {
+      this.logger.warn(
+        `Skipping notification email for user ${userId}: no email on file`,
+      );
+      return;
+    }
+
+    const language = this.i18nService.resolveLanguage(
+      undefined,
+      user.preferredLanguage,
+    );
+
+    await this.emailService.sendNotificationEmail(
+      user.email,
+      subject,
+      template,
+      data,
+      language,
+    );
   }
 
   /**

--- a/backend/src/modules/users/dto/update-user.dto.ts
+++ b/backend/src/modules/users/dto/update-user.dto.ts
@@ -5,12 +5,14 @@ import {
   IsEmail,
   IsOptional,
   IsPhoneNumber,
+  IsIn,
   MinLength,
   Matches,
   IsBoolean,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ValidationUtils } from '../../../common/utils/validation/validation.utils';
+import { SUPPORTED_LANGUAGES } from '../../i18n/i18n.service';
 import { CreateUserDto } from './create-user.dto';
 
 export class UpdateUserProfileDto {
@@ -46,9 +48,16 @@ export class UpdateUserProfileDto {
   @IsString()
   avatarUrl?: string;
 
-  @ApiPropertyOptional({ example: 'en', description: 'Preferred language' })
+  @ApiPropertyOptional({
+    example: 'en',
+    description: 'Preferred language',
+    enum: SUPPORTED_LANGUAGES,
+  })
   @IsOptional()
   @IsString()
+  @IsIn(SUPPORTED_LANGUAGES, {
+    message: `preferredLanguage must be one of: ${SUPPORTED_LANGUAGES.join(', ')}`,
+  })
   preferredLanguage?: string;
 
   @ApiPropertyOptional({ example: 'UTC', description: 'Timezone' })

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -204,6 +204,22 @@ describe('UsersService', () => {
       );
     });
 
+    it('persists the preferredLanguage locale preference', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ ...mockUser });
+      mockUserRepository.save.mockImplementation((u: unknown) =>
+        Promise.resolve(u),
+      );
+
+      const result = await service.updateProfile('1', {
+        preferredLanguage: 'fr',
+      });
+
+      expect(result.preferredLanguage).toBe('fr');
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ preferredLanguage: 'fr' }),
+      );
+    });
+
     it('should throw NotFoundException if user not found', async () => {
       mockUserRepository.findOne.mockResolvedValue(null);
 

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -247,6 +247,12 @@ export class UsersService {
       }
     }
 
+    // Durable locale preference used as the i18n fallback for API responses
+    // and outbound notification emails when no per-request `lang` is given.
+    if (updateProfileDto.preferredLanguage !== undefined) {
+      user.preferredLanguage = updateProfileDto.preferredLanguage;
+    }
+
     const updatedUser = await this.userRepository.save(user);
 
     // Audit log for PII access

--- a/frontend/components/settings/SettingsPageClient.tsx
+++ b/frontend/components/settings/SettingsPageClient.tsx
@@ -67,6 +67,8 @@ type PasswordFormValues = z.infer<typeof passwordSchema>;
 const LANGUAGE_OPTIONS = [
   { value: 'en', label: 'English' },
   { value: 'fr', label: 'French' },
+  { value: 'es', label: 'Spanish' },
+  { value: 'ar', label: 'Arabic' },
 ];
 
 const CURRENCY_OPTIONS = [
@@ -338,6 +340,27 @@ export function SettingsPageClient({
       ...preferences,
       appearanceTheme: theme,
     });
+  };
+
+  const handleLanguageChange = (language: string) => {
+    // Keep the in-app preferences blob in sync (existing behavior)...
+    updatePreference({
+      ...preferences,
+      language,
+    });
+
+    // ...and persist the durable User.preferredLanguage column, which the
+    // backend uses as the i18n fallback for API responses and notification
+    // emails when a request carries no explicit language.
+    if (!accessToken) return;
+    void fetch('/api/users/me', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ preferredLanguage: language }),
+    }).catch(() => undefined);
   };
 
   const handlePasswordChange = handleSubmit(async (values) => {
@@ -666,12 +689,7 @@ export function SettingsPageClient({
                 id="language"
                 value={preferences.language}
                 disabled={isSavingPreferences}
-                onChange={(event) =>
-                  updatePreference({
-                    ...preferences,
-                    language: event.target.value,
-                  })
-                }
+                onChange={(event) => handleLanguageChange(event.target.value)}
                 className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/50"
               >
                 {LANGUAGE_OPTIONS.map((option) => (


### PR DESCRIPTION


`I18nService` was entirely request-scoped (`?lang=` query param or `Accept-Language` header), so notification emails and API responses had no way to default to a user's chosen language without the client passing `lang` on every request. This wires up the existing `User.preferredLanguage` column as a durable fallback.

- `User.preferredLanguage` already existed on the entity/migration but wasn't validated, wasn't persisted by `updateProfile`, and wasn't consumed anywhere.
- `I18nService.resolveLanguage()` now accepts an optional `fallback` argument: an explicit candidate (query/header) wins, then the fallback (stored preference), then the service default (`en`).
- `EmailService.sendNotificationEmail()` accepts an optional `language` and localizes the email chrome (default title / call-to-action) via `I18nService`.
- `NotificationsService.sendEmailNotification(userId, ...)` is a new entry point that looks up the user's `preferredLanguage` and passes it through, since background notification flows have no per-request language signal.
- `UpdateUserProfileDto.preferredLanguage` is now validated against `I18nService.SUPPORTED_LANGUAGES` (`en`, `fr`, `es`, `ar`) instead of accepting any string.
- `UsersService.updateProfile()` now actually persists `preferredLanguage` (previously silently dropped).
- Frontend settings page: language selector now also PUTs `preferredLanguage` to `/api/users/me` (previously it only wrote to the separate notification-preferences JSON blob), and gained `es`/`ar` options to match the backend's supported locales.

## Changes

- `backend/src/modules/i18n/i18n.service.ts` — `resolveLanguage(candidate?, fallback?)`; exported `SUPPORTED_LANGUAGES` const.
- `backend/src/modules/i18n/data/{en,fr,es,ar}.ts` — added `notifications.emailTitle` / `notifications.viewDetails` keys (kept catalog parity across all four locales).
- `backend/src/modules/notifications/email.service.ts` — `sendNotificationEmail(..., language?)`; `renderTemplate` localizes default title/action text.
- `backend/src/modules/notifications/notifications.service.ts` — injects `User` repo, `EmailService`, `I18nService`; new `sendEmailNotification()` method with a graceful no-op when the user has no email on file.
- `backend/src/modules/users/dto/update-user.dto.ts` — `preferredLanguage` validated with `@IsIn(SUPPORTED_LANGUAGES)`.
- `backend/src/modules/users/users.service.ts` — `updateProfile()` persists `preferredLanguage` when provided.
- `frontend/components/settings/SettingsPageClient.tsx` — `handleLanguageChange()` persists to `PUT /api/users/me`; added Spanish/Arabic to `LANGUAGE_OPTIONS`.



closes #1770