### PR TITLE
Review-prompt service is a no-op stub 

### DIFF
--- a/backend/src/migrations/1930300000000-CreateReviewPromptsTable.ts
+++ b/backend/src/migrations/1930300000000-CreateReviewPromptsTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateReviewPromptsTable1930300000000
+  implements MigrationInterface
+{
+  name = 'CreateReviewPromptsTable1930300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "review_prompts" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "context" character varying NOT NULL,
+        "source_id" uuid NOT NULL,
+        "prompted_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_review_prompts_context_source_id" UNIQUE ("context", "source_id"),
+        CONSTRAINT "PK_review_prompts_id" PRIMARY KEY ("id")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "review_prompts"`);
+  }
+}

--- a/backend/src/modules/agreements/agreements.service.ts
+++ b/backend/src/modules/agreements/agreements.service.ts
@@ -353,6 +353,8 @@ export class AgreementsService {
       );
     }
 
+    await this.promptLeaseReviewSafely(id);
+
     return saved;
   }
 
@@ -410,7 +412,27 @@ export class AgreementsService {
       'agreement.status.changed',
       new AgreementStatusChangedEvent(id, oldStatus, newStatus, reason),
     );
+
+    if (newStatus === AgreementStatus.EXPIRED) {
+      await this.promptLeaseReviewSafely(id);
+    }
+
     return saved;
+  }
+
+  /**
+   * Sends the lease-end review prompt without letting a notification
+   * failure block the status transition that triggered it.
+   */
+  private async promptLeaseReviewSafely(agreementId: string): Promise<void> {
+    try {
+      await this.reviewPromptService.promptForLeaseReview(agreementId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to send lease review prompt for agreement ${agreementId}`,
+        error,
+      );
+    }
   }
 
   async generateAgreementPdf(id: string): Promise<Buffer> {

--- a/backend/src/modules/maintenance/maintenance.service.ts
+++ b/backend/src/modules/maintenance/maintenance.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
@@ -36,6 +36,8 @@ export interface MaintenanceFilter {
 
 @Injectable()
 export class MaintenanceService {
+  private readonly logger = new Logger(MaintenanceService.name);
+
   constructor(
     @InjectRepository(MaintenanceRequest)
     private readonly maintenanceRepo: Repository<MaintenanceRequest>,
@@ -136,7 +138,14 @@ export class MaintenanceService {
 
     // Trigger review prompt if closed
     if (status === MaintenanceStatus.CLOSED) {
-      await this.reviewPromptService.promptForMaintenanceReview(id);
+      try {
+        await this.reviewPromptService.promptForMaintenanceReview(id);
+      } catch (error) {
+        this.logger.error(
+          `Failed to send maintenance review prompt for request ${id}`,
+          error,
+        );
+      }
     }
 
     return saved;

--- a/backend/src/modules/reviews/entities/review-prompt.entity.ts
+++ b/backend/src/modules/reviews/entities/review-prompt.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Unique,
+} from 'typeorm';
+import { ReviewContext } from '../review.entity';
+
+/**
+ * Tracks that a review prompt was already sent for a given lease/maintenance
+ * event, so repeated triggers (e.g. re-running a status transition) never
+ * re-notify the same parties for the same event.
+ */
+@Entity('review_prompts')
+@Unique(['context', 'sourceId'])
+export class ReviewPrompt {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  context: ReviewContext;
+
+  @Column()
+  sourceId: string;
+
+  @CreateDateColumn()
+  promptedAt: Date;
+}

--- a/backend/src/modules/reviews/review-prompt.service.spec.ts
+++ b/backend/src/modules/reviews/review-prompt.service.spec.ts
@@ -1,21 +1,156 @@
 import { ReviewPromptService } from './review-prompt.service';
+import { ReviewContext } from './review.entity';
 
 describe('ReviewPromptService', () => {
+  const reviewPromptRepo = {
+    findOne: jest.fn(),
+    insert: jest.fn(),
+  };
+  const agreementRepo = {
+    findOne: jest.fn(),
+  };
+  const maintenanceRepo = {
+    findOne: jest.fn(),
+  };
+  const notificationsService = {
+    notify: jest.fn(),
+  };
+
   let service: ReviewPromptService;
 
   beforeEach(() => {
-    service = new ReviewPromptService();
+    jest.clearAllMocks();
+    reviewPromptRepo.findOne.mockResolvedValue(null);
+    reviewPromptRepo.insert.mockResolvedValue(undefined);
+    notificationsService.notify.mockResolvedValue(undefined);
+    service = new ReviewPromptService(
+      reviewPromptRepo as never,
+      agreementRepo as never,
+      maintenanceRepo as never,
+      notificationsService as never,
+    );
   });
 
-  it('exposes lease review prompt entry point', async () => {
+  describe('promptForLeaseReview', () => {
+    it('notifies both tenant and landlord referencing the agreement', async () => {
+      agreementRepo.findOne.mockResolvedValue({
+        id: 'agreement-1',
+        agreementNumber: 'CHIOMA-2026-0001',
+        userId: 'tenant-1',
+        adminId: 'landlord-1',
+      });
+
+      await service.promptForLeaseReview('agreement-1');
+
+      expect(reviewPromptRepo.insert).toHaveBeenCalledWith({
+        context: ReviewContext.LEASE,
+        sourceId: 'agreement-1',
+      });
+      expect(notificationsService.notify).toHaveBeenCalledTimes(2);
+      expect(notificationsService.notify).toHaveBeenCalledWith(
+        'tenant-1',
+        expect.any(String),
+        expect.stringContaining('CHIOMA-2026-0001'),
+        'review_prompt_lease',
+      );
+      expect(notificationsService.notify).toHaveBeenCalledWith(
+        'landlord-1',
+        expect.any(String),
+        expect.stringContaining('CHIOMA-2026-0001'),
+        'review_prompt_lease',
+      );
+    });
+
+    it('does not re-prompt when a prompt was already recorded for this agreement', async () => {
+      reviewPromptRepo.findOne.mockResolvedValue({
+        id: 'prompt-1',
+        context: ReviewContext.LEASE,
+        sourceId: 'agreement-1',
+      });
+
+      await service.promptForLeaseReview('agreement-1');
+
+      expect(reviewPromptRepo.insert).not.toHaveBeenCalled();
+      expect(agreementRepo.findOne).not.toHaveBeenCalled();
+      expect(notificationsService.notify).not.toHaveBeenCalled();
+    });
+
+    it('skips notifying when the agreement cannot be found', async () => {
+      agreementRepo.findOne.mockResolvedValue(null);
+
+      await service.promptForLeaseReview('missing-agreement');
+
+      expect(notificationsService.notify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('promptForMaintenanceReview', () => {
+    it('notifies both tenant and landlord referencing the maintenance ticket', async () => {
+      maintenanceRepo.findOne.mockResolvedValue({
+        id: 'request-1',
+        category: 'plumbing',
+        tenantId: 'tenant-1',
+        landlordId: 'landlord-1',
+      });
+
+      await service.promptForMaintenanceReview('request-1');
+
+      expect(reviewPromptRepo.insert).toHaveBeenCalledWith({
+        context: ReviewContext.MAINTENANCE,
+        sourceId: 'request-1',
+      });
+      expect(notificationsService.notify).toHaveBeenCalledTimes(2);
+      expect(notificationsService.notify).toHaveBeenCalledWith(
+        'tenant-1',
+        expect.any(String),
+        expect.stringContaining('plumbing'),
+        'review_prompt_maintenance',
+      );
+      expect(notificationsService.notify).toHaveBeenCalledWith(
+        'landlord-1',
+        expect.any(String),
+        expect.stringContaining('plumbing'),
+        'review_prompt_maintenance',
+      );
+    });
+
+    it('does not re-prompt when a prompt was already recorded for this ticket', async () => {
+      reviewPromptRepo.findOne.mockResolvedValue({
+        id: 'prompt-1',
+        context: ReviewContext.MAINTENANCE,
+        sourceId: 'request-1',
+      });
+
+      await service.promptForMaintenanceReview('request-1');
+
+      expect(reviewPromptRepo.insert).not.toHaveBeenCalled();
+      expect(maintenanceRepo.findOne).not.toHaveBeenCalled();
+      expect(notificationsService.notify).not.toHaveBeenCalled();
+    });
+
+    it('skips notifying when the maintenance request cannot be found', async () => {
+      maintenanceRepo.findOne.mockResolvedValue(null);
+
+      await service.promptForMaintenanceReview('missing-request');
+
+      expect(notificationsService.notify).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not let one failed notification stop the other from being attempted', async () => {
+    agreementRepo.findOne.mockResolvedValue({
+      id: 'agreement-1',
+      agreementNumber: 'CHIOMA-2026-0001',
+      userId: 'tenant-1',
+      adminId: 'landlord-1',
+    });
+    notificationsService.notify.mockRejectedValueOnce(new Error('boom'));
+    notificationsService.notify.mockResolvedValueOnce(undefined);
+
     await expect(
       service.promptForLeaseReview('agreement-1'),
     ).resolves.toBeUndefined();
-  });
 
-  it('exposes maintenance review prompt entry point', async () => {
-    await expect(
-      service.promptForMaintenanceReview('maintenance-1'),
-    ).resolves.toBeUndefined();
+    expect(notificationsService.notify).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/src/modules/reviews/review-prompt.service.ts
+++ b/backend/src/modules/reviews/review-prompt.service.ts
@@ -1,14 +1,135 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { ReviewPrompt } from './entities/review-prompt.entity';
+import { ReviewContext } from './review.entity';
+import { RentAgreement } from '../rent/entities/rent-contract.entity';
+import { MaintenanceRequest } from '../maintenance/maintenance-request.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+
+/** Postgres unique_violation error code. */
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error as unknown as { code?: string }).code === POSTGRES_UNIQUE_VIOLATION
+  );
+}
 
 @Injectable()
 export class ReviewPromptService {
-  async promptForLeaseReview(_agreementId: string) {
-    // Fetch agreement, notify tenant and landlord to review each other
-    // Implementation: send notification or create review prompt record
+  private readonly logger = new Logger(ReviewPromptService.name);
+
+  constructor(
+    @InjectRepository(ReviewPrompt)
+    private readonly reviewPromptRepository: Repository<ReviewPrompt>,
+    @InjectRepository(RentAgreement)
+    private readonly agreementRepository: Repository<RentAgreement>,
+    @InjectRepository(MaintenanceRequest)
+    private readonly maintenanceRepository: Repository<MaintenanceRequest>,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  async promptForLeaseReview(agreementId: string): Promise<void> {
+    if (!(await this.claimPrompt(ReviewContext.LEASE, agreementId))) {
+      return;
+    }
+
+    const agreement = await this.agreementRepository.findOne({
+      where: { id: agreementId },
+    });
+    if (!agreement) {
+      this.logger.warn(
+        `Skipping lease review prompt: agreement ${agreementId} not found`,
+      );
+      return;
+    }
+
+    const reference = agreement.agreementNumber ?? agreement.id;
+    await this.notifyParties(
+      [agreement.userId, agreement.adminId],
+      'Leave a review',
+      `Your lease ${reference} has ended. Share a review to help others in the community.`,
+      'review_prompt_lease',
+    );
   }
 
-  async promptForMaintenanceReview(_maintenanceId: string) {
-    // Fetch maintenance request, notify tenant and landlord to review each other
-    // Implementation: send notification or create review prompt record
+  async promptForMaintenanceReview(maintenanceId: string): Promise<void> {
+    if (!(await this.claimPrompt(ReviewContext.MAINTENANCE, maintenanceId))) {
+      return;
+    }
+
+    const request = await this.maintenanceRepository.findOne({
+      where: { id: maintenanceId },
+    });
+    if (!request) {
+      this.logger.warn(
+        `Skipping maintenance review prompt: request ${maintenanceId} not found`,
+      );
+      return;
+    }
+
+    await this.notifyParties(
+      [request.tenantId, request.landlordId],
+      'Leave a review',
+      `Your maintenance request "${request.category}" has been closed. Share a review of how it was handled.`,
+      'review_prompt_maintenance',
+    );
+  }
+
+  private async notifyParties(
+    userIds: (string | null | undefined)[],
+    title: string,
+    message: string,
+    type: string,
+  ): Promise<void> {
+    const recipients = [...new Set(userIds.filter((id): id is string => Boolean(id)))];
+
+    const results = await Promise.allSettled(
+      recipients.map((userId) =>
+        this.notificationsService.notify(userId, title, message, type),
+      ),
+    );
+
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected') {
+        this.logger.error(
+          `Failed to send review prompt to user ${recipients[index]}`,
+          result.reason instanceof Error
+            ? result.reason.stack
+            : String(result.reason),
+        );
+      }
+    }
+  }
+
+  /**
+   * Atomically claims the right to prompt for `(context, sourceId)` by
+   * inserting a tracking row first. Returns false when a prompt was already
+   * sent for this event — either the row already existed, or a concurrent
+   * caller won the insert race — so the same lease end/ticket close event
+   * never triggers duplicate notifications.
+   */
+  private async claimPrompt(
+    context: ReviewContext,
+    sourceId: string,
+  ): Promise<boolean> {
+    const existing = await this.reviewPromptRepository.findOne({
+      where: { context, sourceId },
+    });
+    if (existing) {
+      return false;
+    }
+
+    try {
+      await this.reviewPromptRepository.insert({ context, sourceId });
+      return true;
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        return false;
+      }
+      throw error;
+    }
   }
 }

--- a/backend/src/modules/reviews/reviews.module.ts
+++ b/backend/src/modules/reviews/reviews.module.ts
@@ -4,13 +4,24 @@ import { Review } from './review.entity';
 import { ReviewsService } from './reviews.service';
 import { ReviewsController } from './reviews.controller';
 import { ReviewPromptService } from '../reviews/review-prompt.service';
+import { ReviewPrompt } from './entities/review-prompt.entity';
 import { GuestReview } from './entities/guest-review.entity';
 import { HostReview } from './entities/host-review.entity';
 import { RentAgreement } from '../rent/entities/rent-contract.entity';
+import { MaintenanceRequest } from '../maintenance/maintenance-request.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Review, GuestReview, HostReview, RentAgreement]),
+    TypeOrmModule.forFeature([
+      Review,
+      GuestReview,
+      HostReview,
+      RentAgreement,
+      MaintenanceRequest,
+      ReviewPrompt,
+    ]),
+    NotificationsModule,
   ],
   providers: [ReviewsService, ReviewPromptService],
   controllers: [ReviewsController],


### PR DESCRIPTION


`ReviewPromptService.promptForLeaseReview()` and `promptForMaintenanceReview()` were empty method bodies (comments only), so nothing ever actually prompted tenants/landlords to leave a review after a lease ended or a maintenance ticket closed — the `reviews` module was fully built but silently starved of content.

This PR implements both methods end-to-end:

- Fetches the relevant agreement / maintenance request.
- Resolves the counterparties (tenant + landlord).
- Sends a review-prompt notification to each side via the existing `notifications` module, referencing the agreement number / maintenance ticket.
- Tracks prompt state in a new `review_prompts` table so the same lease/ticket is never re-prompted on repeated events.

It also wires the lease-end trigger, which was injected into `AgreementsService` but never actually called.

## Changes

- **`backend/src/modules/reviews/entities/review-prompt.entity.ts`** (new) — `ReviewPrompt` entity tracking `(context, sourceId)` with a unique constraint, reusing the existing `ReviewContext` enum (`LEASE` / `MAINTENANCE`).
- **`backend/src/migrations/1930300000000-CreateReviewPromptsTable.ts`** (new) — creates the `review_prompts` table.
- **`backend/src/modules/reviews/review-prompt.service.ts`** — implemented both methods:
  - `promptForLeaseReview(agreementId)` loads the `RentAgreement` and notifies `userId` (tenant) and `adminId` (landlord).
  - `promptForMaintenanceReview(maintenanceId)` loads the `MaintenanceRequest` and notifies `tenantId` and `landlordId`.
  - Both atomically "claim" the prompt by inserting the tracking row first, catching a Postgres `23505` unique-violation on race (same pattern already used in `referral.service.ts`), so concurrent/duplicate triggers never double-notify.
  - Per-recipient notification failures are caught individually (`Promise.allSettled`) so one failed send doesn't block the other party's notification.
- **`backend/src/modules/reviews/reviews.module.ts`** — registers `ReviewPrompt` and `MaintenanceRequest` with TypeORM and imports `NotificationsModule`.
- **`backend/src/modules/agreements/agreements.service.ts`** — `promptForLeaseReview` was injected but never called. Now invoked:
  - in `terminate()` after status is set to `TERMINATED`;
  - in `updateStatusWithGuard()` when transitioning to `EXPIRED` (used by the daily cron job).
  - Both call through a `promptLeaseReviewSafely` helper so a notification failure can't fail the lease-termination/expiry transaction.
- **`backend/src/modules/maintenance/maintenance.service.ts`** — wrapped the existing `promptForMaintenanceReview` call (on ticket close) in the same try/catch-and-log pattern for consistency.
- **`backend/src/modules/reviews/review-prompt.service.spec.ts`** — rewritten from a placeholder ("resolves to undefined") into real assertions: notifications dispatched to both parties with correct content, duplicate prompts suppressed, missing agreement/ticket handled gracefully, and one failed notification doesn't prevent the other from being attempted.

## Why "already wired" wasn't quite true

The issue described `promptForLeaseReview` as already wired into `agreements.service.ts` on lease end. In practice `ReviewPromptService` was only *injected* there — nothing ever called it. This PR adds the actual call sites (`terminate()` and the `EXPIRED` cron transition) in addition to implementing the method body.

## Test plan

- [x] `npx jest modules/reviews modules/notifications modules/maintenance modules/agreements` — 7 suites / 83 tests pass (1 skipped, pre-existing).
- [x] `npx tsc --noEmit` — clean.
- [ ] Run the new migration against a staging DB before deploying.

closes #1783